### PR TITLE
feat(react-app): implement react framework modules

### DIFF
--- a/packages/react-app/README.md
+++ b/packages/react-app/README.md
@@ -4,6 +4,20 @@ Package for developing applications that uses the `@equinor/fusion-framework`.
 
 [API documentation](https://equinor.github.io/fusion-framework/modules/_equinor_fusion_framework_react_app.html)
 
+__Dependencies__
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-framework?label=fusion-framework&style=for-the-badge)
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-framework-module?label=fusion-framework-module&style=for-the-badge)
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-framework-module-http?label=fusion-framework-module-http&style=for-the-badge)
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-framework-module-msal?label=fusion-framework-module-msal&style=for-the-badge)
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-framework-react?label=fusion-framework-react&style=for-the-badge)
+
+![npm (scoped)](https://img.shields.io/npm/v/@equinor/fusion-observable?label=fusion-observable&style=for-the-badge)
+
 ## Configure
 ```tsx
 // config.ts
@@ -35,10 +49,23 @@ export default render;
 
 ## Hooks
 
+### useModule
+```tsx
+import { useModule } from '@equinor/fusion-framework-react-app';
+const ShowToken = () => {
+  const auth = useModule('auth');
+  const [token, setToken] = useState<string>('');
+  useEffect(() => {
+    auth.acquireAccessToken().then(setToken);
+  }, [auth]);
+  return <span>{token ?? 'fetching token'}</span>
+}
+```
+
 ### useHttpClient
 
 ```tsx
-import {useHttpClient} from '@equinor/fusion-framework-react-app/hooks';
+import { useHttpClient } from '@equinor/fusion-framework-react-app/http';
 const App = () => {
   const fooClient = useHttpClient('foo');
   

--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -44,7 +44,6 @@
     "@equinor/fusion-framework-module-http": "^0.4.0",
     "@equinor/fusion-framework-module-msal": "^0.1.24",
     "@equinor/fusion-framework-react": "^0.2.12",
-    "@equinor/fusion-framework-react-module-app-config": "^0.0.0",
     "@equinor/fusion-observable": "^0.1.3"
   },
   "devDependencies": {

--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -5,12 +5,16 @@
   "main": "dist/esm/index.js",
   "exports": {
     ".": "./dist/esm/index.js",
+    "./config": "./dist/esm/config/index.js",
     "./framework": "./dist/esm/framework/index.js",
     "./http": "./dist/esm/http/index.js"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {
     "*": {
+      "config": [
+        "dist/types/config/index.d.ts"
+      ],
       "framework": [
         "dist/types/framework/index.d.ts"
       ],
@@ -39,7 +43,9 @@
     "@equinor/fusion-framework-module": "^0.3.0",
     "@equinor/fusion-framework-module-http": "^0.4.0",
     "@equinor/fusion-framework-module-msal": "^0.1.24",
-    "@equinor/fusion-framework-react": "^0.2.12"
+    "@equinor/fusion-framework-react": "^0.2.12",
+    "@equinor/fusion-framework-react-module-app-config": "^0.0.0",
+    "@equinor/fusion-observable": "^0.1.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.11",

--- a/packages/react-app/src/create-app.tsx
+++ b/packages/react-app/src/create-app.tsx
@@ -98,6 +98,9 @@ export const createApp =
             };
             const AppModuleProvider = await createModuleProvider(
                 configurator,
+                // TODO type hint concat of modules
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 appModules.concat(modules),
                 fusion.modules
             );

--- a/packages/react-app/src/create-app.tsx
+++ b/packages/react-app/src/create-app.tsx
@@ -4,9 +4,11 @@ import { lazy } from 'react';
 import type { Fusion, AppManifest } from '@equinor/fusion-framework';
 import FrameworkProvider from '@equinor/fusion-framework-react';
 
-import { AnyModule, initializeModules, ModulesConfigType } from '@equinor/fusion-framework-module';
+import { AnyModule, ModulesConfigType } from '@equinor/fusion-framework-module';
 
-import { ModuleProvider, appModules, AppModules } from './modules';
+import { appModules, AppModules } from './modules';
+
+import { createModuleProvider } from '@equinor/fusion-framework-react-module';
 
 /**
  * Interface for type hinting configuration callbacks
@@ -94,7 +96,7 @@ export const createApp =
                     await Promise.resolve(configure(config, fusion, env));
                 }
             };
-            const value = await initializeModules(
+            const AppModuleProvider = await createModuleProvider(
                 configurator,
                 appModules.concat(modules),
                 fusion.modules
@@ -102,9 +104,9 @@ export const createApp =
             return {
                 default: () => (
                     <FrameworkProvider value={fusion}>
-                        <ModuleProvider value={value}>
+                        <AppModuleProvider>
                             <Component />
-                        </ModuleProvider>
+                        </AppModuleProvider>
                     </FrameworkProvider>
                 ),
             };

--- a/packages/react-app/src/http/useHttpClient.ts
+++ b/packages/react-app/src/http/useHttpClient.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { HttpClientMsal, IHttpClient } from '@equinor/fusion-framework-module-http';
 import { useMemo } from 'react';
-import { useModuleContext } from '../modules';
+import { useAppModule } from '../modules';
 
 /**
  * Use a configured client from application modules
@@ -15,10 +15,10 @@ import { useModuleContext } from '../modules';
  * @param name Named client from configuration
  */
 export const useHttpClient = <TType extends IHttpClient = HttpClientMsal>(name: string): TType => {
-    const module = useModuleContext();
+    const http = useAppModule('http');
     const client = useMemo(() => {
-        if (module.http.hasClient(name)) {
-            return module.http.createClient(name);
+        if (http.hasClient(name)) {
+            return http.createClient(name);
         }
         throw Error(`no configured client for key [${name}]`);
     }, [name]);

--- a/packages/react-app/src/index.ts
+++ b/packages/react-app/src/index.ts
@@ -4,11 +4,4 @@
  */
 
 export { AppConfigurator, createApp, default } from './create-app';
-export {
-    AppModules,
-    AppModulesInstance,
-    ModuleProvider,
-    appModules,
-    createModuleProvider,
-    useModuleContext,
-} from './modules';
+export { AppModules, AppModulesInstance, appModules, useAppModule, useAppModules } from './modules';

--- a/packages/react-app/src/modules.tsx
+++ b/packages/react-app/src/modules.tsx
@@ -1,56 +1,19 @@
-import { createContext, lazy, useContext } from 'react';
-
-import {
-    initializeModules,
-    ModulesConfigurator,
-    AnyModule,
-    ModulesInstanceType,
-} from '@equinor/fusion-framework-module';
+import { ModulesInstanceType } from '@equinor/fusion-framework-module';
 
 import http, { HttpModule } from '@equinor/fusion-framework-module-http';
 import msal, { MsalModule } from '@equinor/fusion-framework-module-msal';
+// import appConfig, { AppConfigModule } from '@equinor/fusion-framework-react-module-app-config';
 
+import { useModules } from '@equinor/fusion-framework-react-module';
+
+// export type AppModules = [HttpModule, MsalModule, AppConfigModule];
 export type AppModules = [HttpModule, MsalModule];
 export type AppModulesInstance = ModulesInstanceType<AppModules>;
 
+// export const appModules = [http, msal, appConfig];
 export const appModules = [http, msal];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const moduleContext = createContext<any>(null);
-
-/**
- * Context provider for application modules instances
- * @see {@link createModuleProvider | createModuleProvider}
- * @see {@link appModules | appModules}
- * @see {@link useModuleContext | useModuleContext}
- */
-export const ModuleProvider = moduleContext.Provider;
-
-type ModuleProviderCreator = <TModules extends Array<AnyModule> = Array<AnyModule>>(
-    configurator: ModulesConfigurator<TModules>,
-    modules: TModules
-) => Promise<React.LazyExoticComponent<React.FunctionComponent>>;
-
-export const createModuleProvider: ModuleProviderCreator = async <
-    TModules extends Array<AnyModule>
->(
-    configurator: ModulesConfigurator<TModules>,
-    modules: TModules
-): Promise<React.LazyExoticComponent<React.FunctionComponent>> => {
-    const Component = lazy(async () => {
-        const value = await initializeModules(configurator, modules);
-        return {
-            default: ({ children }: { children?: React.ReactNode }) => (
-                <ModuleProvider value={value}>{children}</ModuleProvider>
-            ),
-        };
-    });
-    return Component;
-};
-
-/**
- * @template T - type-hint which module types that are in context, defaults to standard [[AppModulesInstance]]
- */
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint, @typescript-eslint/no-explicit-any
-export const useModuleContext = <T extends any = AppModulesInstance>(): T =>
-    useContext(moduleContext) as T;
+export const useAppModules = useModules<AppModulesInstance>;
+export const useAppModule = <TKey extends keyof AppModulesInstance>(
+    module: TKey
+): AppModulesInstance[TKey] => useAppModules()[module];

--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -29,9 +29,6 @@
     {
       "path": "../react-module"
     },
-    {
-      "path": "../react-module-app-config"
-    },
     
   ],
   "include": [

--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -9,6 +9,9 @@
   },
   "references": [
     {
+      "path": "../observable"
+    },
+    {
       "path": "../framework"
     },
     {
@@ -22,7 +25,14 @@
     },
     {
       "path": "../module-msal"
-    }
+    },
+    {
+      "path": "../react-module"
+    },
+    {
+      "path": "../react-module-app-config"
+    },
+    
   ],
   "include": [
     "src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,6 +1395,14 @@
   dependencies:
     rxjs "7.5.6"
 
+"@equinor/fusion-observable@^0.1.3":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@equinor/fusion-observable/-/fusion-observable-0.1.12.tgz#ea238e1d79b13f648f57cae74bd040ed39930cd2"
+  integrity sha512-ki+Eq5byrDca6KhiKCan4xtuYew9yai61fJEDUDy6CL7ZMB8SSRr2oZ+N2VAEoMWS4XnooetcOP7FLb4UaDZRg==
+  dependencies:
+    rxjs "7.5.6"
+    uuid "^8.3.2"
+
 "@equinor/fusion-react-progress-indicator@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@equinor/fusion-react-progress-indicator/-/fusion-react-progress-indicator-0.1.5.tgz#4de6a3b12b32f6d614ae1d340636c83f59aa6dd3"


### PR DESCRIPTION
+ use module creator in create-app
+ retype module interfaces
+ update hooks for accessing module context
+ update `useHttpClients` to re-use module hook
+ update docs