### PR TITLE
chore(framework-react): update types for useFramework

### DIFF
--- a/packages/framework-react/src/hooks/use-framework.ts
+++ b/packages/framework-react/src/hooks/use-framework.ts
@@ -1,5 +1,7 @@
-import { useContext } from 'react';
 import type { Fusion } from '@equinor/fusion-framework';
+import type { AnyModule } from '@equinor/fusion-framework-module';
+
+import { useContext } from 'react';
 import { context } from '../context';
 /**
  * @example
@@ -10,7 +12,7 @@ import { context } from '../context';
  * }
  * ```
  */
-export const useFramework = (): Fusion => {
+export const useFramework = <TModules extends Array<AnyModule> = []>(): Fusion<TModules> => {
     let framework = useContext(context);
     if (!framework) {
         console.warn('could not locate fusion in context!');


### PR DESCRIPTION
To be able to access your own modules using the useFramework hook on need to write the code below.

```TS
type MyModule = { name: 'myModule'; initialize: () => { test: 'test' } };

const useSometing = () => {
     const  { modules }  = useFramework() as Fusion<[MyModule]>
     return modules .myModule
}
```

I would prefer to write 

```TS
type MyModule = { name: 'myModule'; initialize: () => { test: 'test' } };

export const useMyModule = () => {
    const { modules } = useFramework<[MyModule ]>();
    return modules.myModule;
};

```
