### PR TITLE
fix(module-auth): make http module await auth

### DIFF
--- a/packages/framework-react/tsconfig.json
+++ b/packages/framework-react/tsconfig.json
@@ -22,6 +22,9 @@
     },
     {
       "path": "../react-module-http"
+    },
+    {
+      "path": "../module-service-discovery"
     }
   ],
   "include": [

--- a/packages/framework/src/configurator.ts
+++ b/packages/framework/src/configurator.ts
@@ -11,6 +11,7 @@ import http, {
     configureHttp,
     HttpClientOptions,
 } from '@equinor/fusion-framework-module-http';
+import type { HttpClientMsal } from '@equinor/fusion-framework-module-http/client';
 
 import auth, { configureMsal } from '@equinor/fusion-framework-module-msal';
 
@@ -29,7 +30,7 @@ export class FusionConfigurator<
     TRef = any
 > extends ModulesConfigurator<FusionModules<TModules>, TRef> {
     constructor() {
-        super([event, http, auth, disco, services, app, context]);
+        super([event, auth, http, disco, services, app, context]);
         this.logger = new ModuleConsoleLogger('FrameworkConfigurator');
     }
 
@@ -45,7 +46,7 @@ export class FusionConfigurator<
         this.addConfig(configureMsal(...args));
     }
 
-    public configureServiceDiscovery(args: { client: HttpClientOptions }) {
+    public configureServiceDiscovery(args: { client: HttpClientOptions<HttpClientMsal> }) {
         this.configureHttpClient('service_discovery', args.client);
     }
 }

--- a/packages/module-app/tsconfig.json
+++ b/packages/module-app/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../module-http"
+    },
+    {
+      "path": "../module-service-discovery"
     }
   ],
   "include": [

--- a/packages/module-http/package.json
+++ b/packages/module-http/package.json
@@ -43,6 +43,7 @@
     },
     "dependencies": {
         "@equinor/fusion-framework-module": "^1.2.8",
+        "@equinor/fusion-framework-module-msal": "^1.0.17",
         "rxjs": "^7.5.7"
     },
     "devDependencies": {

--- a/packages/module-http/tsconfig.json
+++ b/packages/module-http/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../module"
+    },
+    {
+      "path": "../module-msal"
     }
   ],
   "include": [

--- a/packages/module-msal/package.json
+++ b/packages/module-msal/package.json
@@ -32,8 +32,7 @@
     },
     "dependencies": {
         "@azure/msal-browser": "^2.21.0",
-        "@equinor/fusion-framework-module": "^1.2.8",
-        "@equinor/fusion-framework-module-http": "^2.1.2"
+        "@equinor/fusion-framework-module": "^1.2.8"
     },
     "devDependencies": {
         "typescript": "^4.8.4"

--- a/packages/module-msal/src/configurator.ts
+++ b/packages/module-msal/src/configurator.ts
@@ -33,11 +33,14 @@ export interface IAuthConfigurator {
      * @param options config options
      */
     configureDefault(options: AuthClientOptions): void;
+
+    requiresAuth: boolean;
 }
 
 export class AuthConfigurator implements IAuthConfigurator {
     /** internal map of keyed configs */
     protected _configs: Record<string, AuthClientOptions> = {};
+    requiresAuth = true;
 
     get defaultConfig(): AuthClientOptions | undefined {
         return this._configs[DEFAULT_CONFIG_KEY];

--- a/packages/module-msal/tsconfig.json
+++ b/packages/module-msal/tsconfig.json
@@ -9,11 +9,7 @@
   "references": [
     {
       "path": "../module"
-    },
-    {
-      "path": "../module-http"
-    },
-   
+    }
   ],
   "include": [
     "src/**/*",


### PR DESCRIPTION
- [x] await auth module in http module
- [x] remove request processor from msal module
- [x] add flag for forcing auth when creating auth provider 

in some odd cases other modules will try to acquire token before auth module (like creating a http client within init of module)