### PR TITLE
Feat(observable): handle queue operator

### DIFF
--- a/packages/module-app/src/provider.ts
+++ b/packages/module-app/src/provider.ts
@@ -9,7 +9,7 @@ import {
 
 import { ModuleType } from '@equinor/fusion-framework-module';
 
-import { Query, queryValue } from '@equinor/fusion-observable/query';
+import { Query } from '@equinor/fusion-observable/query';
 
 import {
     EventModule,
@@ -78,25 +78,25 @@ export class AppProvider extends Observable<AppManifest | undefined> implements 
     }
 
     public getApp(appKey: string): Observable<AppManifest> {
-        return queryValue(this.#appClient.query({ appKey }));
+        return Query.extractQueryValue(this.#appClient.query({ appKey }));
     }
 
     public getAllApps(): Observable<AppManifest[]> {
-        return queryValue(this.#appsClient.query());
+        return Query.extractQueryValue(this.#appsClient.query());
     }
 
     public getAppConfig<TType = unknown>(
         appKey: string,
         tag?: string
     ): Observable<AppConfig<TType>> {
-        return queryValue(this.#configClient.query({ appKey, tag }));
+        return Query.extractQueryValue(this.#configClient.query({ appKey, tag }));
     }
 
     public setCurrentApp(appKey: string): Promise<void> {
         return new Promise((complete, error) => {
-            const query$ = this.#appClient.query({ appKey }, { skipQueue: true });
+            const query$ = this.#appClient.query({ appKey });
             this.#subscription.add(
-                queryValue(query$).subscribe({
+                Query.extractQueryValue(query$).subscribe({
                     next: (x) => this.#current$.next(x),
                     error,
                     complete,

--- a/packages/module-context/src/client/ContextClient.ts
+++ b/packages/module-context/src/client/ContextClient.ts
@@ -2,7 +2,6 @@ import { Observable, BehaviorSubject, EMPTY } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import { Query, QueryCtorOptions } from '@equinor/fusion-observable/query';
-import { QueryClientStatus } from '@equinor/fusion-observable/query/client';
 
 import { ContextItem } from '../types';
 
@@ -22,10 +21,6 @@ export class ContextClient extends Observable<ContextItem> {
 
     get currentContext$(): Observable<ContextItem | undefined> {
         return this.#currentContext$.asObservable();
-    }
-
-    get status$(): Observable<QueryClientStatus> {
-        return this.#client.client.pipe(map((x) => x.status));
     }
 
     get client(): Query<ContextItem, { id: string }> {

--- a/packages/module-context/src/configurator.ts
+++ b/packages/module-context/src/configurator.ts
@@ -4,7 +4,6 @@ import { QueryCtorOptions } from '@equinor/fusion-observable/query';
 import { ContextClientOptions } from './client/ContextClient';
 import { ContextItem, QueryContextParameters } from './types';
 import { getContextSelector, queryContextSelector } from './selectors';
-import { debounceTime } from 'rxjs/operators';
 
 export interface IContextModuleConfig {
     getContext: ContextClientOptions;
@@ -72,7 +71,6 @@ export class ContextModuleConfigurator implements IContextModuleConfigurator<[Se
             queryContext: {
                 client: await this.createContextClientQuery(init),
                 key: (args) => JSON.stringify(args),
-                queueOperator: (_) => ($) => $.pipe(debounceTime(250)),
                 expire: this.defaultExpireTime,
             },
         };

--- a/packages/module-service-discovery/package.json
+++ b/packages/module-service-discovery/package.json
@@ -24,7 +24,9 @@
     },
     "dependencies": {
         "@equinor/fusion-framework-module": "^1.2.9",
-        "@equinor/fusion-framework-module-http": "^2.1.4"
+        "@equinor/fusion-framework-module-http": "^2.1.4",
+        "@equinor/fusion-observable": "^1.3.1",
+        "rxjs": "^7.5.7"
     },
     "devDependencies": {
         "typescript": "^4.8.4"

--- a/packages/module-service-discovery/tsconfig.json
+++ b/packages/module-service-discovery/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../module-http"
+    },
+    {
+      "path": "../observable"
     }
   ],
   "include": [

--- a/packages/observable/src/query/cache/actions.ts
+++ b/packages/observable/src/query/cache/actions.ts
@@ -6,7 +6,12 @@ export type QueryCacheActions<TType = unknown, TArgs = unknown> = {
         'set',
         {
             key: string;
-            value: QueryCacheRecord<TType, TArgs>;
+            value: {
+                value: TType;
+                args: TArgs;
+                transaction: string;
+                created?: number;
+            };
         }
     >;
     clear: PayloadAction<'clear', { key: string }>;

--- a/packages/observable/src/query/cache/types.ts
+++ b/packages/observable/src/query/cache/types.ts
@@ -1,8 +1,8 @@
 export type QueryCacheRecord<TType = unknown, TArgs = unknown> = {
     value: TType;
-    args?: TArgs;
-    transaction?: string;
-    created?: number;
+    args: TArgs;
+    transaction: string;
+    created: number;
     updated?: number;
     updates?: number;
 };

--- a/packages/observable/src/query/client/QueryClient.ts
+++ b/packages/observable/src/query/client/QueryClient.ts
@@ -1,74 +1,79 @@
-import { asyncScheduler, firstValueFrom, Observable, Subscription } from 'rxjs';
-import { map, observeOn } from 'rxjs/operators';
+import { firstValueFrom, Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import { v4 as uuid } from 'uuid';
+import * as uuid from 'uuid';
 
-import { ActionType, ExtractAction, ReactiveObservable } from '../..';
+import { ActionMeta, ActionType, ExtractAction, ReactiveObservable } from '../..';
 import { filterAction } from '../../operators';
 
 import { ActionTypes, RequestAction } from './actions';
 import { handleRequests, handleFailures } from './epics';
+import { filterQueryTaskComplete } from './operators';
 import { QueryClientError } from './QueryClientError';
 import { createReducer } from './reducer';
 
-import { State, RetryOptions, QueryFn } from './types';
+import { State, RetryOptions, QueryFn, QueryTaskCompleted, QueryTaskValue } from './types';
 
-// import { RetryOpt, QueryFn, QueryState, QueryStatus } from './types';
 /**
  * - __controller__: [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) [optional]
  * - __retry__: retry config {@link RetryOpt}
  */
-export type QueryClientOptions = {
+export type QueryClientOptions<TType = unknown, TArgs = unknown> = {
     controller: AbortController;
     retry: Partial<RetryOptions>;
     /** reference to a query  */
-    transaction?: string;
+    ref?: string;
+    task?: Subject<QueryTaskValue<TType, TArgs>>;
 };
 
 export type QueryClientCtorOptions = {
     retry?: Partial<RetryOptions>;
 };
 
-export class QueryClient<TType, TArgs> extends Observable<State> {
+export class QueryClient<TType, TArgs> extends Observable<State<TType, TArgs>> {
     /** internal state */
-    #state$: ReactiveObservable<State, ActionTypes<TType, TArgs>>;
+    #state: ReactiveObservable<State<TType, TArgs>, ActionTypes<TType, TArgs>>;
 
     #subscription: Subscription;
 
-    public get value(): State {
-        return this.#state$.value;
-    }
-
     /** get stream of dispatched actions */
     public get action$(): Observable<ActionTypes<TType, TArgs>> {
-        return this.#state$.action$;
+        return this.#state.action$;
     }
 
     public get closed() {
-        return this.#state$.closed;
+        return this.#state.closed;
     }
 
-    public get status() {
-        return this.value.status;
+    public get success$(): Observable<TType> {
+        return this.action$.pipe(
+            filterAction('success'),
+            map(({ payload }) => payload)
+        );
     }
 
-    public get error() {
-        return this.value.error;
+    public get error$(): Observable<QueryClientError> {
+        return this.action$.pipe(
+            filterAction('error'),
+            map(
+                ({ payload }) => new QueryClientError('error', 'failed to execute request', payload)
+            )
+        );
     }
 
     constructor(queryFn: QueryFn<TType, TArgs>, options?: QueryClientCtorOptions) {
         super((subscriber) => {
-            return this.#state$.subscribe(subscriber);
+            return this.#state.subscribe(subscriber);
         });
 
-        this.#state$ = new ReactiveObservable(createReducer(), { status: 'idle' });
+        this.#state = new ReactiveObservable(createReducer<TType, TArgs>(), {});
 
-        this.#subscription = new Subscription(() => this.#state$.complete());
+        this.#subscription = new Subscription(() => this.#state.complete());
 
-        this.#subscription.add(this.#state$.addEpic(handleRequests(queryFn)));
+        this.#subscription.add(this.#state.addEpic(handleRequests(queryFn)));
 
         const retry = Object.assign({ count: 0, delay: 0 }, options?.retry);
-        this.#subscription.add(this.#state$.addEpic(handleFailures(retry)));
+        this.#subscription.add(this.#state.addEpic(handleFailures(retry)));
     }
 
     /**
@@ -77,9 +82,11 @@ export class QueryClient<TType, TArgs> extends Observable<State> {
      * @param opt query options {@link QueryClientOptions}
      * @returns id of the request
      */
-    public next(args?: TArgs, opt?: Partial<QueryClientOptions>): string {
-        const action = this._next(args, opt);
-        return action.meta.transaction;
+    public next(
+        args?: TArgs,
+        opt?: Partial<QueryClientOptions<TType, TArgs>>
+    ): ActionMeta<RequestAction<TArgs, TType>> {
+        return this._next(args, opt).meta;
     }
 
     /**
@@ -90,33 +97,21 @@ export class QueryClient<TType, TArgs> extends Observable<State> {
      */
     public async nextAsync(
         args?: TArgs,
-        opt?: Partial<QueryClientOptions>
-    ): Promise<TType | Error> {
-        this._next(args, opt);
-        const complete$ = this.#state$.action$.pipe(
-            filterAction('success', 'error', 'cancel'),
-            map((action): TType | QueryClientError => {
-                const { payload, type } = action;
-                switch (type) {
-                    case 'error':
-                        throw new QueryClientError(
-                            'error',
-                            'failed to execute request',
-                            payload as Error
-                        );
-                    case 'cancel':
-                        throw new QueryClientError(
-                            'abort',
-                            'request was canceled',
-                            new Error(String(payload))
-                        );
-                }
-                return payload as TType;
-            }),
-            observeOn(asyncScheduler)
-        );
+        opt?: Partial<QueryClientOptions<TType, TArgs>>
+    ): Promise<QueryTaskCompleted<TType, TArgs>> {
+        return firstValueFrom(this.next(args, opt).task.pipe(filterQueryTaskComplete()));
+    }
 
-        return firstValueFrom(complete$);
+    public getTaskByTransaction(
+        transaction: string
+    ): Subject<QueryTaskValue<TType, TArgs>> | undefined {
+        const entry = this.#state.value[transaction];
+        return entry && entry.task;
+    }
+
+    public getTaskByRef(ref: string): Subject<QueryTaskValue<TType, TArgs>> | undefined {
+        const entry = Object.values(this.#state.value).find((x) => x.ref === ref);
+        return entry && entry.task;
     }
 
     /**
@@ -124,16 +119,16 @@ export class QueryClient<TType, TArgs> extends Observable<State> {
      * @param reason message of why request was canceled
      */
     public cancel(transaction?: string, reason?: string): void {
-        if (this.value.status !== 'canceled') {
-            reason ??= `request [${transaction || this.value.transaction}] was canceled!`;
-            this.#state$.next({
+        if (transaction && this.#state.value[transaction]) {
+            reason ??= `[${transaction}]: transaction canceled`;
+            this.#state.next({
                 type: 'cancel',
-                payload: transaction,
-                meta: {
-                    request: undefined,
-                    reason,
-                },
+                payload: { transaction, reason },
             });
+        } else {
+            for (const key of Object.keys(this.#state.value)) {
+                this.cancel(key, `[${transaction}]: all transactions canceled`);
+            }
         }
     }
 
@@ -147,7 +142,7 @@ export class QueryClient<TType, TArgs> extends Observable<State> {
             subject: QueryClient<TType, TArgs>
         ) => void
     ) {
-        return this.#state$.addEffect(type, (action) => {
+        return this.#state.addEffect(type, (action) => {
             cb(action, this);
         });
     }
@@ -158,19 +153,28 @@ export class QueryClient<TType, TArgs> extends Observable<State> {
     }
 
     public asObservable() {
-        return this.#state$.asObservable();
+        return this.#state.asObservable();
     }
 
-    protected _next(args?: TArgs, opt?: Partial<QueryClientOptions>): RequestAction<TArgs> {
-        const { controller = new AbortController(), transaction = uuid() } = opt ?? {};
-        const meta = { ...opt, controller, transaction };
-        const action: RequestAction<TArgs> = {
+    protected _next(
+        args?: TArgs,
+        opt?: Partial<QueryClientOptions<TType, TArgs>>
+    ): RequestAction<TArgs, TType> {
+        const meta = Object.assign(
+            {
+                transaction: uuid.v4(),
+                controller: new AbortController(),
+                task: new ReplaySubject<QueryTaskValue>(),
+            },
+            opt ?? {}
+        );
+        const action: RequestAction<TArgs, TType> = {
             type: 'request',
             payload: args as TArgs,
             meta,
         };
 
-        this.#state$.next(action);
+        this.#state.next(action);
 
         return action;
     }

--- a/packages/observable/src/query/client/index.ts
+++ b/packages/observable/src/query/client/index.ts
@@ -1,12 +1,8 @@
 export { ActionTypes as QueryClientActions } from './actions';
 
-export {
-    State as QueryClientState,
-    Status as QueryClientStatus,
-    QueryFn as QueryClientFn,
-    RetryOptions as QueryClientRetryOptions,
-} from './types';
-
 export { QueryClientError } from './QueryClientError';
 
 export { default, QueryClient, QueryClientOptions, QueryClientCtorOptions } from './QueryClient';
+
+export * from './types';
+export * as operators from './operators';

--- a/packages/observable/src/query/client/operators.ts
+++ b/packages/observable/src/query/client/operators.ts
@@ -1,0 +1,8 @@
+import type { OperatorFunction } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { QueryTaskCompleted, QueryTaskValue } from './types';
+
+export const filterQueryTaskComplete = <TType, TArgs>(): OperatorFunction<
+    QueryTaskValue,
+    QueryTaskCompleted<TType, TArgs>
+> => filter((x): x is QueryTaskCompleted<TType, TArgs> => x.status === 'complete');

--- a/packages/observable/src/query/client/reducer.ts
+++ b/packages/observable/src/query/client/reducer.ts
@@ -1,65 +1,95 @@
 import type { Reducer } from '../..';
 
 import { ActionTypes } from './actions';
-import { State } from './types';
+import { QueryClientError } from './QueryClientError';
+import { QueryTaskCompleted, State } from './types';
 
 export const createReducer =
-    <TType, TArgs>(): Reducer<State, ActionTypes<TType, TArgs>> =>
+    <TType, TArgs>(): Reducer<State<TType, TArgs>, ActionTypes<TType, TArgs>> =>
     (state, action) => {
         switch (action.type) {
-            // case 'skipped': {
-            //     return state;
-            // }
-
             case 'request': {
-                const { transaction } = action.meta;
-                if (state.transaction === transaction) {
-                    return {
-                        ...state,
-                        status: 'active',
-                        retryCount: (state.retryCount || 0) + 1,
-                    };
-                }
-                return {
-                    transaction,
-                    status: 'active',
-                    initiated: Date.now(),
-                    retryCount: 0,
-                };
+                const { transaction, task, ref } = action.meta;
+                return Object.assign({}, state, {
+                    [transaction]: {
+                        transaction,
+                        task,
+                        ref,
+                        created: Date.now(),
+                    },
+                });
             }
 
-            case 'success': {
-                return {
-                    ...state,
-                    status: 'idle',
-                    completed: Date.now(),
-                };
+            case 'retry': {
+                const { transaction } = action.payload.meta;
+                const entry = { ...state[transaction] };
+                if (entry) {
+                    entry.retry = entry.retry ? [...entry.retry, Date.now()] : [];
+                    return Object.assign({}, state, { [transaction]: entry });
+                }
+                break;
             }
 
             case 'failure': {
-                return {
-                    ...state,
-                    status: 'failed',
-                };
-            }
-
-            case 'error': {
-                return {
-                    ...state,
-                    status: 'failed',
-                    error: action.payload,
-                };
+                const { transaction } = action.meta.request.meta;
+                const entry = { ...state[transaction] };
+                if (entry) {
+                    entry.errors = entry.errors ? [...entry.errors, action.payload] : [];
+                    return Object.assign({}, state, { [transaction]: entry });
+                }
+                break;
             }
 
             case 'cancel': {
-                return state.status === 'canceled'
-                    ? state
-                    : {
-                          ...state,
-                          status: 'canceled',
-                      };
+                const { transaction, reason } = action.payload;
+                const entry = state[transaction];
+                if (entry) {
+                    entry.task.error(
+                        new QueryClientError('abort', 'request was canceled', new Error(reason))
+                    );
+                    const next = { ...state };
+                    delete next[transaction];
+                    return next;
+                }
+                break;
+            }
+            case 'error': {
+                const { transaction } = action.meta.request.meta;
+                const entry = state[transaction];
+                if (entry) {
+                    entry.task.error(
+                        new QueryClientError('error', 'failed to execute request', action.payload)
+                    );
+                    const next = { ...state };
+                    delete next[transaction];
+                    return next;
+                }
+                break;
+            }
+            case 'success': {
+                const { request } = action.meta;
+                const { transaction, ref } = request.meta;
+                const entry = state[transaction];
+                if (entry) {
+                    const taskNext: QueryTaskCompleted<TType, TArgs> = {
+                        status: 'complete',
+                        transaction,
+                        ref,
+                        value: action.payload,
+                        args: request.payload,
+                        created: entry.created,
+                        completed: Date.now(),
+                    };
+                    entry.task.next(taskNext);
+                    entry.task.complete();
+                    const next = { ...state };
+                    delete next[transaction];
+                    return next;
+                }
+                break;
             }
         }
+        return state;
     };
 
 export default createReducer;

--- a/packages/observable/src/query/client/types.ts
+++ b/packages/observable/src/query/client/types.ts
@@ -1,19 +1,39 @@
-import type { ObservableInput } from 'rxjs';
+import { ObservableInput, Subject } from 'rxjs';
 
-export type Status = 'idle' | 'active' | 'failed' | 'canceled';
+// export type Status = 'idle' | 'active' | 'failed' | 'canceled';
 
-export type State = {
-    status: Status;
-    transaction?: string;
-    initiated?: number;
-    retryCount?: number;
-    completed?: number;
-    error?: unknown;
+export type QueryTaskValue<TValue = unknown, TArgs = unknown> = {
+    status: string;
+    transaction: string;
+    created: number;
+    args: TArgs;
+    value: TValue;
 };
+export type QueryTaskCompleted<TValue, TArgs = unknown> = QueryTaskValue<TValue, TArgs> & {
+    status: 'complete';
+    ref?: string;
+    completed: number;
+};
+
+export type QueryTask<TValue, TArgs = unknown> = Subject<QueryTaskValue<TValue, TArgs>>;
+
+export type QueueItem<TType = unknown, TArgs = unknown> = {
+    transaction: string;
+    task: QueryTask<TType, TArgs>;
+    created: number;
+    retry?: Array<number>;
+    errors?: Array<Error>;
+    ref?: string;
+};
+
+export type State<TType = unknown, TArgs = unknown> = Record<string, QueueItem<TType, TArgs>>;
 
 export type RetryOptions = {
     count: number;
     delay: number | ((error: unknown) => ObservableInput<void>);
 };
 
-export type QueryFn<TType, TArgs> = (args: TArgs, signal?: AbortSignal) => ObservableInput<TType>;
+export type QueryFn<TType = unknown, TArgs = unknown> = (
+    args: TArgs,
+    signal?: AbortSignal
+) => ObservableInput<TType>;

--- a/packages/observable/src/query/index.ts
+++ b/packages/observable/src/query/index.ts
@@ -1,8 +1,6 @@
-import { map, Observable } from 'rxjs';
-import Query from './Query';
+export * from './types';
+export * as operators from './operators';
 
-export { default, Query, QueryCtorOptions, QueryOptions } from './Query';
+export { default, Query, QueryCtorOptions } from './Query';
 
-export const queryValue = <TType, TArgs>(
-    stream: ReturnType<Query<TType, TArgs>['query']>
-): Observable<TType> => stream.pipe(map((entry) => entry.value));
+

--- a/packages/observable/src/query/operators.ts
+++ b/packages/observable/src/query/operators.ts
@@ -1,0 +1,26 @@
+import type { Observable } from 'rxjs';
+import { concatMap, map, mergeMap, switchMap } from 'rxjs/operators';
+
+import type { QueryTaskValue } from './client';
+import type { Query } from './Query';
+
+import type { QueryQueueItem } from './types';
+
+export const concatQueue =
+    <TArgs, TType>(cb: (args: QueryQueueItem<TArgs, TType>) => Observable<QueryTaskValue<TType>>) =>
+    (source$: Observable<QueryQueueItem<TArgs, TType>>) =>
+        source$.pipe(concatMap(cb));
+
+export const mergeQueue =
+    <TArgs, TType>(cb: (args: QueryQueueItem<TArgs, TType>) => Observable<QueryTaskValue<TType>>) =>
+    (source$: Observable<QueryQueueItem<TArgs, TType>>) =>
+        source$.pipe(mergeMap(cb));
+
+export const switchQueue =
+    <TArgs, TType>(cb: (args: QueryQueueItem<TArgs, TType>) => Observable<QueryTaskValue<TType>>) =>
+    (source$: Observable<QueryQueueItem<TArgs, TType>>) =>
+        source$.pipe(switchMap(cb));
+
+export const queryValue = <TType, TArgs>(
+    source$: ReturnType<Query<TType, TArgs>['query']>
+): Observable<TType> => source$.pipe(map((entry) => entry.value));

--- a/packages/observable/src/query/types.ts
+++ b/packages/observable/src/query/types.ts
@@ -1,4 +1,6 @@
-import type { ObservableInput } from 'rxjs';
+import type { Observable, ObservableInput, OperatorFunction } from 'rxjs';
+import type { QueryCacheRecord } from './cache';
+import type { QueryClientOptions, QueryTaskValue } from './client';
 
 export type QueryState = {
     status: QueryStatus;
@@ -16,9 +18,42 @@ export enum QueryStatus {
     CANCELED = 'canceled',
 }
 
+export type CacheValidator<TType, TArgs> = (
+    entry: QueryCacheRecord<TType, TArgs>,
+    args: TArgs
+) => boolean;
+
+export type CacheOptions<TType, TArgs> = {
+    key: (query: TArgs) => string;
+    validate: CacheValidator<TType, TArgs>;
+};
+
+export type QueryOptions<TType, TArgs = unknown> = {
+    client?: Partial<QueryClientOptions>;
+    cache?: {
+        suppressInvalid: boolean;
+        validate?: CacheValidator<TType, TArgs>;
+    };
+};
+
+export type QueryTaskCached<TValue, TArgs> = QueryTaskValue<TValue, TArgs> & {
+    status: 'cache';
+    updated?: number;
+    updates?: number;
+};
+
+export type QueryQueueItem<TArgs, TType> = {
+    args: TArgs;
+    options?: Partial<QueryClientOptions<TType, TArgs>>;
+};
+
 export type RetryOpt = {
     count: number;
     delay: number | ((error: unknown) => ObservableInput<void>);
 };
 
 export type QueryFn<TType, TArgs> = (args: TArgs, signal?: AbortSignal) => ObservableInput<TType>;
+
+export type QueryQueueFn<TArgs = unknown, TType = unknown> = (
+    fn: (args: QueryQueueItem<TArgs, TType>) => Observable<QueryTaskValue<TType, TArgs>>
+) => OperatorFunction<QueryQueueItem<TArgs, TType>, QueryTaskValue<TType, TArgs>>;

--- a/packages/observable/src/react/index.ts
+++ b/packages/observable/src/react/index.ts
@@ -7,3 +7,5 @@ export * from './useObservableSelector';
 export * from './useObservableSelectorState';
 export * from './useObservableSubscription';
 export * from './useObservableInput';
+
+export * from './useDebounceQuery';

--- a/packages/observable/src/react/useDebounceQuery.ts
+++ b/packages/observable/src/react/useDebounceQuery.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo, useState } from 'react';
+import { debounce, debounceTime, ObservableInput, Subject, switchMap } from 'rxjs';
+import { useObservableState } from './useObservableState';
+import type { ObservableType } from '../types';
+import Query, { QueryCtorOptions } from '../query/Query';
+import { QueryOptions } from '../query/types';
+
+type UseDebounceQueryArgs<TType, TArgs> = { args: TArgs; options?: QueryOptions<TType, TArgs> };
+type UseDebounceQueryValue<TType, TArgs> = ObservableType<ReturnType<Query<TType, TArgs>['query']>>;
+
+export const useDebounceQuery = <TType, TArgs>(
+    clientOrClientCtor: Query<TType, TArgs> | QueryCtorOptions<TType, TArgs>,
+    options: {
+        debounce:
+            | ((value: UseDebounceQueryArgs<TType, TArgs>) => ObservableInput<unknown>)
+            | number;
+        initial?: ObservableType<ReturnType<Query<TType, TArgs>['query']>>;
+        queuer?: Subject<UseDebounceQueryArgs<TType, TArgs>>;
+    }
+): {
+    value: UseDebounceQueryValue<TType, TArgs> | undefined;
+    query: (args: UseDebounceQueryArgs<TType, TArgs>) => void;
+} => {
+    const [client] = useState<Query<TType, TArgs>>(() =>
+        clientOrClientCtor instanceof Query ? clientOrClientCtor : new Query(clientOrClientCtor)
+    );
+    const [queuer] = useState(
+        () => options?.queuer ?? new Subject<UseDebounceQueryArgs<TType, TArgs>>()
+    );
+
+    const query = useCallback(
+        (args: UseDebounceQueryArgs<TType, TArgs>) => queuer.next(args),
+        [queuer]
+    );
+
+    const debounceFn = useMemo(
+        () =>
+            typeof options.debounce === 'function'
+                ? debounce(options.debounce)
+                : debounceTime<UseDebounceQueryArgs<TType, TArgs>>(options.debounce),
+        [options.debounce]
+    );
+
+    const value = useObservableState(
+        useMemo(
+            () =>
+                queuer.pipe(
+                    debounceFn,
+                    switchMap(({ args, options }) => client.query(args, options))
+                ),
+            [client]
+        ),
+        options?.initial
+    );
+
+    return { value, query };
+};
+
+export default useDebounceQuery;

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -26,7 +26,7 @@
         "@equinor/fusion-framework-react-app": "^1.2.10",
         "@equinor/fusion-observable": "^1.3.1",
         "@equinor/fusion-react-progress-indicator": "^0.1.5",
-        "@equinor/fusion-react-styles": "^0.5.4",
+        "@equinor/fusion-react-styles": "^0.5.5",
         "@tanstack/react-query": "^4.2.3",
         "@tanstack/react-query-devtools": "^4.2.3",
         "@types/react": "^18.0.17",
@@ -39,5 +39,8 @@
         "typescript": "^4.8.4",
         "vite": "^3.1.8",
         "vite-plugin-environment": "^1.1.3"
+    },
+    "dependencies": {
+        "rxjs": "^7.5.7"
     }
 }

--- a/packages/test-app/src/pages/context/GetContext.tsx
+++ b/packages/test-app/src/pages/context/GetContext.tsx
@@ -27,8 +27,6 @@ export const GetContext = () => {
     const context = useCurrentContext();
     const portalContext = useFrameworkCurrentContext();
 
-    const status = useObservableState(provider.contextClient.status$);
-
     useEffect(() => {
         if (!contextId) {
             return;
@@ -60,10 +58,6 @@ export const GetContext = () => {
                 <option value="a007e04a-e372-4da5-b5be-8d2f6b671065">Krafla</option>
                 <option value="03f56966-4732-48bc-8b42-6450cedb38fa">Fusion</option>
             </select>
-            <div>
-                <span>Status:</span>
-                <span>{status}</span>
-            </div>
 
             <h3>App Context</h3>
             <pre>


### PR DESCRIPTION
previously the client could only execute one query, now i has an internal queue of task, which the query connects to, this is to handle if multiple sources ask for same resource which are not within same scope.