### PR TITLE
fix(react-app): fix optional dependencie version react-module-context

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -52,7 +52,7 @@
         "typescript": "^4.9.3"
     },
     "peerDependencies": {
-        "@equinor/fusion-framework-react-module-context": "^0.4.2",
+        "@equinor/fusion-framework-react-module-context": "^1.0.1",
         "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Fixing optional dependencies resolve error for ``fusion-framwork-react-app``.
Dependency ``fusion-framework-react-module-context`` to version 1.0.1