### PR TITLE
fix(module-http): adding missing types on module-http iHttpClient

### DIFF
--- a/packages/module-http/src/lib/client/types.ts
+++ b/packages/module-http/src/lib/client/types.ts
@@ -126,12 +126,22 @@ export interface IHttpClient<TRequest extends FetchRequest = FetchRequest, TResp
      */
     fetch<T = TResponse>(path: string, init?: FetchRequestInit<T, TRequest, TResponse>): Promise<T>;
 
+    fetchAsync<T = TResponse>(
+        path: string,
+        args?: FetchRequestInit<T, TRequest, TResponse>
+    ): Promise<T>;
+
     json$<T = TResponse>(
         path: string,
         init?: FetchRequestInit<T, TRequest, TResponse>
     ): StreamResponse<T>;
 
     json<T = TResponse>(path: string, init?: FetchRequestInit<T, TRequest, TResponse>): Promise<T>;
+
+    jsonAsync<T = TResponse>(
+        path: string,
+        args?: FetchRequestInit<T, TRequest, TResponse>
+    ): Promise<T>;
 
     /**
      *


### PR DESCRIPTION
Adding 2 missing types on IHttpClient interface on module-http