### PR TITLE
fix(app): mapping env appKey from manifest to key

### DIFF
--- a/packages/app/src/configure-modules.ts
+++ b/packages/app/src/configure-modules.ts
@@ -20,8 +20,11 @@ export const configureModules =
         const modules = (await configurator.initialize(
             args.fusion.modules
         )) as AppModulesInstance<TModules>;
+
+        const key = args.env.manifest ?? args.env.key;
+
         modules.event.dispatchEvent('onAppModulesLoaded', {
-            detail: { appKey: args.env.manifest.appKey, modules },
+            detail: { appKey: key, modules },
         });
         return modules;
     };

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -37,6 +37,7 @@ export type AppEnv<TConfig = unknown, TProps = unknown> = {
     manifest: AppManifest;
     config?: AppConfig<TConfig>;
     props?: TProps;
+    key?: string;
 };
 
 export type AppModuleInitiator<

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/esm",
     "rootDir": "src",
+    "declaration": true,
     "declarationDir": "./dist/types",
     "baseUrl": "src",
     "jsx": "react-jsx"


### PR DESCRIPTION
mapping fallback value from `env.mainifest.appKey` to `env.key`, in fusion-framework-app `configure-moduels.ts`