### PR TITLE
fix(react-app): check if manifest is provided in env

### DIFF
--- a/packages/app/src/configure-modules.ts
+++ b/packages/app/src/configure-modules.ts
@@ -20,9 +20,14 @@ export const configureModules =
         const modules = (await configurator.initialize(
             args.fusion.modules
         )) as AppModulesInstance<TModules>;
-        modules.event.dispatchEvent('onAppModulesLoaded', {
-            detail: { appKey: args.env.manifest.appKey, modules },
-        });
+
+        // @eikeland
+        // TODO - remove check after fusion-cli is updated (app module is not enabled in fusion-cli)
+        if (args.env.manifest?.appKey) {
+            modules.event.dispatchEvent('onAppModulesLoaded', {
+                detail: { appKey: args.env.manifest.appKey, modules },
+            });
+        }
         return modules;
     };
 

--- a/packages/react-app/src/create-legacy-app.tsx
+++ b/packages/react-app/src/create-legacy-app.tsx
@@ -6,17 +6,25 @@ import type { AnyModule } from '@equinor/fusion-framework-module';
 import type { AppEnv, AppModuleInitiator } from '@equinor/fusion-framework-app';
 
 import { createComponent } from './create-component';
+import { AppModule } from '@equinor/fusion-framework-module-app';
 
 export const createLegacyApp = <TModules extends Array<AnyModule>>(
     Component: React.ComponentType,
     configure?: AppModuleInitiator<TModules>
 ) => {
     return (): JSX.Element => {
-        const fusion = useFramework();
+        const fusion = useFramework<[AppModule]>();
         const RenderComponent = useMemo(() => {
             const creator = createComponent(Component, configure);
+            // @eikeland
+            // TODO - recheck when legacy fusion-cli is updated!
+            const appProvider = fusion.modules.app;
+            if (appProvider?.current) {
+                const { config, manifest } = appProvider.current;
+                return creator(fusion, { config, manifest } as unknown as AppEnv);
+            }
             return creator(fusion, {} as unknown as AppEnv);
-        }, []);
+        }, [fusion]);
         return (
             <Suspense fallback={<p>loading app</p>}>
                 <RenderComponent />

--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../module-msal"
     },
     {
+      "path": "../module-app"
+    },
+    {
       "path": "../module-event"
     },
     {


### PR DESCRIPTION
since legacy `@equinor/fusion-cli` not yet has `@equinor/fusion-framework-module-app` configured, manifest is not provided during init of application modules

closes #497