### PR TITLE
fix(framework): add type AppModule to framework.modules

### DIFF
--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -1,6 +1,7 @@
 import type { CombinedModules, ModulesInstance } from '@equinor/fusion-framework-module';
 import type { AnyModule } from '@equinor/fusion-framework-module';
 
+import { AppModule } from '@equinor/fusion-framework-module-app';
 import { ContextModule } from '@equinor/fusion-framework-module-context';
 import { EventModule } from '@equinor/fusion-framework-module-event';
 import { HttpModule } from '@equinor/fusion-framework-module-http';
@@ -10,7 +11,7 @@ import { ServicesModule } from '@equinor/fusion-framework-module-services';
 
 export type FusionModules<TModules extends Array<AnyModule> | unknown = unknown> = CombinedModules<
     TModules,
-    [ContextModule, EventModule, HttpModule, MsalModule, ServicesModule, ServiceDiscoveryModule]
+    [AppModule, ContextModule, EventModule, HttpModule, MsalModule, ServicesModule, ServiceDiscoveryModule]
 >;
 
 export type FusionModulesInstance<TModules extends Array<AnyModule> | unknown = unknown> =


### PR DESCRIPTION
Missing type on framework, framework.module.app.
Adding AppModule to FusionModules .
