### PR TITLE
feat(module-service-discovery): allow sync resolve of service

### DIFF
--- a/packages/module-service-discovery/src/provider.ts
+++ b/packages/module-service-discovery/src/provider.ts
@@ -18,8 +18,11 @@ export interface IServiceDiscoveryProvider {
     resolveService(key: string): Promise<Service>;
     /**
      * service environment
+     * this might throw error if no environment is loaded
      */
-    readonly environment: Promise<Environment>;
+    readonly environment: Environment;
+
+    resolveServices(): Promise<Environment>;
 
     createClient(
         name: string,
@@ -38,8 +41,12 @@ export class ServiceDiscoveryProvider implements IServiceDiscoveryProvider {
         protected readonly _http: ModuleType<HttpModule>
     ) {}
 
-    public get environment(): Promise<Environment> {
+    public get environment(): Environment {
         return this._client.environment;
+    }
+
+    public resolveServices(): Promise<Environment> {
+        return this._client.fetchEnvironment();
     }
 
     public async resolveService(key: string): Promise<Service> {


### PR DESCRIPTION
allow to access environment from service discovery.
when trying to access this attribute without a loaded environment an error will been thrown.

this attribute is most likely only used internally (case the breaking change)

BREAKING CHANGE: changed `environment` from promise to sync