### PR TITLE
chore: remove signal r hub connection error in development

### DIFF
--- a/packages/modules/signalr/src/SignalRModuleConfigurator.ts
+++ b/packages/modules/signalr/src/SignalRModuleConfigurator.ts
@@ -5,7 +5,7 @@ import {
 } from '@equinor/fusion-framework-module';
 
 import { ServiceDiscoveryModule } from '@equinor/fusion-framework-module-service-discovery';
-import { IHttpConnectionOptions } from '@microsoft/signalr';
+import { IHttpConnectionOptions, LogLevel } from '@microsoft/signalr';
 
 export interface ISignalRConfigurator {
     /** add configuration for hub connection */
@@ -32,6 +32,7 @@ export type SignalRHubConfig = {
 
     /** reconnect when connection lost */
     automaticReconnect?: boolean;
+    logLevel?: LogLevel;
 };
 
 /**

--- a/packages/modules/signalr/src/SignalRModuleProvider.ts
+++ b/packages/modules/signalr/src/SignalRModuleProvider.ts
@@ -1,5 +1,5 @@
 import { HubConnectionBuilder, HubConnection, AbortError } from '@microsoft/signalr';
-import { Observable, shareReplay } from 'rxjs';
+import { delay, Observable, shareReplay } from 'rxjs';
 
 import { SignalRConfig } from './SignalRModuleConfigurator';
 
@@ -26,6 +26,8 @@ export class SignalRModuleProvider implements ISignalRProvider {
     }
 
     protected _createHubConnection(hubId: string): Observable<HubConnection> {
+        const LOG_LEVEL_CRITICAL = 5;
+
         if (hubId in this.#hubConnections) {
             return this.#hubConnections[hubId];
         }
@@ -40,6 +42,8 @@ export class SignalRModuleProvider implements ISignalRProvider {
             });
 
             config.automaticReconnect && builder.withAutomaticReconnect();
+
+            builder.configureLogging(config.logLevel || LOG_LEVEL_CRITICAL);
 
             const connection = builder.build();
 

--- a/packages/modules/signalr/src/SignalRModuleProvider.ts
+++ b/packages/modules/signalr/src/SignalRModuleProvider.ts
@@ -1,5 +1,5 @@
 import { HubConnectionBuilder, HubConnection, AbortError } from '@microsoft/signalr';
-import { delay, Observable, shareReplay } from 'rxjs';
+import { Observable, shareReplay } from 'rxjs';
 
 import { SignalRConfig } from './SignalRModuleConfigurator';
 
@@ -52,7 +52,7 @@ export class SignalRModuleProvider implements ISignalRProvider {
                 .then(() => {
                     observer.next(connection);
                 })
-                .catch((error: any) => {
+                .catch((error: unknown) => {
                     if (error instanceof AbortError) {
                         // Omit AbortError
                     } else {

--- a/packages/modules/signalr/src/SignalRModuleProvider.ts
+++ b/packages/modules/signalr/src/SignalRModuleProvider.ts
@@ -1,4 +1,4 @@
-import { HubConnectionBuilder, HubConnection } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnection, AbortError } from '@microsoft/signalr';
 import { Observable, shareReplay } from 'rxjs';
 
 import { SignalRConfig } from './SignalRModuleConfigurator';
@@ -43,9 +43,18 @@ export class SignalRModuleProvider implements ISignalRProvider {
 
             const connection = builder.build();
 
-            connection.start().then(() => {
-                observer.next(connection);
-            });
+            connection
+                .start()
+                .then(() => {
+                    observer.next(connection);
+                })
+                .catch((error: any) => {
+                    if (error instanceof AbortError) {
+                        // Omit AbortError
+                    } else {
+                        throw error;
+                    }
+                });
 
             const teardown = () => {
                 connection.stop();


### PR DESCRIPTION
Remove AbortError form console log under development, and added log level to signal r config