### PR TITLE
Fix path resolution in app-config.ts

### DIFF
--- a/packages/cli/src/scripts/app-config.ts
+++ b/packages/cli/src/scripts/app-config.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import url from 'url';
 
 import { findUpSync } from 'find-up';
 
@@ -54,7 +55,8 @@ export const getConfigType = (root: string): { type: SupportedTyped; file: strin
 };
 
 const loadConfigFromJavascript = async (file: string): Promise<AppConfig> => {
-    return (await import(file)).default();
+    const path = url.pathToFileUrl(file);
+    return (await import(path)).default();
 };
 
 const loadConfigFromJson = async (file: string): Promise<AppConfig> => {

--- a/packages/cli/src/scripts/app-config.ts
+++ b/packages/cli/src/scripts/app-config.ts
@@ -55,7 +55,7 @@ export const getConfigType = (root: string): { type: SupportedTyped; file: strin
 };
 
 const loadConfigFromJavascript = async (file: string): Promise<AppConfig> => {
-    const path = url.pathToFileUrl(file);
+    const path = url.pathToFileURL(file);
     return (await import(path)).default();
 };
 

--- a/packages/cli/src/scripts/app-config.ts
+++ b/packages/cli/src/scripts/app-config.ts
@@ -55,7 +55,7 @@ export const getConfigType = (root: string): { type: SupportedTyped; file: strin
 };
 
 const loadConfigFromJavascript = async (file: string): Promise<AppConfig> => {
-    const path = url.pathToFileURL(file);
+    const path = url.pathToFileURL(file).href;
     return (await import(path)).default();
 };
 


### PR DESCRIPTION
Converting the file path to an URL ensures this works on any environment (windows, linux, ...) 
Tested locally on windows and it works (without this change, it doesn't)
Should probably be tested more thoroughly.