### PR TITLE
fix(legacy-interopt): react 17.0.2 as dependecy

### DIFF
--- a/packages/react/legacy-interopt/package.json
+++ b/packages/react/legacy-interopt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-framework-legacy-interopt",
-    "version": "2.1.17",
+    "version": "2.1.16",
     "description": "Library for interopt legacy fusion applications",
     "main": "dist/esm/index.js",
     "exports": {
@@ -33,13 +33,13 @@
     "devDependencies": {
         "@equinor/fusion": "^3.4.9",
         "@equinor/fusion-components": "^2.10.5",
-        "@equinor/fusion-framework": "^6.0.11",
-        "@equinor/fusion-framework-app": "^6.0.11",
+        "@equinor/fusion-framework": "^6.0.10",
+        "@equinor/fusion-framework-app": "^6.0.10",
         "@equinor/fusion-framework-module-app": "^4.0.8",
         "@equinor/fusion-framework-module-navigation": "^1.0.8",
-        "@equinor/fusion-framework-react": "^4.0.8",
-        "@types/react": "^17.0.52",
-        "react": "^17.0.0",
+        "@equinor/fusion-framework-react": "^4.0.7",
+        "@types/react": "^17.0.2",
+        "react": "^17.0.2",
         "rxjs": "^7.5.7",
         "typescript": "^4.9.3"
     },
@@ -50,7 +50,7 @@
         "@equinor/fusion-framework-module-app": ">=3.2.0",
         "@equinor/fusion-framework-module-navigation": ">=0.1.5",
         "@equinor/fusion-framework-module-service-discovery": ">=5",
-        "react": "^17.0.52",
+        "react": "^17.0.2",
         "rxjs": "^7.5.7"
     }
 }


### PR DESCRIPTION
Downgrading dependency react to 17.0.2 from 17.0.52 fails the fusion-cli install on newer node versions.
