### PR TITLE
fix(module-navigation): prepend basename

### DIFF
--- a/packages/modules/navigation/package.json
+++ b/packages/modules/navigation/package.json
@@ -31,7 +31,7 @@
         "directory": "packages/modules/navigation"
     },
     "dependencies": {
-        "@remix-run/router": "^1.0.4"
+        "@remix-run/router": "^1.6.1"
     },
     "devDependencies": {
         "@equinor/fusion-framework-module": "^4.0.0",
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "@equinor/fusion-framework-module": ">=1.2.2",
-        "@remix-run/router": "^1.0.4",
+        "@remix-run/router": "^1.6.1",
         "rxjs": "^7.0.0"
     }
 }

--- a/packages/modules/navigation/src/provider.ts
+++ b/packages/modules/navigation/src/provider.ts
@@ -71,11 +71,14 @@ export class NavigationProvider
 
     public createRouter(routes: AgnosticRouteObject[]) {
         const history = this.#navigator;
-        console.debug('NavigationProvider::createRouter', history, routes);
+        console.debug('NavigationProvider::createRouter', routes);
         const router = createRouter({
             basename: history.basename,
             history,
             routes,
+            future: {
+                v7_prependBasename: true,
+            },
         });
         router.initialize();
         return router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,6 +3861,11 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.5.0.tgz#57618e57942a5f0131374a9fdb0167e25a117fdc"
   integrity sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==
 
+"@remix-run/router@1.6.1", "@remix-run/router@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.6.1.tgz#3a3a408481a3796f45223a549c2571517bc8af2d"
+  integrity sha512-YUkWj+xs0oOzBe74OgErsuR3wVn+efrFhXBWrit50kOiED+pvQe2r6MWY0iJMQU/mSVKxvNzL4ZaYvjdX+G7ZA==
+
 "@remix-run/router@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.3.tgz#d6d531d69c0fa3a44fda7dc00b20d49b44549164"
@@ -10316,6 +10321,14 @@ react-router-dom@^5, react-router-dom@^5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-dom@^6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.11.1.tgz#af226bae950deb437208a606a47cf5c2d72c55dc"
+  integrity sha512-dPC2MhoPeTQ1YUOt5uIK376SMNWbwUxYRWk2ZmTT4fZfwlOvabF8uduRKKJIyfkCZvMgiF0GSCQckmkGGijIrg==
+  dependencies:
+    "@remix-run/router" "1.6.1"
+    react-router "6.11.1"
+
 react-router-dom@^6.4.3:
   version "6.8.0"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz"
@@ -10353,6 +10366,13 @@ react-router@6.10.0:
   integrity sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==
   dependencies:
     "@remix-run/router" "1.5.0"
+
+react-router@6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.11.1.tgz#6e58458c03e16834dda2b433c6adb9e7c2b1d7a8"
+  integrity sha512-OZINSdjJ2WgvAi7hgNLazrEV8SGn6xrKA+MkJe9wVDMZ3zQ6fdJocUjpCUCI0cNrelWjcvon0S/QK/j0NzL3KA==
+  dependencies:
+    "@remix-run/router" "1.6.1"
 
 react-router@6.8.0:
   version "6.8.0"


### PR DESCRIPTION
when using the `createRouter` from the provider, the router does not prepend basename

https://github.com/remix-run/react-router/blame/852e05ae4132132cf5dd82ffff4c7e5be76672ae/packages/router/router.ts#L716