### PR TITLE
fix(module-context): only skip first context item if not resolved

### DIFF
--- a/packages/modules/context/src/ContextProvider.ts
+++ b/packages/modules/context/src/ContextProvider.ts
@@ -166,6 +166,8 @@ export class ContextProvider implements IContextProvider {
         opt?: { skipFirst: boolean }
     ): Subscription {
         const parentContext$ = provider.currentContext$.pipe(
+            // do not set context if parent has not initialized
+            filter((x) => x !== undefined),
             filter((next, index) => {
                 if (opt?.skipFirst && index <= 1) {
                     console.debug(

--- a/packages/modules/context/src/module.ts
+++ b/packages/modules/context/src/module.ts
@@ -67,7 +67,10 @@ export const module: ContextModule = {
                                 );
                             },
                             complete: () => {
-                                provider.connectParentContext(parentProvider, { skipFirst: true });
+                                // TODO - do we need to check first?
+                                provider.connectParentContext(parentProvider, {
+                                    skipFirst: !!provider.currentContext,
+                                });
                                 subscriber.complete();
                             },
                         })


### PR DESCRIPTION
when connecting to parent connect module, only skip first context item if there was no context resolved during initialize.