### PR TITLE
fix(module-context): skip internal context queue when settting contex…

### DIFF
--- a/packages/modules/context/src/ContextProvider.ts
+++ b/packages/modules/context/src/ContextProvider.ts
@@ -360,7 +360,7 @@ export class ContextProvider implements IContextProvider {
                             }),
                             /** recursive set current context without validation and resolve */
                             switchMap((resolved) =>
-                                this.setCurrentContext(resolved as unknown as T)
+                                this._setCurrentContext(resolved as unknown as T)
                             )
                         )
                         .subscribe(subscriber);


### PR DESCRIPTION
…t internally

when setting invalid context which resolves to related, the recursive setting of context should skip the queue.