### PR TITLE
Create a base configurator template

### DIFF
--- a/cookbooks/app-react-module/app.config.js
+++ b/cookbooks/app-react-module/app.config.js
@@ -1,0 +1,5 @@
+export default () => ({
+  "manifest": {
+    "key": "demo-module"
+  }
+});

--- a/cookbooks/app-react-module/package.json
+++ b/cookbooks/app-react-module/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@equinor/fusion-framework-cookbook-app-react-module",
+    "version": "0.0.1",
+    "description": "",
+    "private": true,
+    "type": "module",
+    "main": "/src/index.ts",
+    "scripts": {
+        "dev": "fusion-framework-cli app dev",
+        "docker": "cd .. && sh docker-script.sh app-react"
+    },
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+        "@equinor/fusion-framework-cli": "^7.0.8",
+        "@equinor/fusion-framework-module": "^4.0.0",
+        "@equinor/fusion-framework-react-app": "^4.0.14",
+        "@equinor/fusion-framework-react-module": "^3.0.1",
+        "@types/react": "^18.0.24",
+        "@types/react-dom": "^18.0.8",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    }
+}

--- a/cookbooks/app-react-module/src/App.tsx
+++ b/cookbooks/app-react-module/src/App.tsx
@@ -1,0 +1,14 @@
+import { useModule } from '@equinor/fusion-framework-react-module';
+
+export const App = () => {
+    const demoProvider = useModule('demo');
+    return (
+        <>
+            <h1>🚀 Hello custom module</h1>
+            <p>foo: {demoProvider.foo}</p>
+            <p>bar: {demoProvider.bar}</p>
+        </>
+    );
+};
+
+export default App;

--- a/cookbooks/app-react-module/src/config.ts
+++ b/cookbooks/app-react-module/src/config.ts
@@ -1,0 +1,15 @@
+import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
+import { type DemoModule, demoModule } from './modules/demo';
+
+export const configure: AppModuleInitiator<[DemoModule]> = (configurator) => {
+    configurator.addConfig({
+        module: demoModule,
+        configure(configBuilder) {
+            configBuilder.setFoo(async () => 'https://foo.bar');
+            /** disable to see default process */
+            configBuilder.setBar(() => 69);
+        },
+    });
+};
+
+export default configure;

--- a/cookbooks/app-react-module/src/index.ts
+++ b/cookbooks/app-react-module/src/index.ts
@@ -1,0 +1,30 @@
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { ComponentRenderArgs, makeComponent } from '@equinor/fusion-framework-react-app';
+
+import configure from './config';
+import App from './App';
+
+/** create a render component */
+const appComponent = createElement(App);
+
+/** create React render root component */
+const createApp = (args: ComponentRenderArgs) => makeComponent(appComponent, args, configure);
+
+/** Render function */
+export const renderApp = (el: HTMLElement, args: ComponentRenderArgs) => {
+    /** make render element */
+    const app = createApp(args);
+
+    /** create render root from provided element */
+    const root = createRoot(el);
+
+    /** render Application */
+    root.render(createElement(app));
+
+    /** Teardown */
+    return () => root.unmount();
+};
+
+export default renderApp;

--- a/cookbooks/app-react-module/src/modules/demo/configurator.ts
+++ b/cookbooks/app-react-module/src/modules/demo/configurator.ts
@@ -1,0 +1,24 @@
+import { BaseConfigBuilder, type ConfigBuilderCallback } from '@equinor/fusion-framework-module';
+
+export type DemoModuleConfig = { foo: string; bar?: number };
+
+export class DemoModuleConfigurator extends BaseConfigBuilder<DemoModuleConfig> {
+    public setFoo(cb: ConfigBuilderCallback<string>) {
+        this._set('foo', cb);
+    }
+
+    public setBar(cb: ConfigBuilderCallback<number>) {
+        this._set('bar', cb);
+    }
+
+    protected async _processConfig(config: Partial<DemoModuleConfig>) {
+        if (!config.bar) {
+            /** halt operation for demo purpose */
+            await new Promise((resolve) => setTimeout(resolve, 10000));
+            config.bar = 5;
+        }
+        return config as DemoModuleConfig;
+    }
+}
+
+export default DemoModuleConfig;

--- a/cookbooks/app-react-module/src/modules/demo/index.ts
+++ b/cookbooks/app-react-module/src/modules/demo/index.ts
@@ -1,0 +1,2 @@
+export { type DemoModule, demoModule } from './module';
+export { type DemoModuleConfig } from './configurator';

--- a/cookbooks/app-react-module/src/modules/demo/module.ts
+++ b/cookbooks/app-react-module/src/modules/demo/module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@equinor/fusion-framework-module';
+import { DemoModuleConfigurator } from './configurator';
+import DemoProvider from './provider';
+
+export type DemoModule = Module<'demo', DemoProvider, DemoModuleConfigurator>;
+
+export const demoModule: DemoModule = {
+    name: 'demo',
+    configure() {
+        const config = new DemoModuleConfigurator();
+        return config;
+    },
+    initialize: async (args) => {
+        const config = await args.config.createConfigAsync(args, {
+            foo: 'elg',
+        });
+        const module = new DemoProvider(config);
+        return module;
+    },
+};
+
+declare module '@equinor/fusion-framework-module' {
+    interface Modules {
+        demo: DemoModule;
+    }
+}

--- a/cookbooks/app-react-module/src/modules/demo/provider.ts
+++ b/cookbooks/app-react-module/src/modules/demo/provider.ts
@@ -1,0 +1,17 @@
+import { type DemoModuleConfig } from './configurator';
+
+export class DemoProvider {
+    #config: DemoModuleConfig;
+    constructor(config: DemoModuleConfig) {
+        this.#config = config;
+    }
+
+    get foo(): string {
+        return this.#config.foo;
+    }
+    get bar(): number | undefined {
+        return this.#config.bar;
+    }
+}
+
+export default DemoProvider;

--- a/cookbooks/app-react-module/tsconfig.json
+++ b/cookbooks/app-react-module/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": "src",
+    "jsx": "react-jsxdev",
+  },
+  "references": [
+    {
+      "path": "../../packages/react/app"
+    },
+    {
+      "path": "../../packages/cli"
+    },
+  ],
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -1,0 +1,151 @@
+import { from, lastValueFrom, of, type Observable, type ObservableInput } from 'rxjs';
+import { last, mergeMap, scan } from 'rxjs/operators';
+import { Modules, ModuleType } from './types';
+
+/**
+ * callback arguments for config builder callback function
+ * @template TRef parent instance
+ */
+export type ConfigBuilderCallbackArgs<TRef = unknown> = {
+    /** reference, parent modules */
+    ref?: TRef;
+
+    /**
+     * request a sibling module
+     * @template TKey name of module
+     * @argument module name of module
+     */
+    requireInstance<TKey extends string = Extract<keyof Modules, string>>(
+        module: TKey
+    ): Promise<ModuleType<Modules[TKey]>>;
+
+    /**
+     * request a sibling module
+     * @template T module type
+     * @argument module name of module
+     */
+    requireInstance<T>(module: string): Promise<T>;
+
+    /**
+     * check if a module is included in the scope
+     * @template TKey name of module
+     * @argument module name of the module
+     */
+    hasModule<TKey extends string = Extract<keyof Modules, string>>(module: TKey): boolean;
+    hasModule(module: string): boolean;
+};
+
+/**
+ * config builder callback function blueprint
+ * @template TReturn expected return type of callback
+ * @returns either a sync value or an observable input (async)
+ */
+export type ConfigBuilderCallback<TReturn = unknown> = (
+    args: ConfigBuilderCallbackArgs
+) => TReturn | ObservableInput<TReturn>;
+
+/**
+ * template class for building module config
+ *
+ * __Limitations:__
+ * this only allows configuring an attribute of config root level
+ *
+ * @example
+ * ```ts
+ * type MyModuleConfig = { foo: string; bar?: number };
+ *
+ * class MyModuleConfigurator extends BaseConfigBuilder<MyModuleConfig> {
+ *   public setFoo(cb: ModuleConfigCallback<string>) {
+ *       this._set('foo', cb);
+ *   }
+ *
+ *   public setBar(cb: ModuleConfigCallback<number>) {
+ *     this._set('bar', cb);
+ *   }
+ * }
+ * ```
+ * @template TConfig expected config the builder will create
+ */
+export abstract class BaseConfigBuilder<TConfig = unknown> {
+    /** internal hashmap of registered callback functions */
+    #configCallbacks = {} as Record<keyof TConfig, ConfigBuilderCallback>;
+
+    /**
+     * request the builder to generate config
+     * @param init config builder callback arguments
+     * @param initial optional initial config
+     * @returns configuration object
+     */
+    public createConfig(
+        init: ConfigBuilderCallbackArgs,
+        initial?: Partial<TConfig>
+    ): Observable<TConfig> {
+        return this._createConfig(init, initial);
+    }
+
+    /**
+     * @see async version of {@link BaseConfigBuilder.createConfig}
+     */
+    public async createConfigAsync(
+        init: ConfigBuilderCallbackArgs,
+        initial?: Partial<TConfig>
+    ): Promise<TConfig> {
+        return lastValueFrom(this.createConfig(init, initial));
+    }
+
+    /**
+     * internally set configuration of a config attribute
+     * @param target attribute name of config
+     * @param cb callback function for setting the attribute
+     * @template TKey keyof config (attribute name
+     */
+    protected _set<TKey extends keyof TConfig>(
+        target: TKey,
+        cb: ConfigBuilderCallback<TConfig[TKey]>
+    ) {
+        this.#configCallbacks[target] = cb;
+    }
+
+    /**
+     * @private internal creation of config
+     */
+    protected _createConfig(
+        init: ConfigBuilderCallbackArgs,
+        initial?: Partial<TConfig>
+    ): Observable<TConfig> {
+        return this._buildConfig(init, initial).pipe(
+            mergeMap((config) => this._processConfig(config))
+        );
+    }
+
+    /**
+     * @private internal builder
+     */
+    protected _buildConfig(
+        init: ConfigBuilderCallbackArgs,
+        initial?: Partial<TConfig>
+    ): Observable<Partial<TConfig>> {
+        return from(Object.entries<ConfigBuilderCallback>(this.#configCallbacks)).pipe(
+            mergeMap(async ([target, cb]) => {
+                const value = await cb(init);
+                return { target, value };
+            }),
+            scan(
+                (acc, { target, value }) => Object.assign({}, acc, { [target]: value }),
+                initial ?? ({} as TConfig)
+            ),
+            last()
+        );
+    }
+
+    /**
+     * internal post process of config creation.
+     * override this method for post processing of config
+     *
+     * can be used for adding required config attributes which might not been
+     * added config callbacks for
+     */
+    protected _processConfig(config: Partial<TConfig>): ObservableInput<TConfig> {
+        return of(config as TConfig);
+    }
+}

--- a/packages/modules/module/src/ModuleConfigBuilder.ts
+++ b/packages/modules/module/src/ModuleConfigBuilder.ts
@@ -1,5 +1,8 @@
 import { AnyModule, CombinedModules, ModuleInitializerArgs, Modules, ModuleType } from './types';
 
+/**
+ * @deprecated @see {@link BaseConfigBuilder}
+ */
 export abstract class ModuleConfigBuilder<
     TModules extends Array<AnyModule> | unknown = unknown,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/modules/module/src/index.ts
+++ b/packages/modules/module/src/index.ts
@@ -3,8 +3,15 @@ export { initializeModules } from './initialize-modules';
 
 export { ModuleConsoleLogger } from './logger';
 
-export { ModulesConfigurator } from './configurator';
-
 export { ModuleConfigBuilder } from './ModuleConfigBuilder';
+export {
+    type ConfigBuilderCallback,
+    type ConfigBuilderCallbackArgs,
+    BaseConfigBuilder,
+} from './BaseConfigBuilder';
 
-export type { IModuleConfigurator, IModulesConfigurator } from './configurator';
+export {
+    type IModuleConfigurator,
+    type IModulesConfigurator,
+    ModulesConfigurator,
+} from './configurator';


### PR DESCRIPTION
Creating config for modules has been an evolving process, and might confuse new developers.

We have now create `BaseConfigBuilder` which users can extend for building config for their module.

- [x] create base class for building config
- [x] create interface for callback function and argument
- [x] create a cookbook example

__example:__
```ts
import { BaseConfigBuilder, type ConfigBuilderCallback } from '@equinor/fusion-framework-module';

export type DemoModuleConfig = { foo: string; bar?: number };

export class DemoModuleConfigurator extends BaseConfigBuilder<DemoModuleConfig> {
    public setFoo(cb: ConfigBuilderCallback<string>) {
        this._set('foo', cb);
    }

    public setBar(cb: ConfigBuilderCallback<number>) {
        this._set('bar', cb);
    }

    protected async _processConfig(config: Partial<DemoModuleConfig>) {
        if (!config.bar) {
            /** halt operation for demo purpose */
            await new Promise((resolve) => setTimeout(resolve, 10000));
            config.bar = 5;
        }
        return config as DemoModuleConfig;
    }
}
``` 