### PR TITLE
chore: update auto labeling

### DIFF
--- a/.changeset/clean-bats-heal.md
+++ b/.changeset/clean-bats-heal.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+chore: update auto labeling

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,12 @@ labels:
     matcher:
       commits: '^docs.*?:'
       title: '^docs.*?:'
-      files: ['vue-press', '**/*.md']
+      files: ['**/*.md']
+      
+ - label: '🌍 Gihub Pages'
+    sync: true
+    matcher:
+      files: ['vue-press']
 
   - label: '🚧 chore'
     sync: true


### PR DESCRIPTION
## Why
add label when GitHub Pages documentation updates
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
