### PR TITLE
fix(cli): remove requirement of leading slash in main attr

### DIFF
--- a/.changeset/ninety-lizards-sin.md
+++ b/.changeset/ninety-lizards-sin.md
@@ -1,0 +1,6 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+Removes requirement of leading slash in `main` attr in `package.json`, meaning
+both `"main": "src/index.ts"` and `"main": "/src/index.ts"` will resolve.

--- a/packages/cli/src/scripts/app-config.ts
+++ b/packages/cli/src/scripts/app-config.ts
@@ -101,7 +101,7 @@ export const resolveAppConfig = async (): Promise<LocalConfig> => {
         {
             version: pkg.version,
             name: pkg.name,
-            main: pkg.main,
+            main: pkg.main.startsWith('/') ? pkg.main : `/${pkg.main}`,
             __DEV__: { root, configSource: appConfig.configSource, portal: appConfig.portalHost },
         }
     );


### PR DESCRIPTION
This will fix so that both `"main": "src/index.ts"` and `"main": "/src/index.ts"` will resolve.

Closes #908

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
