### PR TITLE
fix(module): add config builder callback args to process config method

### DIFF
--- a/.changeset/rotten-walls-reflect.md
+++ b/.changeset/rotten-walls-reflect.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module": patch
+---
+
+fix(module): add config builder callback args to process config method so that

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -161,7 +161,7 @@ export abstract class BaseConfigBuilder<TConfig = unknown> {
         initial?: Partial<TConfig>
     ): Observable<TConfig> {
         return this._buildConfig(init, initial).pipe(
-            mergeMap((config) => this._processConfig(config))
+            mergeMap((config) => this._processConfig(config, init))
         );
     }
 
@@ -192,7 +192,10 @@ export abstract class BaseConfigBuilder<TConfig = unknown> {
      * can be used for adding required config attributes which might not been
      * added config callbacks for
      */
-    protected _processConfig(config: Partial<TConfig>): ObservableInput<TConfig> {
+    protected _processConfig(
+        config: Partial<TConfig>,
+        _init: ConfigBuilderCallbackArgs
+    ): ObservableInput<TConfig> {
         return of(config as TConfig);
     }
 }


### PR DESCRIPTION
## Why
We add config builder callbacks so that configurator can process config with the builder callback args - for instance !requireInstance`
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
