### PR TITLE
fix(react-legacy-interopt): fix legacy render

### DIFF
--- a/.changeset/fluffy-turtles-live.md
+++ b/.changeset/fluffy-turtles-live.md
@@ -1,0 +1,31 @@
+---
+'@equinor/fusion-framework-legacy-interopt': major
+---
+
+**hotfix** provide legacy app manifest to `createLegacyRender`
+
+all application should have a `render` method for connecting to the framework, minimal effort for getting end-of-life application to run just a little longer...🌈
+
+__How to migrate__
+
+> as a app developer, you should not be using this package! 🙄
+
+as a portal developer, see code below 😎
+
+_current_
+```ts
+// before change
+createLegacyRender(
+  manifest.key, 
+  manifest.AppComponent as React.FunctionComponent, 
+  legacyFusion // fusion context container
+);
+``` 
+
+_after_
+```ts
+createLegacyRender(
+  manifest, // mutated legacy manifest
+  legacyFusion // fusion context container
+);
+```

--- a/packages/react/legacy-interopt/src/create-legacy-render.tsx
+++ b/packages/react/legacy-interopt/src/create-legacy-render.tsx
@@ -67,11 +67,8 @@ const AppWrapper = (
     );
 };
 
-export const createLegacyRender = (
-    appKey: string,
-    AppComponent: React.FunctionComponent,
-    legacy: IFusionContext
-) => {
+export const createLegacyRender = (manifest: AppManifest, legacy: IFusionContext) => {
+    const { key: appKey, AppComponent, context: contextConfig } = manifest;
     const basename = `/apps/${appKey}`;
     const history = createBrowserHistory({ basename });
     return createComponent<[ContextModule, NavigationModule]>(
@@ -81,8 +78,7 @@ export const createLegacyRender = (
                 <AppComponent />
             </AppWrapper>
         )),
-        (configurator, { env }) => {
-            const { context: contextConfig } = env.manifest as unknown as AppManifest;
+        (configurator) => {
             enableNavigation(configurator, basename);
             if (contextConfig) {
                 enableContext(configurator, async (builder) => {


### PR DESCRIPTION
BREAKING CHANGE: args for `createLegacyRender` has changed, legacy app manifest required!

## Why
mutation of manifest is no longer pushed to framework, only to legacy fusion context container.
`createLegacyRender` depended on `manifest.context` for emulating the context module (which is not there 🤯)

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
