### PR TITLE
Revert "Update release.yml"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           createGithubReleases: true
           setupGitUser: false
           version: yarn changeset:version
+          publish: yarn changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Reverts equinor/fusion-framework#937

the workflow need publish to publish, no automatic built in release

inspect why yarn run path is incorrect when releasing