### PR TITLE
build: fix missing references

### DIFF
--- a/.changeset/eight-poems-mate.md
+++ b/.changeset/eight-poems-mate.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-react-components-bookmark': patch
+---
+
+_refactor: only added missing deps for stand alone compile_

--- a/packages/react/components/bookmark/package.json
+++ b/packages/react/components/bookmark/package.json
@@ -24,6 +24,7 @@
     },
     "dependencies": {
         "@equinor/eds-utils": "^0.7.0",
+        "@equinor/fusion-framework-react": "^5.2.2",
         "@equinor/fusion-framework-react-module-bookmark": "^2.0.12"
     },
     "devDependencies": {
@@ -33,9 +34,10 @@
         "@equinor/eds-core-react": "^0.30.0",
         "@equinor/eds-icons": "^0.19.1",
         "@equinor/eds-tokens": "^0.9.0",
+        "@equinor/fusion-framework-module-app": "^5.2.1",
+        "@equinor/fusion-framework-module-event": "^4.0.2",
         "@types/react": "^17.0.11",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2",
         "styled-components": "^5.3.9",
         "typescript": "^5.1.3"
     },
@@ -51,9 +53,6 @@
     },
     "peerDependenciesMeta": {
         "@types/react": {
-            "optional": true
-        },
-        "react-dom": {
             "optional": true
         }
     }

--- a/packages/react/components/bookmark/src/components/BookmarkProvider.tsx
+++ b/packages/react/components/bookmark/src/components/BookmarkProvider.tsx
@@ -1,5 +1,5 @@
 import { Snackbar } from '@equinor/eds-core-react';
-import { FrameworkEvent, FrameworkEventInit } from '@equinor/fusion-framework-module-event';
+import type { FrameworkEvent, FrameworkEventInit } from '@equinor/fusion-framework-module-event';
 import { useFramework } from '@equinor/fusion-framework-react';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { CreateBookmarkModal } from './create-bookmark';

--- a/packages/react/components/bookmark/src/components/create-bookmark/CreateBookmark.tsx
+++ b/packages/react/components/bookmark/src/components/create-bookmark/CreateBookmark.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Button, Checkbox, Dialog, Input, Label, TextField } from '@equinor/eds-core-react';
-import { AppModule } from '@equinor/fusion-framework-module-app';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
 import { useFramework } from '@equinor/fusion-framework-react';
 import { useBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import { ChangeEvent, useState } from 'react';

--- a/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmark.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmark.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { Button, Checkbox, Dialog, Input, Label, TextField } from '@equinor/eds-core-react';
-import { AppModule } from '@equinor/fusion-framework-module-app';
-import { PatchBookmark } from '@equinor/fusion-framework-module-bookmark';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+// TODO - export from `@equinor/fusion-framework-react-module-bookmark`
+import type { PatchBookmark } from '@equinor/fusion-framework-module-bookmark';
 import { useFramework } from '@equinor/fusion-framework-react';
 import { useBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import { ChangeEvent, useEffect, useState } from 'react';

--- a/packages/react/components/bookmark/src/components/sectionList/SectionList.tsx
+++ b/packages/react/components/bookmark/src/components/sectionList/SectionList.tsx
@@ -3,7 +3,8 @@ import { useBookmarkGrouping } from '../../hooks';
 import { Row } from '../row/Row';
 import { Section } from '../section/Section';
 import { SharedIcon } from '../shared/SharedIcon';
-import { Bookmark } from '@equinor/fusion-framework-module-bookmark';
+// TODO - export from `@equinor/fusion-framework-react-module-bookmark`
+import type { Bookmark } from '@equinor/fusion-framework-module-bookmark';
 import { useBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import { useCurrentUser } from '@equinor/fusion-framework-react/hooks';
 import { useCallback, useEffect, useState } from 'react';

--- a/packages/react/components/bookmark/tsconfig.json
+++ b/packages/react/components/bookmark/tsconfig.json
@@ -7,7 +7,12 @@
     "baseUrl": "src",
   },
   "references": [
-
+    {
+      "path": "../../framework"
+    },
+    {
+      "path": "../../modules/bookmark"
+    }
   ],
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Why
build fails since `@equinor/fusion-framework-react-components-bookmark` depends on other framework modules to compile

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
