### PR TITLE
create hook which return ContextProvider for scoped app 

### DIFF
--- a/.changeset/gorgeous-buckets-draw.md
+++ b/.changeset/gorgeous-buckets-draw.md
@@ -1,0 +1,13 @@
+---
+'@equinor/fusion-framework-react-app': patch
+---
+
+create a hook which returns the current `ContextProvider`
+
+example
+```ts
+import { useContextProvider } from '@equinor/fusion-framework-react-app/context';
+const App = () => {
+  const contextProvider = useContextProvider();
+}
+```

--- a/packages/react/app/src/context/index.ts
+++ b/packages/react/app/src/context/index.ts
@@ -1,5 +1,6 @@
 export * from '@equinor/fusion-framework-react-module-context';
 
+export { useContextProvider } from './useContextProvider';
 export { useCurrentContext } from './useCurrentContext';
 
 export { useFrameworkCurrentContext } from '../framework/useFrameworkCurrentContext';

--- a/packages/react/app/src/context/useContextProvider.ts
+++ b/packages/react/app/src/context/useContextProvider.ts
@@ -1,0 +1,6 @@
+import { type ContextModule } from '@equinor/fusion-framework-react-module-context';
+import { useAppModule } from '../useAppModule';
+
+export const useContextProvider = () => useAppModule<ContextModule>('context');
+
+export default useContextProvider;

--- a/packages/react/app/src/context/useCurrentContext.ts
+++ b/packages/react/app/src/context/useCurrentContext.ts
@@ -1,6 +1,6 @@
 import { useCurrentContext as _useCurrentContext } from '@equinor/fusion-framework-react-module-context';
-import { useAppModule } from '../useAppModule';
+import useContextProvider from './useContextProvider';
 
-export const useCurrentContext = () => _useCurrentContext(useAppModule('context'));
+export const useCurrentContext = () => _useCurrentContext(useContextProvider());
 
 export default useCurrentContext;


### PR DESCRIPTION
## Why
convenience hook for `useAppModule('context')`
created for @thomasFjorstad 

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
