### PR TITLE
fix(navigation): correct import of module version

### DIFF
--- a/packages/modules/navigation/src/module.ts
+++ b/packages/modules/navigation/src/module.ts
@@ -10,7 +10,7 @@ import { type INavigationConfigurator, NavigationConfigurator } from './configur
 import { createHistory } from './createHistory';
 import { type INavigationProvider, NavigationProvider } from './lib';
 
-import { version } from './version';
+import version from './version';
 
 export const moduleKey = 'navigation';
 


### PR DESCRIPTION
## Why
Corrects import of the Navigation module's version number used in semantic versioning.

The current import of version number imported an named export but there is only an default export in the version file.

No braking changes in this patch fix.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
