### PR TITLE
fix: corrected the font URL

### DIFF
--- a/vue-press/src/.vuepress/config.ts
+++ b/vue-press/src/.vuepress/config.ts
@@ -15,7 +15,7 @@ export default defineUserConfig({
   title: [name, version].join('@'),
   description,
   head: [
-    ["link", { href:"https://eds-static.equinor.com/font/equinor-font.css", rel:"stylesheet"}]
+    ["link", { href:"https://cdn.eds.equinor.com/font/equinor-font.css", rel:"stylesheet"}]
   ],
   theme,
   plugins: [


### PR DESCRIPTION
## Why
The current font URL in the vite config is outdated. The correct one is now: 
https://cdn.eds.equinor.com/font/equinor-font.css

closes:
~https://github.com/equinor/fusion-framework/issues/980~

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

EDIT: As pointed out by @eikeland, this only updates the vuepress documentation site. I'll let it stand as I guess that's useful as well :)
