### PR TITLE
fusion-framework-cli: updating  fusion-react-styles to 0.5.6

### DIFF
--- a/.changeset/twelve-buttons-double.md
+++ b/.changeset/twelve-buttons-double.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+# Updating @equinor/fusion-react-styles
+
+Updating dependency @equinor/fusion-react-styles to version 0.5.6.
+
+This ads the correct equinor-font cdn link to the themeprovider.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
         "@equinor/fusion-react-person": "^0.2.1",
         "@equinor/fusion-react-progress-indicator": "^0.1.6",
         "@equinor/fusion-react-side-sheet": "0.1.0",
-        "@equinor/fusion-react-styles": "^0.5.5",
+        "@equinor/fusion-react-styles": "^0.5.6",
         "@material-ui/styles": "^4.11.5",
         "@types/express": "^4.17.17",
         "@types/react": "^18.0.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,7 +1110,7 @@
     "@material-ui/styles" "^4.11.4"
     clsx "^1.1.1"
 
-"@equinor/fusion-react-styles@^0.5.5", "@equinor/fusion-react-styles@^0.5.6":
+"@equinor/fusion-react-styles@^0.5.6":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@equinor/fusion-react-styles/-/fusion-react-styles-0.5.6.tgz#fd5322fa4345efdca154c20a37a64c1a14dfe40d"
   integrity sha512-gxM8q6MLRxEZ3WA+h/gmBfCmpXGztC2tU9a4quTRKvmAX9bgKCpOaVdx4TzVMq3fyalO2p+3C4ju5j4RT4IapA==


### PR DESCRIPTION
## Why
Updating fusion-framework-cli dependency @equinor/fusion-react-styles to 0.5.6
To use the correct cdn link to the Equinor font.

Closes #980 


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
