### PR TITLE
Fix/legacy interopt/feature logger

### DIFF
--- a/.changeset/forty-cherries-destroy.md
+++ b/.changeset/forty-cherries-destroy.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-legacy-interopt': patch
+---
+
+# Featurelogger issue
+
+Fixes FeatureLogger in LegacyAppContainer logging null as appKey.

--- a/packages/react/legacy-interopt/src/LegacyAppContainer.ts
+++ b/packages/react/legacy-interopt/src/LegacyAppContainer.ts
@@ -242,12 +242,14 @@ export class LegacyAppContainer extends EventEmitter<AppContainerEvents> {
                 }
 
                 /** log entry to Fusion feature logger */
-                featureLogger.setCurrentApp(currentManifest?.key || null);
+                // CHANGE: switched from currentManifest to current since
+                // currentManifest only loads when app is visited twice
+                featureLogger.setCurrentApp(current?.appKey || null);
                 featureLogger.log('App selected', '0.0.1', {
-                    selectedApp: currentManifest
+                    selectedApp: current
                         ? {
-                              key: currentManifest.key,
-                              name: currentManifest.name,
+                              key: current.appKey,
+                              name: current.manifest?.name ?? null,
                           }
                         : null,
                     previousApps: Object.keys(previousApps.state).map((key) => ({
@@ -262,6 +264,7 @@ export class LegacyAppContainer extends EventEmitter<AppContainerEvents> {
                 }
 
                 /** log change in AI */
+                // TODO: will this logg property name?? manifest is of type {AppComponent, Render, key}
                 telemetryLogger.trackEvent({
                     name: 'App selected',
                     properties: {


### PR DESCRIPTION
## Why
The LegacyAppContainer's implementation of FeatureLogger was not logging the current appKey.
Changing `currentManifest.key` to `current.appKey` fixed the issue.

Closes #1016

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
