### PR TITLE
Feat(react-module-event): add event provider

### DIFF
--- a/.changeset/famous-sheep-peel.md
+++ b/.changeset/famous-sheep-peel.md
@@ -1,0 +1,43 @@
+---
+'@equinor/fusion-framework-react-module-event': minor
+---
+
+Expose the `IEventModuleProvider`
+
+Add functionality for controlling which event provider which is used within the event hooks 
+
+- create context for controlling the `IEventModuleProvider`
+- create a hook for using `IEventModuleProvider`, 
+  - uses the `IEventModuleProvider` from the `EventProvider` context
+  - _fallbacks to event module from current module context_
+- update the `useEventHandler` to use `useEventProvider`
+  - previously resolving `IEventModuleProvider` from module context
+- create a hook `useEventModuleProvider` which resolves `IEventModuleProvider` from module context
+
+
+example app:
+```tsx
+import { EventProvider } = from '@equinor/fusion-framework-react-module-event';
+import { useFramework } = from '@equinor/fusion-framework-react-app/framework';
+const Content = () => {
+  const framework = useFramework().modules.event;
+  return (
+    <EventProvider value={framework.modules.event}>
+      <InnerContent>
+    <EventProvider>
+  );
+};
+```
+```tsx
+const InnerContent = () => {
+  const eventProvider = useEventProvider();
+  useEventHandler('some_event', useCallback((event) => {
+    console.log('FRAMEWORK_EVENT', event.detail);
+  }, [eventProvider]));
+
+  const appEventProvider = useEventModuleProvider();
+  useEventHandler('some_event', useCallback((event) => {
+    console.log('APP_EVENT', event.detail);
+  }, [appEventProvider]));
+}
+```

--- a/packages/react/modules/event/src/EventProvider.tsx
+++ b/packages/react/modules/event/src/EventProvider.tsx
@@ -1,0 +1,29 @@
+import {
+    EventModule,
+    IEventModuleProvider,
+    eventModuleKey,
+} from '@equinor/fusion-framework-module-event';
+import { useModule } from '@equinor/fusion-framework-react-module';
+import { createContext, useContext } from 'react';
+
+export const context = createContext<IEventModuleProvider>(
+    undefined as unknown as IEventModuleProvider
+);
+
+const useModulesEventProvider = (): IEventModuleProvider | undefined =>
+    useModule<EventModule>(eventModuleKey);
+
+export const { Consumer: EventConsumer, Provider: EventProvider } = context;
+
+export const useEventProvider = (): IEventModuleProvider => {
+    const provider = useContext(context);
+    const moduleProvider = useModulesEventProvider();
+    if (provider) {
+        return provider;
+    } else if (moduleProvider) {
+        return moduleProvider;
+    }
+    throw Error('no event provider in context, nor configured within module scope');
+};
+
+export default EventProvider;

--- a/packages/react/modules/event/src/eventContext.ts
+++ b/packages/react/modules/event/src/eventContext.ts
@@ -1,0 +1,8 @@
+import { IEventModuleProvider } from '@equinor/fusion-framework-module-event';
+import { createContext } from 'react';
+
+export const eventContext = createContext<IEventModuleProvider>(
+    undefined as unknown as IEventModuleProvider
+);
+
+export const { Consumer: EventConsumer, Provider: EventProvider } = eventContext;

--- a/packages/react/modules/event/src/index.ts
+++ b/packages/react/modules/event/src/index.ts
@@ -1,3 +1,7 @@
 export * from '@equinor/fusion-framework-module-event';
 
+export { EventConsumer, EventProvider } from './eventContext';
+
+export { useEventProvider } from './useEventProvider';
+export { useModulesEventProvider } from './useModulesEventProvider';
 export { useEventHandler } from './useEventHandler';

--- a/packages/react/modules/event/src/useEventHandler.ts
+++ b/packages/react/modules/event/src/useEventHandler.ts
@@ -1,13 +1,13 @@
-import { useModule } from '@equinor/fusion-framework-react-module';
+import { useEffect } from 'react';
+
 import {
-    eventModuleKey,
     FrameworkEventMap,
     FrameworkEventHandler,
     FrameworkEvent,
     IFrameworkEvent,
-    EventModule,
 } from '@equinor/fusion-framework-module-event';
-import { useEffect } from 'react';
+
+import { useEventProvider } from './useEventProvider';
 
 /**
  * hook for subscribing to framework events
@@ -32,8 +32,8 @@ export const useEventHandler: useEventHandler = <
         ? FrameworkEventHandler<FrameworkEventMap[TKey]>
         : FrameworkEventHandler<TType>
 ): void => {
-    const module = useModule<EventModule>(eventModuleKey);
-    useEffect(() => module.addEventListener(name, cb), [module, name, cb]);
+    const provider = useEventProvider();
+    useEffect(() => provider.addEventListener(name, cb), [provider, name, cb]);
 };
 
 export default useEventHandler;

--- a/packages/react/modules/event/src/useEventProvider.ts
+++ b/packages/react/modules/event/src/useEventProvider.ts
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+
+import { IEventModuleProvider } from '@equinor/fusion-framework-module-event';
+
+import { eventContext } from './eventContext';
+import { useModulesEventProvider } from 'useModulesEventProvider';
+
+/**
+ * Hook for using {@link IEventModuleProvider} from context
+ * If no context provider is provided this hook will try to use the modules event provider
+ */
+export const useEventProvider = (): IEventModuleProvider => {
+    const provider = useContext(eventContext);
+    const moduleProvider = useModulesEventProvider();
+    if (provider) {
+        return provider;
+    } else if (moduleProvider) {
+        return moduleProvider;
+    }
+    throw Error('no event provider in context, nor configured within module scope');
+};

--- a/packages/react/modules/event/src/useModulesEventProvider.ts
+++ b/packages/react/modules/event/src/useModulesEventProvider.ts
@@ -1,0 +1,13 @@
+import { useModule } from '@equinor/fusion-framework-react-module';
+
+import {
+    EventModule,
+    IEventModuleProvider,
+    eventModuleKey,
+} from '@equinor/fusion-framework-module-event';
+
+/**
+ * Hook for using the event module from the closes ModuleProvider
+ */
+export const useModulesEventProvider = (): IEventModuleProvider | undefined =>
+    useModule<EventModule>(eventModuleKey);

--- a/vue-press/src/modules/event/README.md
+++ b/vue-press/src/modules/event/README.md
@@ -167,14 +167,58 @@ config.event.onBubble = (e) => {
 
 ## React
 
-<ModuleBadge module="react-module-event" />
+<ModuleBadge module="/react/modules/event" package="@equinor/fusion-framework-react-module-event"/>
+
+### EventProvider
+
+example app:
+```tsx
+import { EventProvider } = from '@equinor/fusion-framework-react-module-event';
+import { useFramework } = from '@equinor/fusion-framework-react-app/framework';
+const Content = () => {
+  const framework = useFramework().modules.event;
+  return (
+    <EventProvider value={framework.modules.event}>
+      <InnerContent>
+    <EventProvider>
+  );
+};
+```
+```tsx
+const InnerContent = () => {
+  const eventProvider = useEventProvider();
+  useEventHandler('some_event', useCallback((event) => {
+    console.log('FRAMEWORK_EVENT', event.detail);
+  }, [eventProvider]));
+
+  const appEventProvider = useEventModuleProvider();
+  useEventHandler('some_event', useCallback((event) => {
+    console.log('APP_EVENT', event.detail);
+  }, [appEventProvider]));
+}
+```
+
+### Hooks
+
+#### useEventProvider
+
+use `IEventModuleProvider` from current context see [EventProvider](#EventProvider)
+```ts
+import { useEventHandler } from '@equinor/fusion-framework-react-module-event';
+```
+
+#### useEventModuleProvider
+
+use `IEventModuleProvider` from closes module provider
 
 ```ts
-/** 
- * default included in the app module,
- * alternative directly from @equinor/fusion-framework-react-module-event
- */
-import { useEventHandler } from '@equinor/fusion-framework-react-app/event';
+import { useEventModuleProvider } from '@equinor/fusion-framework-react-module-event';
+```
+
+
+#### useEventHandler
+```ts
+import { useEventHandler } from '@equinor/fusion-framework-react-module-event';
 
 const MyHook = () => {
   useEventHandler(


### PR DESCRIPTION
## Why
Add functionality for controlling which event provider which is used within the event hooks 
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
