### PR TITLE
feat(app): allow configuration of service discovery http client

### DIFF
--- a/.changeset/long-walls-vanish.md
+++ b/.changeset/long-walls-vanish.md
@@ -1,0 +1,26 @@
+---
+'@equinor/fusion-framework-app': minor
+---
+
+Allow options for `config.useFrameworkServiceClient`
+
+Add optional configuration when using a predefined client from service discovery
+
+**Changed interface**
+```ts
+type useFrameworkServiceClient = (
+  service_name: string,
+  /** new, allows customize registration of http client from service discovery */
+  options?: Omit<HttpClientOptions<any>, 'baseUri' | 'defaultScopes'>,
+)
+```
+
+__example__
+```ts
+config.useFrameworkServiceClient('some_fusion_service', {
+  onCreate(client: IHttpClient) {
+      /** make creation of http client add default request header */
+      client.requestHandler.setHeader('api-version', '2.0');
+  },
+});
+```

--- a/packages/app/src/AppConfigurator.ts
+++ b/packages/app/src/AppConfigurator.ts
@@ -1,13 +1,20 @@
-import { FusionModulesInstance } from '@equinor/fusion-framework';
+import { type FusionModulesInstance } from '@equinor/fusion-framework';
+
 import {
-    AnyModule,
-    IModulesConfigurator,
+    type AnyModule,
+    type IModulesConfigurator,
     ModuleConsoleLogger,
     ModulesConfigurator,
 } from '@equinor/fusion-framework-module';
 
 import event from '@equinor/fusion-framework-module-event';
-import http, { configureHttpClient, configureHttp } from '@equinor/fusion-framework-module-http';
+
+import http, {
+    configureHttpClient,
+    configureHttp,
+    type HttpClientOptions,
+} from '@equinor/fusion-framework-module-http';
+
 import auth, { configureMsal } from '@equinor/fusion-framework-module-msal';
 
 import { AppModules } from './types';
@@ -92,7 +99,11 @@ export class AppConfigurator<
         this.addConfig(configureHttpClient(...args));
     }
 
-    public useFrameworkServiceClient(serviceName: string): void {
+    public useFrameworkServiceClient(
+        serviceName: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options?: Omit<HttpClientOptions<any>, 'baseUri' | 'defaultScopes'>,
+    ): void {
         this.addConfig({
             module: http,
             configure: async (config, ref) => {
@@ -101,6 +112,7 @@ export class AppConfigurator<
                     throw Error(`failed to configure service [${serviceName}]`);
                 }
                 config.configureClient(serviceName, {
+                    ...options,
                     baseUri: service.uri,
                     defaultScopes: service.defaultScopes,
                 });


### PR DESCRIPTION
## Why
- What kind of change does this PR introduce? 
   - allow configuration of service discovery http client config
- What is the current behavior?
  - when using configuration from service discovery, there are no option for altering the configuration
- What is the new behavior?
  - allow providing `HttpClientOptions` when using `AppConfigurator.useFrameworkServiceClient`
  - passes option to `AppConfigurator.configureClient` _(exludes baseUri and defaultScopes)_ 
- Does this PR introduce a breaking change?
  - none 
<!-- Other information? -->

```ts
type useFrameworkServiceClient = (
  service_name: string,
  /** new, allows customize registration of http client from service discovery */
  options?: Omit<HttpClientOptions<any>, 'baseUri' | 'defaultScopes'>,
)
```

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
