### PR TITLE
chore: add clean-up workflow

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,33 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 1000 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cache-prime.yml
+++ b/.github/workflows/cache-prime.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  on-success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [16, 18]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+          cache: 'pnpm'
+      - uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        with:
+          cache-prefix: ${{ runner.os }}-node-${{ matrix.version }}_
+      - run: |
+          pnpm install --frozen-lockfile
+          pnpm build:cli
+          pnpm install --offline --frozen-lockfile
+          pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,25 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-  prime_cache:
-    needs: release
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [16, 18]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.version }}
-          cache: 'pnpm'
-      - uses: dtinth/setup-github-actions-caching-for-turbo@v1
-        with:
-          cache-prefix: ${{ runner.os }}-node-${{ matrix.version }}_
-      - run: |
-          pnpm install --frozen-lockfile
-          pnpm build:cli
-          pnpm install --offline --frozen-lockfile
-          pnpm build
 


### PR DESCRIPTION
## Why
- [x] add clean-up of cache when pr closes
- [x] run prime of cache in own workflow

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
