### PR TITLE
fix(module-http): add accept headers to http client

### DIFF
--- a/.changeset/tough-plums-speak.md
+++ b/.changeset/tough-plums-speak.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-module-http': patch
+---
+
+Append `Accecpt: application/json` to request headers
+
+when using the `json$` or `json` function on the `HttpClient` add `Accecpt: application/json` to the request header

--- a/packages/modules/http/src/lib/client/client.ts
+++ b/packages/modules/http/src/lib/client/client.ts
@@ -92,6 +92,7 @@ export class HttpClient<TRequest extends FetchRequest = FetchRequest, TResponse 
         const body = typeof args?.body === 'object' ? JSON.stringify(args?.body) : args?.body;
         const selector = args?.selector ?? jsonSelector;
         const headers = new Headers(args?.headers);
+        headers.append('Accept', 'application/json');
         headers.append('Content-Type', 'application/json');
         return this.fetch$(path, {
             ...args,


### PR DESCRIPTION
- append `Accept: application/json` to request when using client json calls

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
