### PR TITLE
Fix/cli/remove emotion

### DIFF
--- a/.changeset/clean-sloths-burn.md
+++ b/.changeset/clean-sloths-burn.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-react-components-bookmark': patch
+---
+
+fix typo in styled components

--- a/.changeset/stupid-foxes-live.md
+++ b/.changeset/stupid-foxes-live.md
@@ -1,0 +1,15 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+Remove emotion decencies from CLI
+
+align CLI with EDS and use style components instead of emotion 🥲
+prevent conflict of react types dependent on both emotion and eds
+
+- remove @emotion/*
+- convert emotion to styled-components
+- fix styling of cli
+  - convert main placeholder to grid
+  - remove unnecessary styling from header
+  - set dynamic width of context selector (min 25rem)

--- a/.github/workflows/actions/node-setup/action.yml
+++ b/.github/workflows/actions/node-setup/action.yml
@@ -25,5 +25,5 @@ runs:
 
     - name: install
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install
         

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,8 +41,6 @@
         "vite-tsconfig-paths": "^4.2.0"
     },
     "devDependencies": {
-        "@emotion/css": "^11.10.6",
-        "@emotion/styled": "^11.11.0",
         "@equinor/eds-core-react": "^0.32.4",
         "@equinor/eds-icons": "^0.19.3",
         "@equinor/eds-tokens": "^0.9.2",
@@ -65,7 +63,7 @@
         "@equinor/fusion-react-menu": "^0.1.5",
         "@equinor/fusion-react-person": "^0.2.9",
         "@equinor/fusion-react-progress-indicator": "^0.1.6",
-        "@equinor/fusion-react-side-sheet": "0.1.0",
+        "@equinor/fusion-react-side-sheet": "1.0.1",
         "@equinor/fusion-react-styles": "^0.5.9",
         "@equinor/fusion-wc-person": "^0.4.6",
         "@material-ui/styles": "^4.11.5",
@@ -75,7 +73,7 @@
         "@types/react-dom": "^18.0.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^5.3.4",
+        "react-router-dom": "^6.15.0",
         "rxjs": "^7.8.1",
         "styled-components": "^6.0.7",
         "typescript": "^5.1.3"

--- a/packages/cli/src/dev-portal/AppLoader.tsx
+++ b/packages/cli/src/dev-portal/AppLoader.tsx
@@ -61,13 +61,11 @@ export const AppLoader = (props: { readonly appKey: string }) => {
 
                     /** create a 'private' element for the application */
                     const el = document.createElement('div');
-                    el.style.height = '100%';
                     if (!ref.current) {
                         throw Error('Missing application mounting point');
                     }
 
                     ref.current.appendChild(el);
-                    ref.current.style.height = '100%';
 
                     /** extract render callback function from javascript module */
                     const render = script.renderApp ?? script.default;
@@ -111,7 +109,11 @@ export const AppLoader = (props: { readonly appKey: string }) => {
         );
     }
 
-    return <section ref={ref}>{loading && <EquinorLoader text="Loading Application" />}</section>;
+    return (
+        <section id="application-content" ref={ref}>
+            {loading && <EquinorLoader text="Loading Application" />}
+        </section>
+    );
 };
 
 export default AppLoader;

--- a/packages/cli/src/dev-portal/ContextSelector.tsx
+++ b/packages/cli/src/dev-portal/ContextSelector.tsx
@@ -20,6 +20,14 @@ import {
 } from '@equinor/fusion-react-context-selector';
 
 import type { AppModulesInstance } from '@equinor/fusion-framework-app';
+import { styled } from 'styled-components';
+
+const Styled = {
+    ContextSelectorWrapper: styled.div`
+        min-width: 25rem;
+        width: fit-content;
+    `,
+};
 
 /**
  * Map context query result to ContextSelectorResult.
@@ -179,19 +187,21 @@ export const ContextSelector = () => {
     const [resolver, setContext, currentContext, clearContext] = useQueryContext();
     return (
         <ContextProvider resolver={resolver}>
-            <ContextSearch
-                id="context-selector-header"
-                placeholder="Search for context"
-                initialText="Start typing to search"
-                dropdownHeight="300px"
-                variant="header"
-                onSelect={setContext}
-                autofocus={true}
-                onClearContext={clearContext}
-                previewItem={currentContext ?? null}
-                value={currentContext?.title}
-                selectedId={currentContext?.title}
-            />
+            <Styled.ContextSelectorWrapper>
+                <ContextSearch
+                    id="context-selector-header"
+                    placeholder="Search for context"
+                    initialText="Start typing to search"
+                    dropdownHeight="300px"
+                    variant="header"
+                    onSelect={setContext}
+                    autofocus={true}
+                    onClearContext={clearContext}
+                    previewItem={currentContext ?? null}
+                    value={currentContext?.title}
+                    selectedId={currentContext?.title}
+                />
+            </Styled.ContextSelectorWrapper>
         </ContextProvider>
     );
 };

--- a/packages/cli/src/dev-portal/ErrorViewer.tsx
+++ b/packages/cli/src/dev-portal/ErrorViewer.tsx
@@ -1,17 +1,12 @@
+import { Typography } from '@equinor/eds-core-react';
+
 export const ErrorViewer = ({ error }: { readonly error: Error }) => {
     return (
         <>
             <div style={{ marginTop: 20, border: '1px solid' }}>
-                <h4
-                    style={{
-                        backgroundColor: 'rgb(153, 0, 37)',
-                        color: 'white',
-                        padding: 10,
-                        margin: 0,
-                    }}
-                >
+                <Typography variant="h4" color="warning">
                     {error.message}
-                </h4>
+                </Typography>
                 <section style={{ padding: 10 }}>{error.stack && <pre>{error.stack}</pre>}</section>
             </div>
             {error.cause && <ErrorViewer error={error.cause as Error} />}

--- a/packages/cli/src/dev-portal/FusionLogo.tsx
+++ b/packages/cli/src/dev-portal/FusionLogo.tsx
@@ -1,17 +1,9 @@
-import { FC } from 'react';
-
-type FusionLogoProps = {
+type FusionLogoProps = Omit<React.SVGProps<SVGSVGElement>, 'viewBox'> & {
     readonly scale?: number;
 };
 
-export const FusionLogo: FC<FusionLogoProps> = ({ scale = 1 }) => (
-    <svg
-        width="50"
-        height="35"
-        viewBox="0 0 50 35"
-        fill="none"
-        style={{ transform: `scale(${scale})` }}
-    >
+export const FusionLogo = (props: FusionLogoProps) => (
+    <svg viewBox="0 0 50 35" style={{ height: '1em', ...props.style }}>
         <path
             d="M0 2V23.1776L7.05405 16.1235V7.05405H16.1235L23.1776 0H2C0.895431 0 0 0.89543 0 2Z"
             transform="translate(50 17.5) scale(0.92727 1.06779) rotate(135)"

--- a/packages/cli/src/dev-portal/Header.tsx
+++ b/packages/cli/src/dev-portal/Header.tsx
@@ -1,51 +1,24 @@
 import { useState, useRef } from 'react';
-import { ThemeProvider, theme } from '@equinor/fusion-react-styles';
 import { ContextSelector } from './ContextSelector';
 import { FusionLogo } from './FusionLogo';
 
 /* typescript reference for makeStyles */
 import '@material-ui/styles';
 import { BookmarkSideSheet } from './BookMarkSideSheet';
-import { Button, Icon, TopBar, Typography } from '@equinor/eds-core-react';
+import { Button, Icon, TopBar } from '@equinor/eds-core-react';
 import { BookmarkProvider } from '@equinor/fusion-framework-react-components-bookmark';
 import { add, menu, tag } from '@equinor/eds-icons';
-import styled from '@emotion/styled';
-import { css } from '@emotion/css';
+import { styled } from 'styled-components';
 
 Icon.add({ menu, add, tag });
 
-const StyledHeader = styled(TopBar.Header)`
-    width: max-content;
-`;
-
-const StyledTopBar = styled(TopBar)`
-    padding: 0px;
-    height: 48px;
-`;
-
-const StyledCustomContent = styled(TopBar.CustomContent)`
-    display: flex;
-    align-items: center;
-`;
-
-const StyledActionsWrapper = styled(TopBar.Actions)`
-    padding-right: 0.5rem;
-`;
-const StyledTitle = styled(Typography)`
-    padding-left: 0.5rem;
-    white-space: nowrap;
-`;
-
-const styles = {
-    logoWrapper: css`
+const Styled = {
+    Title: styled.div`
         display: flex;
-        flex-direction: row;
         align-items: center;
-    `,
-    contextSelector: css`
-        width: 100%;
-        max-width: 420px;
-        margin-left: 1em;
+        gap: 0.75rem;
+        font-size: 1rem;
+        font-weight: 500;
     `,
 };
 
@@ -60,33 +33,31 @@ export const Header = () => {
     }
 
     return (
-        <ThemeProvider theme={theme}>
-            <StyledTopBar>
-                <StyledHeader>
+        <>
+            <TopBar id="cli-top-bar" sticky={false} style={{ padding: 0, height: 48 }}>
+                <TopBar.Header>
                     <Button ref={buttonRef} onClick={() => setOpen(!open)} variant="ghost_icon">
                         <Icon name="menu" />
                     </Button>
-                    <div className={styles.logoWrapper}>
-                        <FusionLogo scale={0.7} />
-                        <StyledTitle variant="h6">Fusion CLI</StyledTitle>
-                    </div>
-                </StyledHeader>
-                <StyledCustomContent>
-                    <div className={styles.contextSelector}>
-                        <ContextSelector />
-                    </div>
-                </StyledCustomContent>
-
-                <StyledActionsWrapper>
+                    <Styled.Title>
+                        <FusionLogo />
+                        <span>Fusion CLI</span>
+                    </Styled.Title>
+                </TopBar.Header>
+                <TopBar.CustomContent>
+                    <ContextSelector />
+                </TopBar.CustomContent>
+                {/* since buttons are 40px but have 48px click bounds */}
+                <TopBar.Actions style={{ minWidth: 48, minHeight: 48 }}>
                     <Button onClick={toggleBookmark} variant="ghost_icon">
                         <Icon name="tag" />
                     </Button>
-                </StyledActionsWrapper>
-            </StyledTopBar>
+                </TopBar.Actions>
+            </TopBar>
             <BookmarkProvider>
                 <BookmarkSideSheet isOpen={isBookmarkOpen} onClose={toggleBookmark} />
             </BookmarkProvider>
-        </ThemeProvider>
+        </>
     );
 };
 

--- a/packages/cli/src/dev-portal/Router.tsx
+++ b/packages/cli/src/dev-portal/Router.tsx
@@ -9,6 +9,17 @@ import { usePersonResolver } from './usePersonResolver';
 import { useFramework } from '@equinor/fusion-framework-react';
 import { NavigationModule } from '@equinor/fusion-framework-module-navigation';
 import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const Styled = {
+    ContentContainer: styled.div`
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: 48px 1fr;
+        height: 100vh;
+        overflow: hidden;
+    `,
+};
 
 const Root = () => {
     const personResolver = usePersonResolver();
@@ -16,12 +27,12 @@ const Root = () => {
     useBookmarkNavigate({ resolveAppPath: (appKey: string) => `/apps/${appKey}` });
 
     return (
-        <div style={{ fontFamily: 'Equinor', height: '100%' }}>
-            <PersonProvider resolve={personResolver}>
+        <PersonProvider resolve={personResolver}>
+            <Styled.ContentContainer>
                 <Header />
                 <Outlet />
-            </PersonProvider>
-        </div>
+            </Styled.ContentContainer>
+        </PersonProvider>
     );
 };
 
@@ -39,14 +50,6 @@ const routes = [
             {
                 path: 'apps/:appKey/*',
                 element: <AppRoute />,
-            },
-            {
-                path: 'apps/test',
-                element: <p>Bookmark Test Route ok</p>,
-            },
-            {
-                path: 'test',
-                element: <p>ok</p>,
             },
         ],
     },

--- a/packages/cli/src/dev-portal/index.html
+++ b/packages/cli/src/dev-portal/index.html
@@ -19,9 +19,21 @@
       }
     };
   </script>
+  <style>
+    html,
+    body {
+      min-height: 100vh;
+      padding: 0;
+      margin: 0;
+    }
 
-<body style="height: 100vh;">
-  <div id="root" style="height: 100%;"></div>
+    #application-content {
+      overflow: auto;
+    }
+  </style>
+
+<body>
+  <div id="root"></div>
   <script type="module" src="/main.tsx"></script>
 </body>
 

--- a/packages/cli/src/dev-portal/main.tsx
+++ b/packages/cli/src/dev-portal/main.tsx
@@ -7,9 +7,7 @@ import { EquinorLoader } from './EquinorLoader';
 import { configure } from './config';
 import { Router } from './Router';
 
-document.body.style.height = '100vh';
 const target = document.getElementById('root') as HTMLElement;
-target.style.height = '100%';
 
 ReactDOM.createRoot(target).render(
     <React.StrictMode>

--- a/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmark.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmark.tsx
@@ -24,7 +24,7 @@ const Styled = {
         gap: 1rem;
     `,
     Actions: styled.div`
-        display: 'flex';
+        display: flex;
         gap: 0.2em;
     `,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      styled-components:
+        specifier: ^6.0.7
+        version: 6.0.7(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       odata-query:
         specifier: ^7.0.4
@@ -415,12 +418,6 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(typescript@5.1.6)(vite@4.4.9)
     devDependencies:
-      '@emotion/css':
-        specifier: ^11.10.6
-        version: 11.10.6
-      '@emotion/styled':
-        specifier: ^11.11.0
-        version: 11.11.0(@emotion/react@11.10.6)(@types/react@18.2.20)(react@18.2.0)
       '@equinor/fusion-framework':
         specifier: workspace:^
         version: link:../framework
@@ -476,8 +473,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6(react@18.2.0)
       '@equinor/fusion-react-side-sheet':
-        specifier: 0.1.0
-        version: 0.1.0(@emotion/css@11.10.6)(@emotion/styled@11.11.0)(@equinor/eds-core-react@0.32.4)(@equinor/eds-icons@0.19.3)(@equinor/eds-tokens@0.9.2)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7)
+        specifier: 1.0.1
+        version: 1.0.1(@equinor/eds-core-react@0.32.4)(@equinor/eds-icons@0.19.3)(@equinor/eds-tokens@0.9.2)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7)
       '@equinor/fusion-react-styles':
         specifier: ^0.5.9
         version: 0.5.9(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)
@@ -506,8 +503,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: ^5.3.4
-        version: 5.3.4(react@18.2.0)
+        specifier: ^6.15.0
+        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -2991,48 +2988,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@emotion/babel-plugin@11.11.0:
-    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
-    dependencies:
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/runtime': 7.22.10
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/serialize': 1.1.2
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.2.0
-    dev: true
-
-  /@emotion/cache@11.11.0:
-    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
-    dependencies:
-      '@emotion/memoize': 0.8.1
-      '@emotion/sheet': 1.2.2
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
-      stylis: 4.2.0
-    dev: true
-
-  /@emotion/css@11.10.6:
-    resolution: {integrity: sha512-88Sr+3heKAKpj9PCqq5A1hAmAkoSIvwEq1O2TwDij7fUtsJpdkV4jMTISSTouFeRvsGvXIpuSuDQ4C1YdfNGXw==}
-    dependencies:
-      '@emotion/babel-plugin': 11.11.0
-      '@emotion/cache': 11.11.0
-      '@emotion/serialize': 1.1.2
-      '@emotion/sheet': 1.2.2
-      '@emotion/utils': 1.2.1
-    dev: true
-
   /@emotion/hash@0.8.0:
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
-
-  /@emotion/hash@0.9.1:
-    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
-    dev: true
 
   /@emotion/is-prop-valid@1.2.1:
     resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
@@ -3042,80 +2999,8 @@ packages:
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
 
-  /@emotion/react@11.10.6(@types/react@18.2.20)(react@18.2.0):
-    resolution: {integrity: sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.22.10
-      '@emotion/babel-plugin': 11.11.0
-      '@emotion/cache': 11.11.0
-      '@emotion/serialize': 1.1.2
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.2.20
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: true
-
-  /@emotion/serialize@1.1.2:
-    resolution: {integrity: sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==}
-    dependencies:
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/unitless': 0.8.1
-      '@emotion/utils': 1.2.1
-      csstype: 3.1.2
-    dev: true
-
-  /@emotion/sheet@1.2.2:
-    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
-    dev: true
-
-  /@emotion/styled@11.11.0(@emotion/react@11.10.6)(@types/react@18.2.20)(react@18.2.0):
-    resolution: {integrity: sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==}
-    peerDependencies:
-      '@emotion/react': ^11.0.0-rc.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.22.10
-      '@emotion/babel-plugin': 11.11.0
-      '@emotion/is-prop-valid': 1.2.1
-      '@emotion/react': 11.10.6(@types/react@18.2.20)(react@18.2.0)
-      '@emotion/serialize': 1.1.2
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
-      '@emotion/utils': 1.2.1
-      '@types/react': 18.2.20
-      react: 18.2.0
-    dev: true
-
   /@emotion/unitless@0.8.1:
     resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
-
-  /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0):
-    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.2.0
-    dev: true
-
-  /@emotion/utils@1.2.1:
-    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
-    dev: true
-
-  /@emotion/weak-memoize@0.3.1:
-    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
-    dev: true
 
   /@equinor/eds-core-react@0.32.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7):
     resolution: {integrity: sha512-UTUE8TImQkVxl3srR0dOkPHTkLtmqsp+lcZz509sl3WRaGFlBseBiPgWrCTdgfT4EtAKRimmXhqsrAHllhGgJA==}
@@ -3399,11 +3284,9 @@ packages:
       - react
     dev: true
 
-  /@equinor/fusion-react-side-sheet@0.1.0(@emotion/css@11.10.6)(@emotion/styled@11.11.0)(@equinor/eds-core-react@0.32.4)(@equinor/eds-icons@0.19.3)(@equinor/eds-tokens@0.9.2)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7):
-    resolution: {integrity: sha512-xfgoTqDSJ3eRSUnR3WZpaIYum+kqOT42zR01VjhUeNvnQZtudkWNoPqTv9nNgwSUd+MTR0vglcnGzlp+VB0BGg==}
+  /@equinor/fusion-react-side-sheet@1.0.1(@equinor/eds-core-react@0.32.4)(@equinor/eds-icons@0.19.3)(@equinor/eds-tokens@0.9.2)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7):
+    resolution: {integrity: sha512-XKl0yrPgodBtooVlY48U+0jczEENaE08tfycDnw4Jo1uSL8lGaOge4xlDYrxiayF3j2SB6Sz9lWU9HYbUr2SgQ==}
     peerDependencies:
-      '@emotion/css': ^11.10.6
-      '@emotion/styled': ^11.10.6
       '@equinor/eds-core-react': ^0.30.0
       '@equinor/eds-icons': ^0.19.1
       '@equinor/eds-tokens': ^0.9.0
@@ -3417,8 +3300,6 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@emotion/css': 11.10.6
-      '@emotion/styled': 11.11.0(@emotion/react@11.10.6)(@types/react@18.2.20)(react@18.2.0)
       '@equinor/eds-core-react': 0.32.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.0.7)
       '@equinor/eds-icons': 0.19.3
       '@equinor/eds-tokens': 0.9.2
@@ -5656,10 +5537,6 @@ packages:
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
-  /@types/parse-json@4.0.0:
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-    dev: true
-
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
@@ -6473,15 +6350,6 @@ packages:
       '@types/babel__core': 7.20.1
       '@types/babel__traverse': 7.20.1
 
-  /babel-plugin-macros@3.1.0:
-    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
-    engines: {node: '>=10', npm: '>=6'}
-    dependencies:
-      '@babel/runtime': 7.22.10
-      cosmiconfig: 7.1.0
-      resolve: 1.22.4
-    dev: true
-
   /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.10):
     resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
     peerDependencies:
@@ -6978,17 +6846,6 @@ packages:
       cosmiconfig: 8.2.0
       ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.1.6)
       typescript: 5.1.6
-    dev: true
-
-  /cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.3.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
     dev: true
 
   /cosmiconfig@8.2.0:
@@ -8078,10 +7935,6 @@ packages:
     resolution: {integrity: sha512-yVn71XCCaNgxz58ERTl8nA/8YYtIQDY9mHSrgFBfiFtdNNfY0h183Vh8BRkKxD8x9TUw3ec290uJKhDVxqGZBw==}
     dependencies:
       parents: 1.0.1
-    dev: true
-
-  /find-root@1.1.0:
-    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
     dev: true
 
   /find-up@4.1.0:
@@ -10527,6 +10380,19 @@ packages:
       tiny-warning: 1.0.3
     dev: true
 
+  /react-router-dom@6.15.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.15.0(react@18.2.0)
+    dev: true
+
   /react-router@5.0.0(react@18.2.0):
     resolution: {integrity: sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==}
     peerDependencies:
@@ -10578,6 +10444,16 @@ packages:
       react-is: 16.13.1
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
+    dev: true
+
+  /react-router@6.15.0(react@18.2.0):
+    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
     dev: true
 
   /react-sizeme@3.0.2:
@@ -11073,11 +10949,6 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -11298,10 +11169,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
-
-  /stylis@4.2.0:
-    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
-    dev: true
 
   /stylis@4.3.0:
     resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
@@ -12267,11 +12134,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-    dev: true
 
   /yaml@2.3.1:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      styled-components:
-        specifier: ^6.0.7
-        version: 6.0.7(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       odata-query:
         specifier: ^7.0.4


### PR DESCRIPTION
## Why
Remove emotion decencies from CLI

align CLI with EDS and use style components instead of emotion 🥲
prevent conflict of react types dependent on both emotion and eds

- remove @emotion/*
- convert emotion to styled-components
- fix styling of cli
  - convert main placeholder to grid
  - remove unnecessary styling from header
  - set dynamic width of context selector (min 25rem)


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
