### PR TITLE
fix(query): fix first cache hit

### DIFF
--- a/.changeset/unlucky-kiwis-change.md
+++ b/.changeset/unlucky-kiwis-change.md
@@ -1,0 +1,23 @@
+---
+'@equinor/fusion-query': patch
+---
+
+Query cache missed on first access since when creating a new cache record, updated was never set.
+
+> when creating a cache item, `entry.created` and `entry.updated` are set to `Date.now()`, but `entry.updates` are only incremented when updating. 
+
+> when invalidating a cache record, `entry.updated` is deleted, which triggers the `defaultCacheValidator` to miss cache
+
+```ts
+const defaultCacheValidator =
+    <TType, TArgs>(expires = 0): CacheValidator<TType, TArgs> =>
+    (entry) =>
+        (entry.updated ?? 0) + expires > Date.now();
+```
+
+
+__IMPORTANT__
+
+any consumer of this package should update ASAP to improve network performance.
+
+_discovered when duplicate service discovery calls was executed from cli portal_

--- a/packages/utils/query/src/cache/create-reducer.ts
+++ b/packages/utils/query/src/cache/create-reducer.ts
@@ -22,12 +22,18 @@ export default function <TType, TArgs>(
                     const { key, entry } = action.payload;
 
                     const record = state[key];
-                    if (!record) {
-                        state[key] = castDraft({ ...entry, created: Date.now() });
-                    } else {
+                    if (record) {
                         record.updated = Date.now();
                         record.updates ??= 0;
                         record.updates++;
+                    } else {
+                        const created = Date.now();
+                        state[key] = castDraft({
+                            ...entry,
+                            created,
+                            /** `updated` = `created`, but `updates` is `undefined` */
+                            updated: created,
+                        });
                     }
                 })
                 .addCase(actions.remove, (state, action) => {


### PR DESCRIPTION
## Why
__What kind of change does this PR introduce?__
Correctly return the cache hit on first access

__What is the current behavior?__
Since `updated` is not set until an actual update, all initial cache hits will miss (first hit)

__What is the new behavior?__
The query client cache will now set `updated` to `created` date when initially created 


__Other information?__
apps and portals using this package should update, rebuild and redeploy to improve network calls. 

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
