### PR TITLE
Fix/observable/exporttype

### DIFF
--- a/.changeset/nasty-news-report.md
+++ b/.changeset/nasty-news-report.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-observable': patch
+---
+
+# package.json setting type.module
+
+Removing type.module from package config since it was causing issues in @equinor/fusion-cli

--- a/packages/react/legacy-interopt/src/components/LegacyFusionWrapper.tsx
+++ b/packages/react/legacy-interopt/src/components/LegacyFusionWrapper.tsx
@@ -23,6 +23,10 @@ export type LegacyFusionWrapperProps = {
     readonly RootWrapper?: (props: { children: ReactChild }) => ReactElement<any, any>;
 };
 
+const FusionRootExtended = FusionRoot as unknown as React.FC<
+    React.PropsWithChildren<React.ComponentProps<typeof FusionRoot>>
+>;
+
 const FallThrewComponent = ({
     children,
 }: {
@@ -49,11 +53,9 @@ export const LegacyFusionWrapper = (props: PropsWithChildren<LegacyFusionWrapper
         <Suspense fallback={loader}>
             <LegacyContext>
                 <RootWrapper>
-                    {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                    {/* @ts-ignore */}
-                    <FusionRoot rootRef={root} overlayRef={overlay}>
+                    <FusionRootExtended rootRef={root} overlayRef={overlay}>
                         {props.children}
-                    </FusionRoot>
+                    </FusionRootExtended>
                 </RootWrapper>
             </LegacyContext>
         </Suspense>

--- a/packages/react/legacy-interopt/src/components/LegacyFusionWrapper.tsx
+++ b/packages/react/legacy-interopt/src/components/LegacyFusionWrapper.tsx
@@ -49,6 +49,7 @@ export const LegacyFusionWrapper = (props: PropsWithChildren<LegacyFusionWrapper
         <Suspense fallback={loader}>
             <LegacyContext>
                 <RootWrapper>
+                    {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                     {/* @ts-ignore */}
                     <FusionRoot rootRef={root} overlayRef={overlay}>
                         {props.children}

--- a/packages/utils/observable/package.json
+++ b/packages/utils/observable/package.json
@@ -10,7 +10,6 @@
     ],
     "homepage": "https://equinor.github.io/fusion-framework/",
     "license": "ISC",
-    "type": "module",
     "main": "dist/esm/index.js",
     "exports": {
         ".": "./dist/esm/index.js",


### PR DESCRIPTION
## Why

Removing types.module from @equinor/fusion-observable.

The config was causing issues in @equinor/fusion-cli.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
