### PR TITLE
feat: allow defaultScopes in service discovery

### DIFF
--- a/.changeset/shiny-lemons-change.md
+++ b/.changeset/shiny-lemons-change.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-service-discovery': patch
+---
+
+Use defaultScopes in service discovery if available, otherwise fall back to default scope

--- a/packages/modules/service-discovery/src/client.ts
+++ b/packages/modules/service-discovery/src/client.ts
@@ -67,7 +67,7 @@ export class ServiceDiscoveryClient<T extends Environment = Environment>
                 [service.key]: {
                     clientId: env.clientId,
                     uri: service.uri,
-                    defaultScopes: [env.clientId + '/.default'],
+                    defaultScopes: service.defaultScopes ?? [env.clientId + '/.default'],
                 },
             });
         }, {} as T);

--- a/packages/modules/service-discovery/src/types.ts
+++ b/packages/modules/service-discovery/src/types.ts
@@ -3,6 +3,7 @@ export type EnvironmentResponse = {
     services: Array<{
         key: string;
         uri: string;
+        defaultScopes?: Array<string>;
     }>;
 };
 


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
Add optional defaultScopes flag to services in service discovery. If available, it will use the custom scopes. If not, falls back to old behaviour (`[env.clientId + '/.default']`), keeping everything backwards compatible.
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes: #1223

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [X] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [] Confirm project selected and category, actual, iteration are set
- [] Confirm Milestone selected _(if any)_
