### PR TITLE
feat(module-http): add functionality for blob query

### DIFF
--- a/.changeset/lazy-flowers-pull.md
+++ b/.changeset/lazy-flowers-pull.md
@@ -1,0 +1,15 @@
+---
+'@equinor/fusion-framework-module-http': minor
+---
+
+add method for executing blob requests
+
+- added selector for extracting blob from response
+- added function for fetching blob as stream or promise on the http client
+
+
+```tsx
+const data = await client.blob('/person/photo');
+const url = URL.createObjectURL(blob);
+return <img src={url} />
+```

--- a/packages/modules/http/src/lib/client/client.ts
+++ b/packages/modules/http/src/lib/client/client.ts
@@ -3,7 +3,7 @@ import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
 
 import { HttpRequestHandler, HttpResponseHandler } from '../operators';
-import { jsonSelector } from '../selectors';
+import { blobSelector, jsonSelector } from '../selectors';
 
 import type { Observable, ObservableInput } from 'rxjs';
 import type { IHttpRequestHandler, IHttpResponseHandler } from '../operators';
@@ -26,8 +26,10 @@ export type HttpClientCreateOptions<
 };
 
 /** Base http client for executing requests */
-export class HttpClient<TRequest extends FetchRequest = FetchRequest, TResponse = FetchResponse>
-    implements IHttpClient<TRequest, TResponse>
+export class HttpClient<
+    TRequest extends FetchRequest = FetchRequest,
+    TResponse extends FetchResponse = FetchResponse,
+> implements IHttpClient<TRequest, TResponse>
 {
     readonly requestHandler: IHttpRequestHandler<TRequest>;
 
@@ -107,6 +109,21 @@ export class HttpClient<TRequest extends FetchRequest = FetchRequest, TResponse 
         args?: FetchRequestInit<T, JsonRequest<TRequest>, TResponse>,
     ): Promise<T> {
         return firstValueFrom(this.json$<T>(path, args));
+    }
+
+    public blob$(
+        path: string,
+        args?: FetchRequestInit<Blob, TRequest, TResponse>,
+    ): StreamResponse<Blob> {
+        const selector = args?.selector ?? blobSelector;
+        return this.fetch$(path, {
+            ...args,
+            selector,
+        } as FetchRequestInit<Blob, TRequest, TResponse>);
+    }
+
+    public blob(path: string, args?: FetchRequestInit<Blob, TRequest, TResponse>): Promise<Blob> {
+        return firstValueFrom(this.blob$(path, args));
     }
 
     /** @deprecated */

--- a/packages/modules/http/src/lib/client/types.ts
+++ b/packages/modules/http/src/lib/client/types.ts
@@ -145,10 +145,21 @@ export interface IHttpClient<TRequest extends FetchRequest = FetchRequest, TResp
         init?: FetchRequestInit<T, JsonRequest<TRequest>, TResponse>,
     ): Promise<T>;
 
+    /** @deprecated */
     jsonAsync<T = unknown>(
         path: string,
         args?: FetchRequestInit<T, JsonRequest<TRequest>, TResponse>,
     ): Promise<T>;
+
+    blob(
+        path: string,
+        args?: FetchRequestInit<Blob, JsonRequest<TRequest>, TResponse>,
+    ): Promise<Blob>;
+
+    blob$(
+        path: string,
+        args?: FetchRequestInit<Blob, JsonRequest<TRequest>, TResponse>,
+    ): StreamResponse<Blob>;
 
     /**
      * Abort all ongoing request for current client

--- a/packages/modules/http/src/lib/selectors/blob-selector.ts
+++ b/packages/modules/http/src/lib/selectors/blob-selector.ts
@@ -1,0 +1,19 @@
+export const blobSelector = <TResponse extends Response = Response>(
+    response: TResponse,
+): Promise<Blob> => {
+    if (!response.ok) {
+        throw new Error('network response was not OK');
+    }
+    //Status code 204 is no content
+    if (response.status === 204) {
+        throw new Error('no content');
+    }
+
+    try {
+        return response.blob();
+    } catch (err) {
+        throw Error('failed to parse response');
+    }
+};
+
+export default blobSelector;

--- a/packages/modules/http/src/lib/selectors/index.ts
+++ b/packages/modules/http/src/lib/selectors/index.ts
@@ -1,1 +1,2 @@
 export { jsonSelector } from './json-selector';
+export { blobSelector } from './blob-selector';


### PR DESCRIPTION
## Why
add method for executing blob requests

- add selector for extracting blob from response
- add function for fetching blob as stream or promise on the http client

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
