### PR TITLE
feat(module-services): add people api

### DIFF
--- a/.changeset/spicy-bottles-tease.md
+++ b/.changeset/spicy-bottles-tease.md
@@ -1,0 +1,18 @@
+---
+'@equinor/fusion-framework-module-services': minor
+---
+
+Added person services
+
+> __for internal usage only!__
+
+- add function for fetching person details
+- add function for querying persons
+- add function for downloading person photo
+
+```ts
+const personApi = await modules.services.createPeopleClient();
+personApi.query('v2', 'json$', {search: 'foo@bar.com'})
+personApi.get('v4', 'json$', {azureId: '1234'})
+personApi.photo('v2', 'blob$', {azureId: '123'})
+``

--- a/packages/modules/services/src/people/api-models.ts
+++ b/packages/modules/services/src/people/api-models.ts
@@ -1,0 +1,59 @@
+import { ApiVersion } from './static';
+
+// TODO
+type ApiPersonDetailEntity_vX = {
+    azureId: string;
+    name?: string;
+    pictureSrc?: string;
+    jobTitle?: string;
+    department?: string;
+    mail?: string;
+    company?: string;
+    mobilePhone?: string;
+    // TODO
+    accountType?: ApiPersonAccountType_vX;
+    officeLocation?: string;
+    // TODO
+    positions?: ApiPersonPosition_vX[];
+    // TODO
+    manager?: ApiPersonManager_vX;
+    managerAzureUniqueId?: string;
+};
+
+// TODO
+enum ApiPersonAccountType_vX {
+    Employee = 'Employee',
+    Consultant = 'Consultant',
+    Enterprise = 'Enterprise',
+    External = 'External',
+    ExternalHire = 'External Hire',
+}
+
+// TODO
+type ApiPersonPosition_vX = {
+    id: string;
+    name: string;
+    project: {
+        id: string;
+        name: string;
+    };
+};
+
+// TODO
+type ApiPersonManager_vX = {
+    azureUniqueId: string;
+    name?: string;
+    pictureSrc?: string;
+    department?: string;
+    // TODO
+    accountType?: ApiPersonAccountType_vX;
+};
+
+type ApiPersonDetailTypes = {
+    // TODO
+    [ApiVersion.v2]: ApiPersonDetailEntity_vX;
+    // TODO
+    [ApiVersion.v4]: ApiPersonDetailEntity_vX;
+};
+
+export type ApiPersonDetailType<T extends ApiVersion> = ApiPersonDetailTypes[T];

--- a/packages/modules/services/src/people/client.ts
+++ b/packages/modules/services/src/people/client.ts
@@ -1,0 +1,89 @@
+import { IHttpClient } from '@equinor/fusion-framework-module-http';
+
+import type { ClientDataMethod, ClientMethod } from '../types';
+import { ApiVersion } from './static';
+
+import {
+    client as getClient,
+    ApiResponse as GetPersonApiResponse,
+    ApiRequestFn as GetPersonApiRequestFn,
+    ApiResult as GetPersonResult,
+    SupportedApiVersion as SupportedGetPersonApiVersion,
+} from './person-details';
+
+import {
+    client as queryClient,
+    ApiResponse as QueryPersonApiResponse,
+    ApiRequestFn as QueryPersonApiRequestFn,
+    ApiResult as QueryPersonResult,
+    SupportedApiVersion as SupportedQueryApiVersion,
+} from './query';
+
+import {
+    client as photoClient,
+    ApiResponse as PhotoPersonApiResponse,
+    ApiRequestFn as PhotoPersonApiRequestFn,
+    ApiResult as PhotoPersonResult,
+    SupportedApiVersion as SupportedPhotoApiVersion,
+} from './person-photo';
+
+export class PeopleApiClient<
+    // TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+    TClient extends IHttpClient = IHttpClient,
+> {
+    get Version(): typeof ApiVersion {
+        return ApiVersion;
+    }
+
+    constructor(protected _client: TClient) {}
+
+    /**
+     * Fetch person by id
+     */
+    public get<
+        TVersion extends SupportedGetPersonApiVersion,
+        TResult = GetPersonApiResponse<TVersion>,
+        TMethod extends keyof ClientMethod<TResult> = keyof ClientMethod<TResult>,
+    >(
+        version: TVersion,
+        method: TMethod,
+        ...args: Parameters<GetPersonApiRequestFn<TVersion, TMethod, TClient, TResult>>
+    ): GetPersonResult<TVersion, TMethod, TResult> {
+        const fn = getClient<TVersion, TMethod, TClient>(this._client, version, method);
+        return fn<TResult>(...args);
+    }
+
+    /**
+     * Query person service
+     */
+    public query<
+        TVersion extends SupportedQueryApiVersion,
+        TResult = QueryPersonApiResponse<TVersion>,
+        TMethod extends keyof ClientMethod<TResult> = keyof ClientMethod<TResult>,
+    >(
+        version: TVersion,
+        method: TMethod,
+        ...args: Parameters<QueryPersonApiRequestFn<TVersion, TMethod, TClient, TResult>>
+    ): QueryPersonResult<TVersion, TMethod, TResult> {
+        const fn = queryClient<TVersion, TMethod, TClient>(this._client, version, method);
+        return fn<TResult>(...args);
+    }
+
+    /**
+     * Photo person service
+     */
+    public photo<
+        TVersion extends SupportedPhotoApiVersion,
+        TResult extends Blob = PhotoPersonApiResponse<TVersion>,
+        TMethod extends keyof ClientDataMethod = keyof ClientDataMethod,
+    >(
+        version: TVersion,
+        method: TMethod,
+        ...args: Parameters<PhotoPersonApiRequestFn<TVersion, TMethod, TClient, TResult>>
+    ): PhotoPersonResult<TMethod> {
+        const fn = photoClient<TVersion, TMethod, TClient>(this._client, version, method);
+        return fn<TResult>(...args);
+    }
+}
+
+export default PeopleApiClient;

--- a/packages/modules/services/src/people/person-details/client.ts
+++ b/packages/modules/services/src/people/person-details/client.ts
@@ -1,0 +1,32 @@
+import { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateParameters } from './generate-parameters';
+
+import type { ClientMethod } from '../../types';
+import type { ApiResponse, ApiResult, ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for fetching context item from context service
+ * @param client - client for execution of request
+ * @param version - version of API to call
+ * @param method - client method to call
+ */
+export const client =
+    <
+        TVersion extends SupportedApiVersion,
+        TMethod extends keyof ClientMethod = keyof ClientMethod,
+        TClient extends IHttpClient = IHttpClient,
+    >(
+        client: TClient,
+        version: TVersion,
+        method: TMethod = 'json' as TMethod,
+    ) =>
+    <T = ApiResponse<TVersion>>(
+        args: ApiRequestArgs<TVersion>,
+        init?: ClientRequestInit<TClient, T>,
+    ): ApiResult<TVersion, TMethod, T> =>
+        client[method](
+            ...generateParameters<T, TVersion, TClient>(version, args, init),
+        ) as ApiResult<TVersion, TMethod, T>;
+
+export default client;

--- a/packages/modules/services/src/people/person-details/generate-endpoint.ts
+++ b/packages/modules/services/src/people/person-details/generate-endpoint.ts
@@ -1,0 +1,25 @@
+import { UnsupportedApiVersion } from '../../errors';
+import { ApiVersion } from '../static';
+
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for generating endpoint for getting context by id
+ */
+export const generateEndpoint = <TVersion extends SupportedApiVersion>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+) => {
+    const apiVersion = ApiVersion[version as keyof typeof ApiVersion] ?? version;
+    switch (apiVersion) {
+        case ApiVersion.v4: {
+            const { azureId } = args;
+            const params = new URLSearchParams();
+            params.append('api-version', apiVersion);
+            return `/persons/${azureId}?${String(params)}`;
+        }
+        default: {
+            throw new UnsupportedApiVersion(version);
+        }
+    }
+};

--- a/packages/modules/services/src/people/person-details/generate-parameters.ts
+++ b/packages/modules/services/src/people/person-details/generate-parameters.ts
@@ -1,0 +1,22 @@
+import type { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateEndpoint } from './generate-endpoint';
+
+import type { ApiClientArguments } from '../../types';
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/** function for creating http client arguments  */
+export const generateParameters = <
+    TResult,
+    TVersion extends SupportedApiVersion,
+    TClient extends IHttpClient = IHttpClient,
+>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+): ApiClientArguments<TClient, TResult> => {
+    const path = generateEndpoint(version, args);
+    return [path, init];
+};
+
+export default generateParameters;

--- a/packages/modules/services/src/people/person-details/index.ts
+++ b/packages/modules/services/src/people/person-details/index.ts
@@ -1,0 +1,6 @@
+export { client, default } from './client';
+
+export { generateEndpoint } from './generate-endpoint';
+export { generateParameters } from './generate-parameters';
+
+export * from './types';

--- a/packages/modules/services/src/people/person-details/types.ts
+++ b/packages/modules/services/src/people/person-details/types.ts
@@ -1,0 +1,41 @@
+import { IHttpClient, ClientRequestInit } from '@equinor/fusion-framework-module-http/client';
+
+import { ApiVersion } from '../static';
+import { ApiPersonDetailType } from '../api-models';
+import { ClientMethod } from '../../types';
+
+export type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v4'>;
+
+type ApiRequestArgsMap = {
+    [ApiVersion.v4]: {
+        azureId: string;
+    };
+};
+
+export type ApiRequestArgs<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiRequestArgsMap[(typeof ApiVersion)[T]]
+    : never;
+
+type ApiResponseTypes = {
+    [ApiVersion.v4]: ApiPersonDetailType<ApiVersion.v4>;
+};
+
+export type ApiResponse<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiResponseTypes[(typeof ApiVersion)[T]]
+    : never;
+
+export type ApiRequestFn<
+    TVersion extends SupportedApiVersion,
+    TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+    TClient extends IHttpClient = IHttpClient,
+    TResult = ApiResponse<TVersion>,
+> = (
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+) => ApiResult<TVersion, TMethod, TResult>;
+
+export type ApiResult<
+    TVersion extends SupportedApiVersion,
+    TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+    TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];

--- a/packages/modules/services/src/people/person-photo/client.ts
+++ b/packages/modules/services/src/people/person-photo/client.ts
@@ -1,0 +1,32 @@
+import { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateParameters } from './generate-parameters';
+
+import type { ClientDataMethod } from '../../types';
+import type { ApiResponse, ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for fetching context item from context service
+ * @param client - client for execution of request
+ * @param version - version of API to call
+ * @param method - client method to call
+ */
+export const client =
+    <
+        TVersion extends SupportedApiVersion,
+        TMethod extends keyof ClientDataMethod = keyof ClientDataMethod,
+        TClient extends IHttpClient = IHttpClient,
+    >(
+        client: TClient,
+        version: TVersion,
+        method: TMethod = 'blob' as TMethod,
+    ) =>
+    <T extends Blob = ApiResponse<TVersion>>(
+        args: ApiRequestArgs<TVersion>,
+        init?: ClientRequestInit<TClient, T>,
+    ): ClientDataMethod[TMethod] =>
+        client[method](
+            ...generateParameters<T, TVersion, TClient>(version, args, init),
+        ) as ClientDataMethod[TMethod];
+
+export default client;

--- a/packages/modules/services/src/people/person-photo/generate-endpoint.ts
+++ b/packages/modules/services/src/people/person-photo/generate-endpoint.ts
@@ -1,0 +1,25 @@
+import { UnsupportedApiVersion } from '../../errors';
+import { ApiVersion } from '../static';
+
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for generating endpoint for getting context by id
+ */
+export const generateEndpoint = <TVersion extends SupportedApiVersion>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+) => {
+    const apiVersion = ApiVersion[version as keyof typeof ApiVersion] ?? version;
+    switch (apiVersion) {
+        case ApiVersion.v2: {
+            const { azureId } = args;
+            const params = new URLSearchParams();
+            params.append('api-version', apiVersion);
+            return `/persons/${azureId}?${String(params)}`;
+        }
+        default: {
+            throw new UnsupportedApiVersion(version);
+        }
+    }
+};

--- a/packages/modules/services/src/people/person-photo/generate-parameters.ts
+++ b/packages/modules/services/src/people/person-photo/generate-parameters.ts
@@ -1,0 +1,22 @@
+import type { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateEndpoint } from './generate-endpoint';
+
+import type { ApiClientArguments } from '../../types';
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/** function for creating http client arguments  */
+export const generateParameters = <
+    TResult,
+    TVersion extends SupportedApiVersion,
+    TClient extends IHttpClient = IHttpClient,
+>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+): ApiClientArguments<TClient, TResult> => {
+    const path = generateEndpoint(version, args);
+    return [path, init];
+};
+
+export default generateParameters;

--- a/packages/modules/services/src/people/person-photo/index.ts
+++ b/packages/modules/services/src/people/person-photo/index.ts
@@ -1,0 +1,6 @@
+export { client, default } from './client';
+
+export { generateEndpoint } from './generate-endpoint';
+export { generateParameters } from './generate-parameters';
+
+export * from './types';

--- a/packages/modules/services/src/people/person-photo/types.ts
+++ b/packages/modules/services/src/people/person-photo/types.ts
@@ -1,0 +1,37 @@
+import { IHttpClient, ClientRequestInit } from '@equinor/fusion-framework-module-http/client';
+
+import { ApiVersion } from '../static';
+import { ClientDataMethod } from '../../types';
+
+export type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v2'>;
+
+type ApiRequestArgsMap = {
+    [ApiVersion.v2]: {
+        azureId: string;
+    };
+};
+
+export type ApiRequestArgs<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiRequestArgsMap[(typeof ApiVersion)[T]]
+    : never;
+
+type ApiResponseTypes = {
+    [ApiVersion.v2]: Blob;
+};
+
+export type ApiResponse<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiResponseTypes[(typeof ApiVersion)[T]]
+    : never;
+
+export type ApiRequestFn<
+    TVersion extends SupportedApiVersion,
+    TMethod extends keyof ClientDataMethod = keyof ClientDataMethod,
+    TClient extends IHttpClient = IHttpClient,
+    TResult = ApiResponse<TVersion>,
+> = (
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+) => ClientDataMethod[TMethod];
+
+export type ApiResult<TMethod extends keyof ClientDataMethod = keyof ClientDataMethod> =
+    ClientDataMethod[TMethod];

--- a/packages/modules/services/src/people/query/client.ts
+++ b/packages/modules/services/src/people/query/client.ts
@@ -1,0 +1,32 @@
+import { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateParameters } from './generate-parameters';
+
+import type { ClientMethod } from '../../types';
+import type { ApiResponse, ApiResult, ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for fetching context item from context service
+ * @param client - client for execution of request
+ * @param version - version of API to call
+ * @param method - client method to call
+ */
+export const client =
+    <
+        TVersion extends SupportedApiVersion,
+        TMethod extends keyof ClientMethod = keyof ClientMethod,
+        TClient extends IHttpClient = IHttpClient,
+    >(
+        client: TClient,
+        version: TVersion,
+        method: TMethod = 'json' as TMethod,
+    ) =>
+    <T = ApiResponse<TVersion>>(
+        args: ApiRequestArgs<TVersion>,
+        init?: ClientRequestInit<TClient, T>,
+    ): ApiResult<TVersion, TMethod, T> =>
+        client[method](
+            ...generateParameters<T, TVersion, TClient>(version, args, init),
+        ) as ApiResult<TVersion, TMethod, T>;
+
+export default client;

--- a/packages/modules/services/src/people/query/generate-endpoint.ts
+++ b/packages/modules/services/src/people/query/generate-endpoint.ts
@@ -1,0 +1,26 @@
+import { UnsupportedApiVersion } from '../../errors';
+import { ApiVersion } from '../static';
+
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/**
+ * Method for generating endpoint for getting context by id
+ */
+export const generateEndpoint = <TVersion extends SupportedApiVersion>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+) => {
+    const apiVersion = ApiVersion[version as keyof typeof ApiVersion] ?? version;
+    switch (apiVersion) {
+        case ApiVersion.v2: {
+            const { search } = args;
+            const params = new URLSearchParams();
+            params.append('api-version', apiVersion);
+            params.append('search', search);
+            return `/persons?${String(params)}`;
+        }
+        default: {
+            throw new UnsupportedApiVersion(version);
+        }
+    }
+};

--- a/packages/modules/services/src/people/query/generate-parameters.ts
+++ b/packages/modules/services/src/people/query/generate-parameters.ts
@@ -1,0 +1,22 @@
+import type { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+
+import { generateEndpoint } from './generate-endpoint';
+
+import type { ApiClientArguments } from '../../types';
+import type { ApiRequestArgs, SupportedApiVersion } from './types';
+
+/** function for creating http client arguments  */
+export const generateParameters = <
+    TResult,
+    TVersion extends SupportedApiVersion,
+    TClient extends IHttpClient = IHttpClient,
+>(
+    version: TVersion,
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+): ApiClientArguments<TClient, TResult> => {
+    const path = generateEndpoint(version, args);
+    return [path, init];
+};
+
+export default generateParameters;

--- a/packages/modules/services/src/people/query/index.ts
+++ b/packages/modules/services/src/people/query/index.ts
@@ -1,0 +1,6 @@
+export { client, default } from './client';
+
+export { generateEndpoint } from './generate-endpoint';
+export { generateParameters } from './generate-parameters';
+
+export * from './types';

--- a/packages/modules/services/src/people/query/types.ts
+++ b/packages/modules/services/src/people/query/types.ts
@@ -1,0 +1,41 @@
+import { IHttpClient, ClientRequestInit } from '@equinor/fusion-framework-module-http/client';
+
+import { ApiVersion } from '../static';
+import { ApiPersonDetailType } from '../api-models';
+import { ClientMethod } from '../../types';
+
+export type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v2'>;
+
+type ApiRequestArgsMap = {
+    [ApiVersion.v2]: {
+        search: string;
+    };
+};
+
+export type ApiRequestArgs<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiRequestArgsMap[(typeof ApiVersion)[T]]
+    : never;
+
+type ApiResponseTypes = {
+    [ApiVersion.v2]: Array<ApiPersonDetailType<ApiVersion.v2>>;
+};
+
+export type ApiResponse<T extends SupportedApiVersion> = T extends SupportedApiVersion
+    ? ApiResponseTypes[(typeof ApiVersion)[T]]
+    : never;
+
+export type ApiRequestFn<
+    TVersion extends SupportedApiVersion,
+    TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+    TClient extends IHttpClient = IHttpClient,
+    TResult = ApiResponse<TVersion>,
+> = (
+    args: ApiRequestArgs<TVersion>,
+    init?: ClientRequestInit<TClient, TResult>,
+) => ApiResult<TVersion, TMethod, TResult>;
+
+export type ApiResult<
+    TVersion extends SupportedApiVersion,
+    TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+    TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];

--- a/packages/modules/services/src/people/static.ts
+++ b/packages/modules/services/src/people/static.ts
@@ -1,0 +1,4 @@
+export enum ApiVersion {
+    'v2' = '2.0',
+    'v4' = '4.0',
+}

--- a/packages/modules/services/src/provider.ts
+++ b/packages/modules/services/src/provider.ts
@@ -5,6 +5,7 @@ import { ApiClientFactory } from './types';
 import { ContextApiClient } from './context';
 import BookmarksApiClient from './bookmarks/client';
 import { NotificationApiClient } from './notification';
+import { PeopleApiClient } from './people/client';
 
 export interface IApiProvider<TClient extends IHttpClient = IHttpClient> {
     /**
@@ -26,6 +27,10 @@ export interface IApiProvider<TClient extends IHttpClient = IHttpClient> {
     createNotificationClient<TMethod extends keyof ClientMethod>(
         method: TMethod,
     ): Promise<NotificationApiClient<TMethod, TClient>>;
+    /**
+     * @param method - Version of the service to use
+     */
+    createPeopleClient(): Promise<PeopleApiClient<TClient>>;
 }
 
 type ApiProviderCtorArgs<TClient extends IHttpClient = IHttpClient> = {
@@ -101,5 +106,10 @@ export class ApiProvider<TClient extends IHttpClient = IHttpClient>
         const httpClient = await this._createClientFn('context');
         httpClient.responseHandler.add('validate_api_request', validateResponse);
         return new ContextApiClient(httpClient, method);
+    }
+    public async createPeopleClient(): Promise<PeopleApiClient<TClient>> {
+        const httpClient = await this._createClientFn('people');
+        httpClient.responseHandler.add('validate_api_request', validateResponse);
+        return new PeopleApiClient(httpClient);
     }
 }

--- a/packages/modules/services/src/types.ts
+++ b/packages/modules/services/src/types.ts
@@ -38,4 +38,9 @@ export type ClientMethod<T = unknown> = {
     json$: StreamResponse<T>;
 };
 
+export type ClientDataMethod = {
+    blob: Blob;
+    blob$: StreamResponse<Blob>;
+};
+
 export type ClientMethodType = keyof ClientMethod;


### PR DESCRIPTION
initial people service

## Why
initial api implementations of people service

> this module is meant for internal usage

lacking documentation, but not meant for consumption outside 'core' functionality
 
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
