### PR TITLE
Feat/react/components/people resolver/initial

### DIFF
--- a/.changeset/four-swans-sip.md
+++ b/.changeset/four-swans-sip.md
@@ -1,0 +1,25 @@
+---
+'@equinor/fusion-framework-react-components-people-provider': major
+---
+
+Component for providing people api resources to the @equinor/fusion-wc-person and @equinor/fusion-react-person components
+
+mapping and caching of `@equinor/fusion-framework-module-services/people`
+
+> Strongly collated to the Fusion ecosystems
+
+```tsx
+import { PeopleResolverProvider } from '@equinor/fusion-framework-react-components-people-provider';
+
+<PeopleResolverProvider>
+    <fwc-person-avatar azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-avatar>
+    <fwc-person-card azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-card>
+    <fwc-person-list-item azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-list-item>
+</PeopleResolverProvider>
+```
+
+> we might in the future provide a module which provides same functionality as the resolver
+>
+> atm there are no flexible way to configure this provider since the api models are strongly collated to the models of the components
+>
+> if requested we can create a provider for the functionality

--- a/packages/react/components/people-resolver/README.md
+++ b/packages/react/components/people-resolver/README.md
@@ -1,0 +1,21 @@
+Component for providing resolver to person elements
+
+mapping and caching of `@equinor/fusion-framework-module-services/people`
+
+> Strongly collated to the Fusion ecosystems
+
+```tsx
+import { PeopleResolverProvider } from '@equinor/fusion-framework-react-components-people-provider';
+
+<PeopleResolverProvider>
+    <fwc-person-avatar azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-avatar>
+    <fwc-person-card azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-card>
+    <fwc-person-list-item azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-list-item>
+</PeopleResolverProvider>
+```
+
+> we might in the future provide a module which provides same functionality as the resolver
+>
+> atm there are no flexible way to configure this provider since the api models are strongly collated to the models of the components
+>
+> if requested we can create a provider for the functionality

--- a/packages/react/components/people-resolver/package.json
+++ b/packages/react/components/people-resolver/package.json
@@ -1,0 +1,51 @@
+{
+    "name": "@equinor/fusion-framework-react-components-people-provider",
+    "version": "0.0.0",
+    "description": "",
+    "main": "dist/esm/index.js",
+    "exports": {
+        ".": "./dist/esm/index.js"
+    },
+    "types": "./dist/types/index.d.ts",
+    "scripts": {
+        "build": "tsc -b",
+        "prepack": "pnpm build"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/equinor/fusion-framework.git",
+        "directory": "packages/react/components/people-provider"
+    },
+    "dependencies": {
+        "@equinor/fusion-framework-react": "workspace:^",
+        "@equinor/fusion-framework-react-module": "workspace:^",
+        "@equinor/fusion-framework-react-module-bookmark": "workspace:^",
+        "@equinor/fusion-query": "workspace:^",
+        "rxjs": "^7.8.1"
+    },
+    "devDependencies": {
+        "@equinor/fusion-framework-module-app": "workspace:^",
+        "@equinor/fusion-framework-module-bookmark": "workspace:^",
+        "@equinor/fusion-framework-module-event": "workspace:^",
+        "@equinor/fusion-framework-module-services": "workspace:^",
+        "@equinor/fusion-wc-person": "1.0.0-next.4",
+        "@types/react": "^18.2.20",
+        "react": "^18.2.0",
+        "typescript": "^5.1.3"
+    },
+    "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
+    }
+}

--- a/packages/react/components/people-resolver/src/PeopleResolver.tsx
+++ b/packages/react/components/people-resolver/src/PeopleResolver.tsx
@@ -22,5 +22,4 @@ export const PeopleResolver = (props: React.PropsWithChildren<{ resolver: Person
         }
     }, [ref, resolver]);
     return <fwc-person-provider ref={ref}>{children}</fwc-person-provider>;
-
 };

--- a/packages/react/components/people-resolver/src/PeopleResolver.tsx
+++ b/packages/react/components/people-resolver/src/PeopleResolver.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+import {
+    PersonProviderElement,
+    PersonAvatarElement,
+    PersonCardElement,
+    PersonResolver,
+    PersonListItemElement,
+} from '@equinor/fusion-wc-person';
+
+PersonProviderElement;
+PersonAvatarElement;
+PersonCardElement;
+PersonListItemElement;
+
+export const PeopleResolver = (props: React.PropsWithChildren<{ resolver: PersonResolver }>) => {
+    const { resolver, children } = props;
+    const ref = useRef<PersonProviderElement | null>(null);
+    useEffect(() => {
+        if (ref.current && resolver) {
+            ref.current.setResolver(resolver);
+        }
+    }, [ref, resolver]);
+    return <fwc-person-provider ref={ref}>{children}</fwc-person-provider>;
+
+};

--- a/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
+++ b/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
@@ -1,0 +1,20 @@
+import { Suspense, useMemo } from 'react';
+import { ServicesModule } from '@equinor/fusion-framework-module-services';
+import { useModule } from '@equinor/fusion-framework-react-module';
+import { makeResolver } from './makeResolver';
+
+export const PeopleResolverProvider = ({ children }: { readonly children?: React.ReactNode }) => {
+    const services = useModule<ServicesModule>('services');
+    if (!services) {
+        throw Error('missing service module');
+    }
+    const Component = useMemo(() => makeResolver(services), [services]);
+    return (
+        <Suspense fallback={<span>TODO</span>}>
+            <Component>{children}</Component>
+        </Suspense>
+    );
+};
+
+export default PeopleResolverProvider;
+

--- a/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
+++ b/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
@@ -17,4 +17,3 @@ export const PeopleResolverProvider = ({ children }: { readonly children?: React
 };
 
 export default PeopleResolverProvider;
-

--- a/packages/react/components/people-resolver/src/PersonController.ts
+++ b/packages/react/components/people-resolver/src/PersonController.ts
@@ -32,7 +32,7 @@ const personMatcher =
 export interface IPersonController {
     getPerson(args: MatcherArgs): Observable<GetPersonResult>;
     getPersonInfo(args: MatcherArgs): Observable<ApiPerson<'v2'>>;
-    getPhoto(args: MatcherArgs): Observable<string>
+    getPhoto(args: MatcherArgs): Observable<string>;
     search(args: { search: string }): Observable<PersonSearchResult>;
 }
 

--- a/packages/react/components/people-resolver/src/PersonController.ts
+++ b/packages/react/components/people-resolver/src/PersonController.ts
@@ -32,7 +32,7 @@ const personMatcher =
 export interface IPersonController {
     getPerson(args: MatcherArgs): Observable<GetPersonResult>;
     getPersonInfo(args: MatcherArgs): Observable<ApiPerson<'v2'>>;
-    getPhoto(args: MatcherArgs): Observable<string>;
+    getPhoto(args: MatcherArgs): Observable<string>;;
     search(args: { search: string }): Observable<PersonSearchResult>;
 }
 

--- a/packages/react/components/people-resolver/src/PersonController.ts
+++ b/packages/react/components/people-resolver/src/PersonController.ts
@@ -1,0 +1,232 @@
+import { Observable, concat, from } from 'rxjs';
+import { filter, find, map, raceWith, switchMap, take } from 'rxjs/operators';
+
+import type { ApiPerson, PeopleApiClient } from '@equinor/fusion-framework-module-services/people';
+import type { ApiResponse as GetPersonApiResponse } from '@equinor/fusion-framework-module-services/people/get';
+import type { ApiResponse as QueryPersonApiResponse } from '@equinor/fusion-framework-module-services/people/query';
+import Query from '@equinor/fusion-query';
+
+type GetPersonResult = GetPersonApiResponse<
+    'v4',
+    { azureId: ''; expand: ['positions', 'manager'] }
+>;
+
+type PersonSearchResult = QueryPersonApiResponse<'v2'>;
+
+type MatcherArgs = { upn: string; azureId?: string } | { upn?: string; azureId: string };
+
+const personMatcher =
+    (args: MatcherArgs) =>
+    <T extends { azureUniqueId?: string; upn?: string }>(value: T): value is T => {
+        const { azureId, upn } = args;
+        if (azureId && upn) {
+            return value.upn === upn && value.azureUniqueId === azureId;
+        } else if (azureId) {
+            return value.azureUniqueId === azureId;
+        } else if (upn) {
+            return value.upn === upn;
+        }
+        return false;
+    };
+
+export interface IPersonController {
+    getPerson(args: MatcherArgs): Observable<GetPersonResult>;
+    getPersonInfo(args: MatcherArgs): Observable<ApiPerson<'v2'>>;
+    getPhoto(args: MatcherArgs): Observable<string>
+    search(args: { search: string }): Observable<PersonSearchResult>;
+}
+
+export class PersonController implements IPersonController {
+    #personQuery: Query<GetPersonResult, { azureId: string }>;
+    #personSearchQuery: Query<PersonSearchResult, { search: string }>;
+    #personPhotoQuery: Query<Blob, { azureId: string }>;
+
+    constructor(client: PeopleApiClient) {
+        const expire = 3 * 60 * 1000;
+        this.#personQuery = new Query({
+            expire,
+            queueOperator: 'merge',
+            key: ({ azureId }) => azureId,
+            client: {
+                fn: ({ azureId }, signal): Observable<GetPersonResult> => {
+                    return client.get(
+                        'v4',
+                        'json$',
+                        { azureId, expand: ['manager', 'positions'] },
+                        { signal },
+                    );
+                },
+            },
+        });
+        this.#personSearchQuery = new Query({
+            expire,
+            queueOperator: 'merge',
+            key: ({ search }) => search,
+            client: {
+                fn: ({ search }, signal) => {
+                    return client.query('v2', 'json$', { search }, { signal });
+                },
+            },
+        });
+        this.#personPhotoQuery = new Query({
+            expire,
+            queueOperator: 'merge',
+            key: ({ azureId }) => azureId,
+            client: {
+                fn: ({ azureId }, signal) => {
+                    return client.photo('v2', 'blob$', { azureId }, { signal });
+                },
+            },
+        });
+    }
+
+    /** TODO why does this need to have data?!? */
+    public getPhoto(args: MatcherArgs): Observable<string> {
+        const { azureId, upn } = args;
+
+        const resolve = (azureId: string) =>
+            this.#personPhotoQuery
+                .query({ azureId })
+                .pipe(map((blob) => URL.createObjectURL(blob.value)));
+
+        if (azureId) {
+            return resolve(azureId);
+        }
+
+        if (!azureId && upn) {
+            const cache$ = this._personCache$(args).pipe(raceWith(this._queryCache$(args)));
+            return concat(
+                /** */
+                cache$.pipe(find((x) => x?.upn === upn)),
+                this.getPersonInfo({ upn }),
+            ).pipe(
+                /** */
+                filter((x): x is ApiPerson<'v2'> => {
+                    return !!x;
+                }),
+                switchMap((x) => resolve(x.azureUniqueId)),
+            );
+        }
+        throw Error('invalid args provided');
+    }
+
+    public getPerson(args: MatcherArgs): Observable<GetPersonResult> {
+        if (args.azureId) {
+            return this._getPersonById(args.azureId);
+        } else if (args.upn) {
+            return this._getPersonByUpn(args.upn);
+        }
+        throw Error('invalid args provided');
+    }
+
+    public getPersonInfo(args: MatcherArgs): Observable<ApiPerson<'v2'>> {
+        if (args.azureId) {
+            return this._getPersonInfoById(args.azureId);
+        } else if (args.upn) {
+            return this._getPersonInfoByUpn(args.upn);
+        }
+        throw Error('invalid args provided');
+    }
+
+    public search(args: { search: string }): Observable<PersonSearchResult> {
+        return this.#personSearchQuery.query(args).pipe(
+            /** extract value */
+            map((x) => x.value),
+        );
+    }
+
+    protected _getPersonById(azureId: string): Observable<GetPersonResult> {
+        return this.#personQuery.query({ azureId }).pipe(map((x) => x.value));
+    }
+
+    protected _getPersonInfoById(azureId: string): Observable<ApiPerson<'v2'>> {
+        return concat(
+            this._personCache$({ azureId }).pipe(filter((x): x is GetPersonResult => !!x)),
+            concat(
+                this._queryCache$({ azureId }),
+                this.#personQuery.query({ azureId }).pipe(
+                    // TODO add mapper from v4 -> v2
+                    map((x) => x.value as ApiPerson<'v2'>),
+                ),
+            ).pipe(filter((x): x is ApiPerson<'v2'> => !!x)),
+        ).pipe(
+            map((x) => {
+                if (!x) {
+                    throw Error(`upn [${azureId}] not found`);
+                }
+                return x as ApiPerson<'v2'>;
+            }),
+        );
+    }
+
+    protected _getPersonByUpn(upn: string): Observable<GetPersonResult> {
+        return concat(
+            this._personCache$({ upn }),
+            this._getPersonInfoByUpn(upn).pipe(
+                filter((x): x is ApiPerson<'v2'> => !!x),
+                switchMap((x) =>
+                    this.#personQuery.query({ azureId: x!.azureUniqueId }).pipe(
+                        /** extract value */
+                        map((x) => x.value),
+                    ),
+                ),
+            ),
+        ).pipe(
+            map((x) => {
+                if (!x) {
+                    throw Error(`upn [${upn}] not found`);
+                }
+                return x;
+            }),
+        );
+    }
+
+    protected _getPersonInfoByUpn(upn: string): Observable<ApiPerson<'v2'>> {
+        return concat(
+            this._personCache$({ upn }),
+            concat(
+                this._queryCache$({ upn }),
+                this.#personSearchQuery.query({ search: upn }).pipe(
+                    /** extract first match, should only be 0 or 1 */
+                    map((x) => x.value.find((x) => x.upn === upn)),
+                    /** type cast and end stream */
+                    find((x): x is ApiPerson<'v2'> => !!x),
+                ),
+            ).pipe(filter((x): x is ApiPerson<'v2'> => !!x)),
+        ).pipe(
+            map((x) => {
+                if (!x) {
+                    throw Error(`upn [${upn}] not found`);
+                }
+                return x as ApiPerson<'v2'>;
+            }),
+        );
+    }
+
+    protected _personCache$(args: MatcherArgs): Observable<GetPersonResult | undefined> {
+        const mather = personMatcher(args);
+        return this.#personQuery.cache.state$.pipe(
+            /** make subscription cold */
+            take(1),
+            /** map out cached ApiPerson_v2 which matches upn  */
+            map((x) => Object.values(x).find((x) => mather(x.value))?.value),
+        );
+    }
+
+    protected _queryCache$(args: MatcherArgs) {
+        const mather = personMatcher(args);
+        return this.#personSearchQuery.cache.state$.pipe(
+            /** make subscription cold */
+            take(1),
+            switchMap((entry) =>
+                /** expand cache records */
+                from(Object.values(entry)).pipe(
+                    /** find matching cache record item */
+                    map((x) => x.value.find((x) => mather(x))),
+                    /** type cast and end stream */
+                    find((x): x is ApiPerson<'v2'> => !!x),
+                ),
+            ),
+        );
+    }
+}

--- a/packages/react/components/people-resolver/src/create-resolver.ts
+++ b/packages/react/components/people-resolver/src/create-resolver.ts
@@ -1,0 +1,48 @@
+import { firstValueFrom, map } from 'rxjs';
+
+import { PersonDetails, PersonInfo, PersonResolver } from '@equinor/fusion-wc-person';
+import { IPersonController } from './PersonController';
+
+export const createResolver = (controller: IPersonController): PersonResolver => ({
+    getDetails(args) {
+        console.warn('resolve.getDetails is deprecated');
+        return firstValueFrom(
+            controller.getPerson(args).pipe(
+                /** TODO */
+                map((x) => ({ ...x, azureId: x.azureUniqueId }) as unknown as PersonDetails),
+            ),
+        );
+    },
+    getInfo(args) {
+        return firstValueFrom(
+            controller.getPersonInfo(args).pipe(
+                /** TODO */
+                map((x) => ({ ...x, azureId: x.azureUniqueId }) as unknown as PersonDetails),
+            ),
+        );
+    },
+    getPhoto(args) {
+        return firstValueFrom(controller.getPhoto(args));
+    },
+    search(args) {
+        return firstValueFrom(
+            controller.search(args).pipe(
+                map((x) =>
+                    x.map(
+                        (x) =>
+                            ({
+                                ...x,
+                                azureId: x.azureUniqueId,
+                                // TODO
+                                // @asbjornhaland
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore https://github.com/equinor/fusion-web-components/issues/804
+                            }) as unknown as PersonInfo,
+                    ),
+                ),
+            ),
+        );
+    },
+});
+
+export default createResolver;

--- a/packages/react/components/people-resolver/src/index.ts
+++ b/packages/react/components/people-resolver/src/index.ts
@@ -1,0 +1,1 @@
+export { PeopleResolverProvider, default } from './PeopleResolverProvider';

--- a/packages/react/components/people-resolver/src/makeResolver.tsx
+++ b/packages/react/components/people-resolver/src/makeResolver.tsx
@@ -1,0 +1,19 @@
+import { lazy } from 'react';
+import { PeopleResolver } from './PeopleResolver';
+import { PersonController } from './PersonController';
+import { createResolver } from './create-resolver';
+import { IApiProvider } from '@equinor/fusion-framework-module-services';
+
+export const makeResolver = (services: IApiProvider) => {
+    return lazy(async () => {
+        const client = await services.createPeopleClient();
+        const controller = new PersonController(client);
+        const resolver = createResolver(controller);
+        const Component = ({ children }: { readonly children?: React.ReactNode }) => (
+            <PeopleResolver resolver={resolver}>{children}</PeopleResolver>
+        );
+        return {
+            default: Component,
+        };
+    });
+};

--- a/packages/react/components/people-resolver/src/types.ts
+++ b/packages/react/components/people-resolver/src/types.ts
@@ -1,0 +1,6 @@
+import type { ApiResponse as PersonDetailApiResponse } from '@equinor/fusion-framework-module-services/people/get';
+
+export type ApiPerson = PersonDetailApiResponse<
+    'v4',
+    { azureId: ''; expand: ['positions', 'manager'] }
+>;

--- a/packages/react/components/people-resolver/tsconfig.json
+++ b/packages/react/components/people-resolver/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.react.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "declarationDir": "./dist/types"
+  },
+  "references": [
+    {
+      "path": "../../framework"
+    },
+    {
+      "path": "../../../modules/services"
+    }
+  ],
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,6 +964,49 @@ importers:
         specifier: ^5.1.3
         version: 5.1.6
 
+  packages/react/components/people-resolver:
+    dependencies:
+      '@equinor/fusion-framework-react':
+        specifier: workspace:^
+        version: link:../../framework
+      '@equinor/fusion-framework-react-module':
+        specifier: workspace:^
+        version: link:../../modules/module
+      '@equinor/fusion-framework-react-module-bookmark':
+        specifier: workspace:^
+        version: link:../../modules/bookmark
+      '@equinor/fusion-query':
+        specifier: workspace:^
+        version: link:../../../utils/query
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+    devDependencies:
+      '@equinor/fusion-framework-module-app':
+        specifier: workspace:^
+        version: link:../../../modules/app
+      '@equinor/fusion-framework-module-bookmark':
+        specifier: workspace:^
+        version: link:../../../modules/bookmark
+      '@equinor/fusion-framework-module-event':
+        specifier: workspace:^
+        version: link:../../../modules/event
+      '@equinor/fusion-framework-module-services':
+        specifier: workspace:^
+        version: link:../../../modules/services
+      '@equinor/fusion-wc-person':
+        specifier: 1.0.0-next.4
+        version: 1.0.0-next.4
+      '@types/react':
+        specifier: ^18.2.20
+        version: 18.2.20
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      typescript:
+        specifier: ^5.1.3
+        version: 5.1.6
+
   packages/react/framework:
     dependencies:
       '@equinor/fusion-framework':
@@ -3589,6 +3632,15 @@ packages:
       lit: 2.7.0
     dev: true
 
+  /@equinor/fusion-wc-avatar@2.0.0-next.4:
+    resolution: {integrity: sha512-GXuKheXTggIZHdWXA3kuM7HYGw3VBhGCSQmHj5DQjUKEEkno+mPid+gjWKNFI/KiRZcPCC3O62jYb7SX5xcGJw==}
+    dependencies:
+      '@equinor/fusion-wc-core': 1.0.5
+      '@equinor/fusion-wc-picture': 2.0.0-next.4
+      '@equinor/fusion-wc-ripple': 0.2.19
+      lit: 2.7.0
+    dev: true
+
   /@equinor/fusion-wc-badge@0.2.32:
     resolution: {integrity: sha512-kXUzgb6Dx76bSJ6/IytYSTnxjhpLl2QalkcA4TLpxkJLqC4hGCD6koR7WtAbronjpyLKYWuG4w4XK5RCTFr6Ng==}
     dependencies:
@@ -3697,11 +3749,33 @@ packages:
       lit: 2.7.0
     dev: true
 
+  /@equinor/fusion-wc-person@1.0.0-next.4:
+    resolution: {integrity: sha512-slz3h3BmK6i8Y0sDeafQcBt8MTYQpjGqnN7Nn9aAfu2W5EtxPlb7SNpZ7Ev1N6VC9jRWyTwXywdv14a7tuV+pw==}
+    dependencies:
+      '@equinor/fusion-wc-avatar': 2.0.0-next.4
+      '@equinor/fusion-wc-badge': 0.2.32
+      '@equinor/fusion-wc-button': 1.4.3
+      '@equinor/fusion-wc-core': 1.0.5
+      '@equinor/fusion-wc-icon': 1.0.31
+      '@equinor/fusion-wc-skeleton': 0.2.24
+      '@floating-ui/dom': 1.5.1
+      '@lit-labs/observers': 2.0.0
+      '@lit-labs/task': 3.0.1
+      lit: 2.7.0
+    dev: true
+
   /@equinor/fusion-wc-picture@1.0.29:
     resolution: {integrity: sha512-/oG648ymvxmznUj2QSheWatRjUBTRWYDpOcRJdSmOb//XNIC6rv7bJbuetM5ZDg+qRMxMoM9VMoop8xtMiSN7Q==}
     dependencies:
       '@equinor/fusion-wc-core': 1.0.5
       '@equinor/fusion-wc-intersection': 1.0.27
+      lit: 2.7.0
+    dev: true
+
+  /@equinor/fusion-wc-picture@2.0.0-next.4:
+    resolution: {integrity: sha512-OTkJFjTvkKUarGyPIhdv0ARAM2EI9VEp8hV/eK/BoZwC0JqThqsA6NGcVExRF9mpJGax0SqCAguoL7SDhjpKTA==}
+    dependencies:
+      '@equinor/fusion-wc-core': 1.0.5
       lit: 2.7.0
     dev: true
 
@@ -4183,6 +4257,12 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /@lit-labs/observers@2.0.0:
+    resolution: {integrity: sha512-NMbCjJEqp8V9TpTtt8HhzFVymx/WGpTD7iU+FMKSis4u3iBWwu2UYh6KChwFTEPW9xMum70r2IBnaViBINaGTA==}
+    dependencies:
+      '@lit/reactive-element': 1.6.3
     dev: true
 
   /@lit-labs/react@1.2.1:


### PR DESCRIPTION
## Why
Component for providing people api resources to the @equinor/fusion-wc-person and @equinor/fusion-react-person components

mapping and caching of `@equinor/fusion-framework-module-services/people`

> Strongly collated to the Fusion ecosystems

```tsx
import { PeopleResolverProvider } from '@equinor/fusion-framework-react-components-people-provider';

<PeopleResolverProvider>
    <fwc-person-avatar azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-avatar>
    <fwc-person-card azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-card>
    <fwc-person-list-item azureId='cbc6480d-12c1-467e-b0b8-cfbb22612daa'></fwc-person-list-item>
</PeopleResolverProvider>
```


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
