### PR TITLE
feat(module-services): add compare util

### DIFF
--- a/.changeset/breezy-zoos-marry.md
+++ b/.changeset/breezy-zoos-marry.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-module-services': patch
+---
+
+add util for checking if object is person
+
+> extremely crude, but good enough until backend comes of with new models or endpoint
+
+_updated typings for person v4_

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/workflows/actions/build-packages
         with: 
-          only-affected: ${{ github.actor != 'dependabot[bot]' }}
+          only-affected: false
           
       - name: Review build log
         run: node process-turbo-build-log.cjs | reviewdog -f=tsc -reporter=${{ steps.reporter.outputs.value }} -fail-on-error

--- a/packages/modules/services/package.json
+++ b/packages/modules/services/package.json
@@ -28,6 +28,9 @@
             "people": [
                 "dist/types/people/index"
             ],
+            "people/utils": [
+                "dist/types/people/utils"
+            ],
             "people/get": [
                 "dist/types/people/person-details/index"
             ],
@@ -49,6 +52,7 @@
         "./notification": "./dist/esm/notification/index.js",
         "./context/get": "./dist/esm/context/get-context/index.js",
         "./people": "./dist/esm/people/index.js",
+        "./utils": "./dist/esm/people/utils.js",
         "./people/get": "./dist/esm/people/person-details/index.js",
         "./people/query": "./dist/esm/people/query/index.js",
         "./people/photo": "./dist/esm/people/person-photo/index.js",

--- a/packages/modules/services/src/people/api-models.v4.ts
+++ b/packages/modules/services/src/people/api-models.v4.ts
@@ -1,12 +1,23 @@
 import {
     ApiAccountClassification,
     ApiInvitationStatus,
+    ApiManager,
     ApiProfileAccountLink,
     ApiProfileAccountType,
     ApiProjectMaster,
 } from './api-models';
 
-export type ApiPerson_v4 = {
+export type ApiPersonExpandMap_v4 = {
+    roles: Array<ApiPersonRole_v4>;
+    positions: Array<ApiPersonPosition_v4>;
+    contracts: Array<ApiPersonContract_v4>;
+    manager: ApiManager;
+    companies: Array<ApiCompanyInfo_v4>;
+};
+
+export type ApiPersonExpandProps_v4 = keyof ApiPersonExpandMap_v4;
+
+export type ApiPerson_v4<TExpand extends Array<ApiPersonExpandProps_v4> = []> = {
     azureUniqueId: string;
     mail?: string;
     name?: string;
@@ -30,7 +41,10 @@ export type ApiPerson_v4 = {
 
     // TODO is this default
     linkedAccounts?: Array<ApiProfileAccountLink>;
-};
+} & /** expanded */ Partial<ApiPersonExpandMap_v4> & {
+        /** Provided */
+        [K in TExpand[number]]: ApiPersonExpandMap_v4[K];
+    };
 
 export type ApiCompanyInfo_v4 = {
     id: string;

--- a/packages/modules/services/src/people/person-details/types.ts
+++ b/packages/modules/services/src/people/person-details/types.ts
@@ -1,12 +1,5 @@
 import { ApiVersion } from '../static';
-import type { ApiManager } from '../api-models';
-import type {
-    ApiCompanyInfo_v4,
-    ApiPersonContract_v4,
-    ApiPerson_v4,
-    ApiPersonPosition_v4,
-    ApiPersonRole_v4,
-} from '../api-models.v4';
+import type { ApiPerson_v4, ApiPersonExpandProps_v4 } from '../api-models.v4';
 import { ClientMethod } from '../../types';
 
 export type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v4'>;
@@ -14,31 +7,17 @@ export type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v4'>;
 type ApiRequestArgsMap = {
     [ApiVersion.v4]: {
         azureId: string;
-        expand?: Array<keyof ExpandMap[ApiVersion.v4]>;
+        expand?: Array<ApiPersonExpandProps_v4>;
     };
 };
 
 export type AllowedArgs = ApiRequestArgsMap[keyof ApiRequestArgsMap];
 
-type ExpandMap = {
-    [ApiVersion.v4]: {
-        roles: Array<ApiPersonRole_v4>;
-        positions: Array<ApiPersonPosition_v4>;
-        contracts: Array<ApiPersonContract_v4>;
-        manager: ApiManager;
-        companies: Array<ApiCompanyInfo_v4>;
-    };
-};
-
 export type ApiRequestArgs<T extends SupportedApiVersion> =
     ApiRequestArgsMap[(typeof ApiVersion)[T]];
 
 type ApiResponseTypes<TArgs extends AllowedArgs> = {
-    [ApiVersion.v4]: TArgs['expand'] extends Array<keyof ExpandMap[ApiVersion.v4]>
-        ? ApiPerson_v4 & {
-              [K in TArgs['expand'][number]]: ExpandMap[ApiVersion.v4][K];
-          }
-        : ApiPerson_v4;
+    [ApiVersion.v4]: ApiPerson_v4<TArgs['expand'] extends [] ? TArgs['expand'] : []>;
 };
 
 export type ApiResponse<

--- a/packages/modules/services/src/people/utils.ts
+++ b/packages/modules/services/src/people/utils.ts
@@ -1,0 +1,32 @@
+import { ApiPerson } from './api-models';
+import { ApiVersion } from './static';
+
+// type SupportedApiVersion = Extract<keyof typeof ApiVersion, 'v2' | 'v4'>;
+
+const requiredApiPersonAttributes = {
+    [ApiVersion.v2]: [
+        'azureUniqueId',
+        'accountType',
+        'invitationStatus',
+        'accountClassification',
+        'managerAzureUniqueId',
+    ] satisfies Array<keyof ApiPerson<'v2'>>,
+    [ApiVersion.v4]: [
+        /** TODO - has to be more required attributes to identify V4??? */
+        'azureUniqueId',
+    ] satisfies Array<keyof ApiPerson<'v4'>>,
+};
+
+export const isApiPerson = <V extends keyof typeof ApiVersion>(version: V) => {
+    /** todo add options for more strict check */
+    return <T>(value: T): value is T extends ApiPerson<V> ? T : never => {
+        /** early escape if value is not defined or not a object */
+        if (!!value || typeof value !== 'object') {
+            return false;
+        }
+        const attr = Object.keys(value as object);
+        const requiredAttr = requiredApiPersonAttributes[ApiVersion[version]];
+        const result = requiredAttr.every((key) => attr.includes(key));
+        return result;
+    };
+};


### PR DESCRIPTION
## Why
add util for checking if object is person

> extremely crude, but good enough until backend comes of with new models or endpoint

_updated typings for person v4_

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
