### PR TITLE
Fix(utils/query): execute query on observe

### DIFF
--- a/.changeset/metal-tools-type.md
+++ b/.changeset/metal-tools-type.md
@@ -1,0 +1,42 @@
+---
+'@equinor/fusion-query': patch
+---
+
+fixed issue where queries where executed before observed.
+
+> __This fix might break existing code, if observation was wrongly implemented!__
+
+```ts
+const queryClient = new Query({
+  client: {
+    fn: async (value: string) => new Promise(
+      (resolve) => {
+        setTimeout(() => {
+          resolve(value);
+        }, 50);
+      }
+    )
+  },
+  key: (value) => value,
+});
+
+/** execute observables sequential */
+concat(
+  /** after 100ms emits 'foo' */
+  interval(100).map(() => 'foo'),
+  /** after 50ms emits 'bar' */
+  queryClient.query('bar')
+).subscribe(console.log);
+
+```
+__expected result:__
+```diff
++ 100ms 'foo' 50ms 'bar' |
+```
+__actual result:__
+```diff
+- 50ms 'bar' 50ms 'foo' |
+```
+
+this is now resolved by having an inner task which is not add request to the queue before the task is observed
+ 

--- a/.changeset/tame-wolves-heal.md
+++ b/.changeset/tame-wolves-heal.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-module-app': patch
+---
+
+fixed duplicate calls from flows
+
+alignment after changes to `@equinor/fusion-query`


### PR DESCRIPTION
read changesets

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
