### PR TITLE
feat(react-component-people-resolver): allow fallback photo

### DIFF
--- a/.changeset/afraid-bulldogs-serve.md
+++ b/.changeset/afraid-bulldogs-serve.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+add fallback image to person provider

--- a/.changeset/five-days-sort.md
+++ b/.changeset/five-days-sort.md
@@ -1,0 +1,22 @@
+---
+'@equinor/fusion-framework-react-components-people-provider': patch
+---
+
+Allow providing fallback image
+
+when defining a `PeopleResolverProvider`, one might want to provide a blob for fallback when a person photo is not found.
+
+> this will increase the general resolve time, since repeating request for resolving a person photo will not execute a new query until cache expires
+
+```tsx
+import { PeopleResolverProvider } from '@equinor/fusion-framework-react-components-people-provider';
+import fallbackSvg from './resources/fallback-photo.svg';
+
+const fallbackImage = new Blob([fallbackSvg], { type: 'image/svg+xml' });
+
+const App = () => (
+  <PeopleResolverProvider options={{fallbackImage}}>
+    ...children
+  </PeopleResolverProvider>
+);
+```

--- a/packages/cli/src/bin/dev-portal/main.tsx
+++ b/packages/cli/src/bin/dev-portal/main.tsx
@@ -10,11 +10,15 @@ import { PeopleResolverProvider } from '@equinor/fusion-framework-react-componen
 
 const target = document.getElementById('root') as HTMLElement;
 
+import fallbackSvg from './resources/fallback-photo.svg';
+
+const fallbackImage = new Blob([fallbackSvg], { type: 'image/svg+xml' });
+
 ReactDOM.createRoot(target).render(
     <React.StrictMode>
         <ThemeProvider theme={theme}>
             <Framework configure={configure} fallback={<EquinorLoader text="Loading framework" />}>
-                <PeopleResolverProvider>
+                <PeopleResolverProvider options={{ fallbackImage }}>
                     <Router />
                 </PeopleResolverProvider>
             </Framework>

--- a/packages/cli/src/bin/dev-portal/resources/fallback-photo.svg.ts
+++ b/packages/cli/src/bin/dev-portal/resources/fallback-photo.svg.ts
@@ -1,0 +1,2 @@
+export const svg = `<svg height="24px" width="24px" fill="#999" viewBox="0 0 24 24" title="person" role="img" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#eee" /><path d="M12 4C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4Zm2 4c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2Zm4 10c-.2-.71-3.3-2-6-2-2.69 0-5.77 1.28-6 2h12ZM4 18c0-2.66 5.33-4 8-4s8 1.34 8 4v2H4v-2Z" fill-rule="evenodd" clip-rule="evenodd" class="sc-dmqHEX eydzYY"></path></svg>`;
+export default svg;

--- a/packages/react/components/people-resolver/README.md
+++ b/packages/react/components/people-resolver/README.md
@@ -19,3 +19,17 @@ import { PeopleResolverProvider } from '@equinor/fusion-framework-react-componen
 > atm there are no flexible way to configure this provider since the api models are strongly collated to the models of the components
 >
 > if requested we can create a provider for the functionality
+
+### Fallback image
+```tsx
+import { PeopleResolverProvider } from '@equinor/fusion-framework-react-components-people-provider';
+import fallbackSvg from './resources/fallback-photo.svg';
+
+const fallbackImage = new Blob([fallbackSvg], { type: 'image/svg+xml' });
+
+const App = () => (
+  <PeopleResolverProvider options={{fallbackImage}}>
+    ...children
+  </PeopleResolverProvider>
+);
+```

--- a/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
+++ b/packages/react/components/people-resolver/src/PeopleResolverProvider.tsx
@@ -1,14 +1,20 @@
-import { Suspense, useMemo } from 'react';
+import { PropsWithChildren, Suspense, useMemo } from 'react';
 import { ServicesModule } from '@equinor/fusion-framework-module-services';
 import { useModule } from '@equinor/fusion-framework-react-module';
 import { makeResolver } from './makeResolver';
+import { PersonControllerOptions } from './PersonController';
 
-export const PeopleResolverProvider = ({ children }: { readonly children?: React.ReactNode }) => {
+type PeopleResolverProviderProps = PropsWithChildren<{
+    readonly options?: PersonControllerOptions;
+}>;
+
+export const PeopleResolverProvider = (props: PeopleResolverProviderProps) => {
+    const { children, options } = props;
     const services = useModule<ServicesModule>('services');
     if (!services) {
         throw Error('missing service module');
     }
-    const Component = useMemo(() => makeResolver(services), [services]);
+    const Component = useMemo(() => makeResolver(services, options), [services, options]);
     return (
         <Suspense fallback={<span>TODO</span>}>
             <Component>{children}</Component>

--- a/packages/react/components/people-resolver/src/create-resolver.ts
+++ b/packages/react/components/people-resolver/src/create-resolver.ts
@@ -16,7 +16,7 @@ export const createResolver = (controller: IPersonController): PersonResolver =>
         return firstValueFrom(
             controller.getPersonInfo(args).pipe(
                 /** TODO */
-                map((x) => ({ ...x, azureId: x.azureUniqueId }) as unknown as PersonDetails),
+                map((x) => ({ ...x, azureId: x.azureUniqueId }) as unknown as PersonInfo),
             ),
         );
     },

--- a/packages/react/components/people-resolver/src/makeResolver.tsx
+++ b/packages/react/components/people-resolver/src/makeResolver.tsx
@@ -1,13 +1,13 @@
 import { lazy } from 'react';
 import { PeopleResolver } from './PeopleResolver';
-import { PersonController } from './PersonController';
+import { PersonController, PersonControllerOptions } from './PersonController';
 import { createResolver } from './create-resolver';
 import { IApiProvider } from '@equinor/fusion-framework-module-services';
 
-export const makeResolver = (services: IApiProvider) => {
+export const makeResolver = (services: IApiProvider, options?: PersonControllerOptions) => {
     return lazy(async () => {
         const client = await services.createPeopleClient();
-        const controller = new PersonController(client);
+        const controller = new PersonController(client, options);
         const resolver = createResolver(controller);
         const Component = ({ children }: { readonly children?: React.ReactNode }) => (
             <PeopleResolver resolver={resolver}>{children}</PeopleResolver>


### PR DESCRIPTION
## Why
Allow `PeopleResolverProvider` to support fallback image when api controller fails to resolve photo


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
