### PR TITLE
feat(cli): Add --dev-portal flag to facilitate using a custom portal

### DIFF
--- a/.changeset/spicy-bags-develop.md
+++ b/.changeset/spicy-bags-develop.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+Allow using a custom dev-portal

--- a/packages/cli/src/bin/create-dev-serve.ts
+++ b/packages/cli/src/bin/create-dev-serve.ts
@@ -85,12 +85,7 @@ export const createDevServer = async (options: {
 
     spinner.info('💾 application entrypoint', formatPath(String(entry)));
 
-    let devPortalPath: string;
-    if (options.devPortalPath) {
-        devPortalPath = resolveRelativePath(options.devPortalPath);
-    } else {
-        devPortalPath = resolveRelativePath('public');
-    }
+    const devPortalPath = resolveRelativePath(options.devPortalPath ?? 'public');
     spinner.info('resolving cli internal assets from ', formatPath(devPortalPath));
 
     /** add proxy handlers */

--- a/packages/cli/src/bin/create-dev-serve.ts
+++ b/packages/cli/src/bin/create-dev-serve.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { assert } from 'node:console';
 
@@ -23,8 +23,6 @@ import { loadPackage } from './utils/load-package.js';
 
 import { rateLimit } from 'express-rate-limit';
 
-const resolveRelativePath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
-
 export const createDevServer = async (options: {
     portal: string;
     configSourceFiles: {
@@ -32,11 +30,11 @@ export const createDevServer = async (options: {
         manifest?: string;
         vite?: string;
     };
-    devPortalPath?: string;
+    devPortalPath: string;
     port?: number;
     library?: 'react';
 }) => {
-    const { configSourceFiles, library, portal, port } = options;
+    const { configSourceFiles, library, portal, port, devPortalPath } = options;
 
     const spinner = Spinner.Global({ prefixText: chalk.dim('dev-server') });
 
@@ -85,7 +83,6 @@ export const createDevServer = async (options: {
 
     spinner.info('💾 application entrypoint', formatPath(String(entry)));
 
-    const devPortalPath = resolveRelativePath(options.devPortalPath ?? 'public');
     spinner.info('resolving cli internal assets from ', formatPath(devPortalPath));
 
     /** add proxy handlers */
@@ -164,10 +161,7 @@ export const createDevServer = async (options: {
         '*',
         async (req, res) => {
             // TODO add check if file request
-            const htmlRaw = readFileSync(
-                resolveRelativePath(devPortalPath + '/index.html'),
-                'utf-8',
-            );
+            const htmlRaw = readFileSync(join(devPortalPath + '/index.html'), 'utf-8');
             const html = await vite.transformIndexHtml(req.url, htmlRaw);
             res.send(html);
         },

--- a/packages/cli/src/bin/dev-proxy.ts
+++ b/packages/cli/src/bin/dev-proxy.ts
@@ -16,6 +16,11 @@ type ProxyHandlerResult<T> = { response?: T; statusCode?: number; path?: string 
 type ProxyHandlerReturn<T> = Promise<ProxyHandlerResult<T>> | ProxyHandlerResult<T>;
 
 export interface ProxyHandler {
+    onManifestListResponse(
+        slug: object,
+        message: IncomingMessage,
+        data?: Array<AppManifest>,
+    ): ProxyHandlerReturn<Array<AppManifest>>;
     onManifestResponse(
         slug: { appKey: string },
         message: IncomingMessage,
@@ -129,6 +134,14 @@ export const createDevProxy = (
         createProxyMiddleware('/api/apps/*', {
             ...proxyOptions,
             onProxyRes: createResponseInterceptor(handler.onManifestResponse),
+        }),
+    );
+
+    app.get(
+        '/api/apps',
+        createProxyMiddleware('/api/apps', {
+            ...proxyOptions,
+            onProxyRes: createResponseInterceptor(handler.onManifestListResponse),
         }),
     );
 

--- a/packages/cli/src/bin/main.app.ts
+++ b/packages/cli/src/bin/main.app.ts
@@ -7,6 +7,8 @@ import { formatPath, chalk } from './utils/format.js';
 import createExportManifest from './create-export-manifest.js';
 import { bundleApplication } from './bundle-application.js';
 import { createExportConfig } from './create-export-config.js';
+import { fileURLToPath } from 'node:url';
+import { resolve, join } from 'node:path';
 
 export default (program: Command) => {
     const app = program
@@ -44,6 +46,9 @@ export default (program: Command) => {
         )
         .option('-d, --dev-portal <string>', 'Location of dev-portal you want to use')
         .action(async (opt) => {
+            const devPortalPath = opt.devPortal
+                ? resolve(join(process.cwd(), opt.devPortal))
+                : fileURLToPath(new URL('public', import.meta.url));
             await createDevServer({
                 portal:
                     process.env.FUSION_PORTAL_HOST ??
@@ -55,7 +60,7 @@ export default (program: Command) => {
                 },
                 library: opt.framework,
                 port: opt.port,
-                devPortalPath: opt.devPortal,
+                devPortalPath: devPortalPath,
             });
         });
 

--- a/packages/cli/src/bin/main.app.ts
+++ b/packages/cli/src/bin/main.app.ts
@@ -42,6 +42,7 @@ export default (program: Command) => {
             )}]`,
             'react',
         )
+        .option('-d, --dev-portal <string>', 'Location of dev-portal you want to use')
         .action(async (opt) => {
             await createDevServer({
                 portal:
@@ -54,6 +55,7 @@ export default (program: Command) => {
                 },
                 library: opt.framework,
                 port: opt.port,
+                devPortalPath: opt.devPortal,
             });
         });
 


### PR DESCRIPTION
## Why
This PR adds a new flag to the fusion-framework-cli (`--dev-portal`), which is meant to pass in a path to a custom portal-bundle, which decouples the fusion framework a bit more from fusion.equinor.com itself. This is done to allow more flexibility for consumers of the fusion-framework who are not necessarily building apps for the fusion portal.
In addition, I have added proxying for /api/apps (previously only /api/apps/:id was handled).

There should be no breaking changes introduced by this PR, as the flag would need to be set for it to have any effect. 


### Check off the following:
- [X] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [X] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [X] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [X] Confirm project selected and category, actual, iteration are set
- [X] Confirm Milestone selected _(if any)_
