### PR TITLE
chore(workflows): add run number to title of release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure git user (trigger actor) 
+      - name: Configure git user (trigger actor)
         uses: ./.github/workflows/actions/config-git-user
-      
+
       - name: Setup node and install deps
         uses: ./.github/workflows/actions/node-setup
 
@@ -29,7 +29,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          title: '🤖 Bip Bop - Fusion Framework Release'
+          title: '🤖 Bip Bop - Fusion Framework Release - ${{ github.run_number }}'
           createGithubReleases: true
           setupGitUser: false
           version: pnpm changeset:version


### PR DESCRIPTION
`GITHUB_RUN_NUMBER` A unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run. For example, 3.

Ref: https://docs.github.com/en/actions/learn-github-actions/variables

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
