### PR TITLE
fix(navigation): double navigation

### DIFF
--- a/.changeset/lovely-impalas-help.md
+++ b/.changeset/lovely-impalas-help.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-navigation': patch
+---
+
+fix double navigation

--- a/packages/modules/navigation/src/navigator.ts
+++ b/packages/modules/navigation/src/navigator.ts
@@ -78,11 +78,12 @@ export class Navigator<T extends NavigationUpdate = NavigationUpdate>
                 if (update.action === 'PUSH' && mode !== 'MASTER') {
                     this.#logger.debug(
                         'Navigator::#history.listen',
-                        'switching action ro [REPLACE], since navigator is not master',
+                        'switching action to [REPLACE], since navigator is not master',
                     );
                     this.#state.next({ ...update, action: 'REPLACE' } as T);
+                } else {
+                    this.#state.next(update as T);
                 }
-                this.#state.next(update as T);
             }),
         );
     }


### PR DESCRIPTION
missing fall-threw on navigator slave

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
