### PR TITLE
fix(cli): use provided config path when developing

### DIFF
--- a/.changeset/small-buckets-draw.md
+++ b/.changeset/small-buckets-draw.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+cli should no use provided config when developing an application which exists in Fusion App Service.
+
+> when dev proxy server did not get 404 when requesting application config, it provided the manifest instead of config file path

--- a/packages/cli/src/bin/create-dev-serve.ts
+++ b/packages/cli/src/bin/create-dev-serve.ts
@@ -97,7 +97,7 @@ export const createDevServer = async (options: {
                         return { response, path, statusCode: 200 };
                     } else if (data) {
                         const { config: response, path } = await createAppConfig(env, data, {
-                            file: configSourceFiles.manifest,
+                            file: configSourceFiles.app,
                         });
                         path && spinner.info('created config from ', formatPath(path));
                         return { response, path };


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes: #1434


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
