### PR TITLE
fix(module-navigation): check previous state

### DIFF
--- a/.changeset/cool-countries-doubt.md
+++ b/.changeset/cool-countries-doubt.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-navigation': patch
+---
+
+checks when `push`|`replace` is called if to is identical to previous to

--- a/packages/modules/navigation/src/configurator.ts
+++ b/packages/modules/navigation/src/configurator.ts
@@ -8,10 +8,4 @@ export interface INavigationConfigurator {
 export class NavigationConfigurator implements INavigationConfigurator {
     public history?: History;
     public basename?: string;
-    /**
-     * indicates if the navigator should behave as a slave or master
-     *
-     * When in `slave` mode the navigator will change push to replace (since master handles pushing history)
-     */
-    mode?: 'MASTER' | 'SLAVE';
 }

--- a/packages/modules/navigation/src/module.ts
+++ b/packages/modules/navigation/src/module.ts
@@ -27,9 +27,6 @@ export const module: NavigationModule = {
         const configurator = new NavigationConfigurator();
         if (ref) {
             configurator.history = (ref as ModuleInstance).navigation.navigator;
-            configurator.mode = 'SLAVE';
-        } else {
-            configurator.mode = 'MASTER';
         }
         return configurator;
     },


### PR DESCRIPTION
check previous state before dispatching push and replace.

partially rolls back #1453 since no longer needs `master` & `slave`

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
