### PR TITLE
feat(cli): allow setting archive name

### DIFF
--- a/.changeset/five-frogs-cheer.md
+++ b/.changeset/five-frogs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+Allow setting archive name when packing bundle

--- a/packages/cli/src/bin/bundle-application.ts
+++ b/packages/cli/src/bin/bundle-application.ts
@@ -1,6 +1,7 @@
 import AdmZip from 'adm-zip';
 
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { mkdir } from 'node:fs/promises';
 
 import { loadPackage } from './utils/load-package.js';
 import { chalk, formatByteSize, formatPath } from './utils/format.js';
@@ -50,6 +51,9 @@ export const bundleApplication = async (options: { outDir: string; archive: stri
     }
 
     spinner.start('compressing content');
+    if (!fileExistsSync(dirname(archive))) {
+        await mkdir(dirname(archive), { recursive: true });
+    }
     bundle.writeZip(archive);
 
     spinner.info(formatPath(archive), formatByteSize(archive));

--- a/packages/cli/src/bin/main.app.ts
+++ b/packages/cli/src/bin/main.app.ts
@@ -113,7 +113,9 @@ export default (program: Command) => {
 
     app.command('pack')
         .option('-o, --outDir, <string>', 'output directory of package', 'dist')
+        .option('-a, --archive, <string>', 'output filename', 'app-bundle.zip')
         .action(async (opt) => {
-            bundleApplication({ archive: 'app-bundle.zip', outDir: opt.outDir });
+            const { outDir, archive } = opt;
+            bundleApplication({ archive, outDir });
         });
 };


### PR DESCRIPTION
## Why
Allow providing archive name when bundling application

closes:

fixes [AB#45894](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/45894)


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
