### PR TITLE
fix: :bug: #1547

### DIFF
--- a/packages/modules/bookmark/src/client/bookmarkClient.ts
+++ b/packages/modules/bookmark/src/client/bookmarkClient.ts
@@ -258,7 +258,6 @@ export class BookmarkClient {
     #addStateEffects() {
         this.#state.subject.addEffect('create::success', (action) => {
             this.#queryAllBookmarks.cache.invalidate('all-bookmarks');
-            this.#currentBookmark$.next(action.payload);
             this.#event?.dispatchEvent('onBookmarkCreated', {
                 detail: action.payload,
                 canBubble: true,


### PR DESCRIPTION
## Why
After creating a bookmark the bookmark module will no longer set it as current. This makes sense because the application is already in the correct state when the bookmark was created

closes: #1547 

My PR doesnt build because the ./version file is missing. Is this a known issue?
https://github.com/equinor/fusion-framework/blob/main/packages/modules/navigation/src/module.ts#L13
