### PR TITLE
feat(bookmarks): no content bookmark

### DIFF
--- a/.changeset/happy-radios-return.md
+++ b/.changeset/happy-radios-return.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-react-components-bookmark': minor
+---
+
+Implement a "No Content" message and relocate the "Loading" indicator to the bookmarks component. Additionally, incorporate an effect to handle cases where the "onBookmarksChanged" event is not triggered.

--- a/packages/cli/src/lib/vite-logger.ts
+++ b/packages/cli/src/lib/vite-logger.ts
@@ -5,7 +5,7 @@ export const createViteLogger = () => {
     const originalLogger = { ...logger };
 
     logger.error = (msg, opt) => {
-        // TODO find a way to make these assets external 
+        // TODO find a way to make these assets external
         if (msg.match(/^Pre-transform error: Failed to load url \/assets/)) {
             return;
         }

--- a/packages/react/components/bookmark/src/components/Bookmark.tsx
+++ b/packages/react/components/bookmark/src/components/Bookmark.tsx
@@ -83,7 +83,7 @@ export const Bookmark = () => {
                 ) : (
                     <Styled.NoContentWrapper>
                         <Message title="No Bookmarks" type="NoContent">
-                            You haven't created any bookmarks yet.
+                            You have not created any bookmarks yet.
                         </Message>
                     </Styled.NoContentWrapper>
                 )}

--- a/packages/react/components/bookmark/src/components/Bookmark.tsx
+++ b/packages/react/components/bookmark/src/components/Bookmark.tsx
@@ -2,12 +2,15 @@ import { useBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import { useBookmarkGrouping } from '../hooks';
 import { BookmarkFilter } from './filter/Filter';
 import { SectionList } from './sectionList/SectionList';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Icon } from '@equinor/eds-core-react';
 import { chevron_down, chevron_right, share, more_vertical, add } from '@equinor/eds-icons';
 
 import styled from 'styled-components';
+import { Message } from './messages/Message';
+import { Loading } from './loading/Loading';
+import { useFramework } from '@equinor/fusion-framework-react';
 
 Icon.add({
     chevron_down,
@@ -29,10 +32,32 @@ const Styled = {
         overflow-x: hidden;
         height: calc((100vh - 85px) - 3rem);
     `,
+    NoContentWrapper: styled.div`
+        position: absolute;
+        top: 150px;
+        bottom: 200px;
+        left: 0px;
+        right: 0px;
+    `,
 };
 
 export const Bookmark = () => {
     const { bookmarks, getAllBookmarks } = useBookmark();
+    const [loading, setLoading] = useState(true);
+
+    const { event } = useFramework().modules;
+
+    useEffect(() => {
+        return event.addEventListener('onBookmarksChanged', () => {
+            setLoading(false);
+        });
+    }, [event]);
+
+    useEffect(() => {
+        if (bookmarks.length > 0) {
+            setLoading(false);
+        }
+    }, [bookmarks]);
 
     useEffect(() => {
         getAllBookmarks();
@@ -51,7 +76,17 @@ export const Bookmark = () => {
                 setSearchText={setSearchText}
             />
             <Styled.List>
-                <SectionList bookmarkGroups={bookmarkGroups} />
+                {bookmarkGroups.length > 0 ? (
+                    <SectionList bookmarkGroups={bookmarkGroups} />
+                ) : loading ? (
+                    <Loading />
+                ) : (
+                    <Styled.NoContentWrapper>
+                        <Message title="No Bookmarks" type="NoContent">
+                            You haven't created any bookmarks yet.
+                        </Message>
+                    </Styled.NoContentWrapper>
+                )}
             </Styled.List>
         </Styled.Wrapper>
     );

--- a/packages/react/components/bookmark/src/components/messages/Message.tsx
+++ b/packages/react/components/bookmark/src/components/messages/Message.tsx
@@ -45,18 +45,18 @@ const Styles = {
 };
 
 interface MessageProps {
-    title: string;
-    body?: React.FC | string;
-    type?: PortalMessageType;
-    color?: string;
+    readonly title: string;
+    readonly body?: React.FC | string;
+    readonly type?: PortalMessageType;
+    readonly color?: string;
 }
 
-export function Message({
+export const Message = ({
     title,
     type = 'Info',
     color,
     children,
-}: PropsWithChildren<MessageProps>) {
+}: PropsWithChildren<MessageProps>) => {
     const currentType = getMessageType(type);
     return (
         <Styles.Wrapper>
@@ -79,4 +79,4 @@ export function Message({
             </Styles.Content>
         </Styles.Wrapper>
     );
-}
+};

--- a/packages/react/components/bookmark/src/components/messages/Message.tsx
+++ b/packages/react/components/bookmark/src/components/messages/Message.tsx
@@ -1,0 +1,82 @@
+import { Icon, Typography } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+import { error_outlined, file_description } from '@equinor/eds-icons';
+
+export type PortalMessageType = 'Error' | 'Info' | 'Warning' | 'NoContent';
+
+const getMessageType = (type?: PortalMessageType) => {
+    switch (type) {
+        case 'Error':
+            return { color: tokens.colors.interactive.danger__resting.hex, icon: error_outlined };
+        case 'Info':
+            return { color: tokens.colors.interactive.primary__resting.hex, icon: error_outlined };
+        case 'Warning':
+            return { color: tokens.colors.interactive.warning__resting.hex, icon: error_outlined };
+        case 'NoContent':
+            return {
+                color: tokens.colors.interactive.primary__resting.hex,
+                icon: file_description,
+            };
+        default:
+            return undefined;
+    }
+};
+
+const Styles = {
+    Wrapper: styled.div`
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        justify-content: center;
+    `,
+    Content: styled.div`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        justify-content: center;
+    `,
+};
+
+interface MessageProps {
+    title: string;
+    body?: React.FC | string;
+    type?: PortalMessageType;
+    color?: string;
+}
+
+export function Message({
+    title,
+    type = 'Info',
+    color,
+    children,
+}: PropsWithChildren<MessageProps>) {
+    const currentType = getMessageType(type);
+    return (
+        <Styles.Wrapper>
+            <Icon
+                data-testid="icon"
+                size={40}
+                color={currentType?.color || color || tokens.colors.text.static_icons__tertiary.hex}
+                data={currentType?.icon || error_outlined}
+            />
+            <Styles.Content>
+                <Typography
+                    color={tokens.colors.text.static_icons__default.hex}
+                    variant={'h3'}
+                    aria-label={`Title for ${type} message`}
+                >
+                    {title}
+                </Typography>
+
+                <Typography>{children && children}</Typography>
+            </Styles.Content>
+        </Styles.Wrapper>
+    );
+}

--- a/packages/react/components/bookmark/src/components/sectionList/SectionList.tsx
+++ b/packages/react/components/bookmark/src/components/sectionList/SectionList.tsx
@@ -7,12 +7,11 @@ import { SharedIcon } from '../shared/SharedIcon';
 import type { Bookmark } from '@equinor/fusion-framework-module-bookmark';
 import { useBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import { useCurrentUser } from '@equinor/fusion-framework-react/hooks';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { delete_to_trash, share, edit, close, update } from '@equinor/eds-icons';
 import { useFramework } from '@equinor/fusion-framework-react';
 import { appendBookmarkIdToUrl } from '../../utils/append-bookmark-to-uri';
 import { filterEmptyGroups, sortByName, toHumanReadable } from '../../utils/utils';
-import { Loading } from '../loading/Loading';
 
 Icon.add({
     delete_to_trash,
@@ -30,18 +29,10 @@ export const SectionList = ({ bookmarkGroups }: SectionListProps) => {
     const { deleteBookmarkById, getCurrentAppKey, updateBookmark, removeBookmarkFavorite } =
         useBookmark();
 
-    const [loading, setLoading] = useState(true);
-
     const user = useCurrentUser();
     const [isMenuByIdOpen, setIsMenuByIdOpen] = useState('');
 
     const { event } = useFramework().modules;
-
-    useEffect(() => {
-        return event.addEventListener('onBookmarksChanged', () => {
-            setLoading(false);
-        });
-    }, [event]);
 
     const editBookmark = useCallback(
         (bookmarkId: string) => {
@@ -80,8 +71,6 @@ export const SectionList = ({ bookmarkGroups }: SectionListProps) => {
             getCurrentAppKey(),
             user?.localAccountId,
         );
-
-    if (loading) return <Loading />;
 
     return (
         <>


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:

Implement a "No Content" message and relocate the "Loading" indicator to the bookmarks component. Additionally, incorporate an effect to handle cases where the "onBookmarksChanged" event is not triggered.

### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
