### PR TITLE
fix(http): Refactor HTTP error handling and JSON parsing

### DIFF
--- a/.changeset/cool-forks-type.md
+++ b/.changeset/cool-forks-type.md
@@ -1,0 +1,21 @@
+---
+'@equinor/fusion-framework-module-http': patch
+---
+
+__Improves error handling when processing json http response__
+
+In packages/modules/http/src/errors.ts:
+- The class HttpResponseError now has a generic parameter TResponse.
+  - Added a static property Name to the class.
+- Added a new class HttpJsonResponseError which extends HttpResponseError and also has generic parameters TType and TResponse.
+  - Added a static property Name to the class.
+  - Added a public property data of type TType.
+  - Modified the constructor to accept an optional data parameter.
+
+In packages/modules/http/src/lib/selectors/json-selector.ts:
+- Added an import statement for HttpJsonResponseError.
+- Modified the jsonSelector function to handle errors when parsing the response.
+  - Added a try-catch block.
+  - Changed the JSON parsing logic to store the parsed data in a variable data.
+  - If the response is not OK, a HttpJsonResponseError is thrown with the appropriate error message, response object, and data property.
+  - If there is an error parsing the response, a HttpJsonResponseError is thrown with the appropriate error message, response object, and cause property.

--- a/packages/modules/http/src/errors.ts
+++ b/packages/modules/http/src/errors.ts
@@ -1,9 +1,32 @@
-export class HttpResponseError extends Error {
+/**
+ * Represents an error that occurs when handling an HTTP response.
+ * @template TResponse The type of the HTTP response.
+ */
+export class HttpResponseError<TResponse = Response> extends Error {
+    static Name = 'HttpResponseError';
     constructor(
-        public message: string,
-        public response: Response,
+        message: string,
+        public readonly response: TResponse,
         options?: ErrorOptions,
     ) {
         super(message, options);
+    }
+}
+
+/**
+ * Represents an error that occurs when handling a JSON response in an HTTP request.
+ * @template TType - The type of the data contained in the response.
+ * @template TResponse - The type of the HTTP response.
+ */
+export class HttpJsonResponseError<
+    TType = unknown,
+    TResponse = Response,
+> extends HttpResponseError<TResponse> {
+    static Name = 'HttpJsonResponseError';
+    public readonly data?: TType;
+    constructor(message: string, response: TResponse, options?: ErrorOptions & { data?: TType }) {
+        super(message, response, options);
+        this.name = HttpJsonResponseError.Name;
+        this.data = options?.data;
     }
 }

--- a/packages/modules/http/src/lib/selectors/json-selector.ts
+++ b/packages/modules/http/src/lib/selectors/json-selector.ts
@@ -1,18 +1,31 @@
-export const jsonSelector = <TType = unknown, TResponse extends Response = Response>(
+import { HttpJsonResponseError } from '../../errors';
+
+/**
+ * Converts the JSON response from an HTTP request into the specified type.
+ * If the response is not OK or if there is an error parsing the response, an error is thrown.
+ * If the response has a status code of 204 (No Content), a resolved Promise is returned.
+ *
+ * @param response The HTTP response object.
+ * @returns A Promise that resolves to the parsed JSON data.
+ * @throws {Error} If the network response is not OK.
+ * @throws {HttpJsonResponseError} If there is an error parsing the response.
+ */
+export const jsonSelector = async <TType = unknown, TResponse extends Response = Response>(
     response: TResponse,
 ): Promise<TType> => {
-    if (!response.ok) {
-        throw new Error('network response was not OK');
-    }
-    //Status code 204 is no content
+    /** Status code 204 is no content */
     if (response.status === 204) {
         return Promise.resolve() as Promise<TType>;
     }
 
     try {
-        return response.json();
-    } catch (err) {
-        throw Error('failed to parse response');
+        const data = await response.json();
+        if (!response.ok) {
+            throw new HttpJsonResponseError('network response was not OK', response, { data });
+        }
+        return data;
+    } catch (cause) {
+        throw new HttpJsonResponseError('failed to parse response', response, { cause });
     }
 };
 


### PR DESCRIPTION
- added `HttpJsonResponseError` which extends `HttpResponseError`
- updated `jsonSelector` to throw `HttpJsonResponseError` on failure

### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
