### PR TITLE
fix: package exports react-module-http

### DIFF
--- a/.changeset/neat-schools-kiss.md
+++ b/.changeset/neat-schools-kiss.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-react-module-http': patch
+---
+
+Fix package exports in react-module-http

--- a/packages/react/modules/http/package.json
+++ b/packages/react/modules/http/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {


### PR DESCRIPTION
## Why
Fixes package exports in react-module-http.

When using the package with `moduleResolution: bundler` you run into the following issue.
```
There are types at 'c:/Users/gustav.eikaas/repo/cc-components/node_modules/@equinor/fusion-framework-react-module-http/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@equinor/fusion-framework-react-module-http' library may need to update its package.json or typings.
```


![image](https://github.com/equinor/fusion-framework/assets/89254170/16f906ca-fa0a-43dd-a0ef-205d09e121b4)
