### PR TITLE
fix: moduleresolution bundler [@equinor/fusion-framework-module-http]

### DIFF
--- a/.changeset/popular-beers-fry.md
+++ b/.changeset/popular-beers-fry.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-http': patch
+---
+
+fix import from non specified export (moduleResolution: bundler)

--- a/packages/modules/http/package.json
+++ b/packages/modules/http/package.json
@@ -20,6 +20,10 @@
         "./selectors": {
             "import": "./dist/esm/lib/selectors/index.js",
             "types": "./dist/types/lib/selectors/index.d.ts"
+        },
+        "./errors": {
+            "import": "./dist/esm/errors.js",
+            "types": "./dist/types/errors.d.ts"
         }
     },
     "typesVersions": {


### PR DESCRIPTION
## Why
Vite gives an error message when using moduleResolution: bundler. The reason is that the package fusion-framework-react-module-http package attempts to import 👇. But the `/errors` export is not specified in package.json

```TS
// @equinor/fusion-framework-react-module-http index.js
export { HttpResponseError, HttpJsonResponseError, } from '@equinor/fusion-framework-module-http/errors';
```


## Testing
I manually added the export declaration in node_modules and my project ran smoothly afterwards