### PR TITLE
Feat/feature flagging/simplify configurator

### DIFF
--- a/.changeset/nice-chairs-remember.md
+++ b/.changeset/nice-chairs-remember.md
@@ -1,0 +1,20 @@
+---
+'@equinor/fusion-framework-module-feature-flag': patch
+---
+
+- Added imports for createApiPlugin and createCgiPlugin from the ./plugins module.
+- Updated the IFeatureFlagConfigurator interface with new method signatures.
+  - The addPlugin method now has a JSDoc comment describing its usage.
+  - The enableCgi method now has a JSDoc comment and parameter description.
+  - The enableApi method now has a JSDoc comment and parameter description.
+- Modified the FeatureFlagConfigurator class:
+  - Added implemented interface IFeatureFlagConfigurator.
+  - Added a private property #plugins as an array of FeatureFlagPluginConfigCallback.
+  - Updated the addPlugin method to append the new plugin handler to the #plugins array.
+  - Added the enableCgi method, which calls createCgiPlugin with the passed arguments and adds the result to the #plugins array.
+  - Added the enableApi method, which does the same for createApiPlugin.
+  - Updated the _processConfig method with additional type annotations and comments.
+  - Added a JSDoc comment for the plugins$ observable.
+  - Added a JSDoc comment for the initial$ observable.
+  - Added a JSDoc comment for the config$ observable.
+  - Updated the return statement to return config$.

--- a/packages/modules/feature-flag/src/FeatureFlagConfigurator.ts
+++ b/packages/modules/feature-flag/src/FeatureFlagConfigurator.ts
@@ -8,26 +8,85 @@ import type {
 } from './types.js';
 import { IFeatureFlag } from './FeatureFlag.js';
 
+import { createApiPlugin, createCgiPlugin } from './plugins';
+
 // TODO allow configurator to have array
 // TODO fix .dot type
 
 export interface IFeatureFlagConfigurator extends BaseConfigBuilder<FeatureFlagConfig> {
-    addPlugin: (handler: FeatureFlagPluginConfigCallback) => void;
+    /**
+     * Adds a plugin to the feature flag configurator.
+     *
+     * You most likely want `enableCgi` or `enableApi`
+     *
+     * @param handler The callback function that configures the feature flag plugin.
+     */
+    addPlugin(handler: FeatureFlagPluginConfigCallback): void;
+    /**
+     * Enables the CGI plugin with the specified arguments.
+     *
+     * @example
+     * ```ts
+     *  configurator.enableCgi(
+     *     'foo-features',
+     *     [
+     *         {
+     *             key: 'foo',
+     *             title: 'Foo Feature',
+     *             description: 'this is the feature',
+     *         }
+     *     ]
+     *  );
+     * ```
+     * @param args - The arguments to be passed to the createCgiPlugin function.
+     */
+    enableCgi(args: Parameters<typeof createCgiPlugin>): void;
+
+    /**
+     * Enables the API plugin with the specified arguments.
+     * @example
+     * ```ts
+     * configurator.enableCgi({
+     *  // see http-module
+     *  httpClientName: 'my-api-client',
+     *  path: '/api/features',
+     *  selector: myHttpResponseSelector
+     * });
+     * ```
+     * @param args - The arguments to pass to the createApiPlugin function.
+     */
+    enableApi(args: Parameters<typeof createApiPlugin>): void;
 }
 
-export class FeatureFlagConfigurator extends BaseConfigBuilder<FeatureFlagConfig> {
-    // implements IFeatureFlagConfigurator
+export class FeatureFlagConfigurator
+    extends BaseConfigBuilder<FeatureFlagConfig>
+    implements IFeatureFlagConfigurator
+{
+    /**
+     * Array of feature flag plugin configuration callbacks.
+     */
     #plugins: FeatureFlagPluginConfigCallback[] = [];
 
     public addPlugin(handler: FeatureFlagPluginConfigCallback) {
         this.#plugins.push(handler);
     }
 
+    public enableCgi(args: Parameters<typeof createCgiPlugin>) {
+        this.addPlugin(createCgiPlugin(...args));
+    }
+
+    public enableApi(args: Parameters<typeof createApiPlugin>) {
+        this.addPlugin(createApiPlugin(...args));
+    }
+
     protected _processConfig(
         config: Partial<FeatureFlagConfig>,
         init: ConfigBuilderCallbackArgs,
     ): Observable<FeatureFlagConfig> {
-        const plugins$ = from(this.#plugins).pipe(
+        /**
+         * Observable stream that emits the initialized plugins.
+         */
+        const plugins$: Observable<Array<FeatureFlagPlugin>> = from(this.#plugins).pipe(
             /** initialize plugins */
             mergeMap((plugin) => plugin(init)),
             reduce((acc, plugin) => {
@@ -38,22 +97,32 @@ export class FeatureFlagConfigurator extends BaseConfigBuilder<FeatureFlagConfig
             share(),
         );
 
-        return forkJoin({
-            initial: plugins$.pipe(
-                concatMap((plugins) =>
-                    from(plugins).pipe(
-                        /** only get initial value from plugins that support functionality */
-                        filter((x) => !!x.initial),
-                        concatMap((x) => x.initial!()),
-                        reduce((acc, items) => {
-                            acc.push(...items);
-                            return acc;
-                        }, [] as IFeatureFlag[]),
-                    ),
+        /**
+         * Observable stream that emits the initial feature flags based on the plugins.
+         */
+        const initial$: Observable<IFeatureFlag[]> = plugins$.pipe(
+            concatMap((plugins) =>
+                from(plugins).pipe(
+                    /** only get initial value from plugins that support functionality */
+                    filter((x) => !!x.initial),
+                    concatMap((x) => x.initial!()),
+                    reduce((acc, items) => {
+                        acc.push(...items);
+                        return acc;
+                    }, [] as IFeatureFlag[]),
                 ),
             ),
+        );
+
+        /**
+         * Observable that emits the merged configuration of initial feature flags and plugins.
+         */
+        const config$: Observable<FeatureFlagConfig> = forkJoin({
+            initial: initial$,
             plugins: plugins$,
         }).pipe(map((resolve) => ({ ...config, ...resolve })));
+
+        return config$;
     }
 }
 


### PR DESCRIPTION
## Why
- Added imports for createApiPlugin and createCgiPlugin from the ./plugins module.
- Updated the IFeatureFlagConfigurator interface with new method signatures.
  - The addPlugin method now has a JSDoc comment describing its usage.
  - The enableCgi method now has a JSDoc comment and parameter description.
  - The enableApi method now has a JSDoc comment and parameter description.
- Modified the FeatureFlagConfigurator class:
  - Added implemented interface IFeatureFlagConfigurator.
  - Added a private property #plugins as an array of FeatureFlagPluginConfigCallback.
  - Updated the addPlugin method to append the new plugin handler to the #plugins array.
  - Added the enableCgi method, which calls createCgiPlugin with the passed arguments and adds the result to the #plugins array.
  - Added the enableApi method, which does the same for createApiPlugin.
  - Updated the _processConfig method with additional type annotations and comments.
  - Added a JSDoc comment for the plugins$ observable.
  - Added a JSDoc comment for the initial$ observable.
  - Added a JSDoc comment for the config$ observable.
  - Updated the return statement to return config$.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
