### PR TITLE
fix(bookmark-module): fixing the infinite loading 

### DIFF
--- a/.changeset/sixty-spies-flow.md
+++ b/.changeset/sixty-spies-flow.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-bookmark': minor
+---
+
+Fixing the infinite loading if a bookmark is created in classic fusion and allowing for sourceSystem to be undefined.

--- a/packages/modules/bookmark/src/client/bookmarkClient.ts
+++ b/packages/modules/bookmark/src/client/bookmarkClient.ts
@@ -43,7 +43,7 @@ export class BookmarkClient {
 
     #currentBookmark$: BehaviorSubject<Bookmark<unknown> | undefined>;
 
-    #sourceSystem: SourceSystem;
+    #sourceSystem?: SourceSystem;
     #event?: IEventModuleProvider;
 
     #state: FlowState<State, ActionBuilder>;
@@ -53,7 +53,7 @@ export class BookmarkClient {
 
     constructor(
         config: BookmarkClientConfig,
-        sourceSystem: SourceSystem,
+        sourceSystem?: SourceSystem,
         event?: IEventModuleProvider,
     ) {
         this.#currentBookmark$ = new BehaviorSubject<Bookmark<unknown> | undefined>(undefined);
@@ -293,7 +293,7 @@ export class BookmarkClient {
     #addSubjectFlows() {
         this.#subscriptions.add(
             this.#state.subject.addFlow(
-                handleBookmarkGetAll(this.#queryAllBookmarks, this.#sourceSystem.identifier),
+                handleBookmarkGetAll(this.#queryAllBookmarks, this.#sourceSystem?.identifier),
             ),
         );
         this.#subscriptions.add(

--- a/packages/modules/bookmark/src/client/bookmarkFlows.ts
+++ b/packages/modules/bookmark/src/client/bookmarkFlows.ts
@@ -10,7 +10,7 @@ import { actions, Actions } from './bookmarkActions';
 export const handleBookmarkGetAll =
     (
         queryAllBookmarks: Query<Array<Bookmark<unknown>>, GetAllBookmarksParameters>,
-        sourceSystemIdentifier: string,
+        sourceSystemIdentifier?: string,
     ) =>
     (action$: Observable<Actions>) =>
         action$.pipe(
@@ -22,7 +22,7 @@ export const handleBookmarkGetAll =
                         actions.getAll.success(
                             bookmarks.value.filter(
                                 (bookmark) =>
-                                    bookmark.sourceSystem.identifier === sourceSystemIdentifier,
+                                    bookmark.sourceSystem?.identifier === sourceSystemIdentifier,
                             ),
                         ),
                     ),

--- a/packages/modules/bookmark/src/configurator.ts
+++ b/packages/modules/bookmark/src/configurator.ts
@@ -16,7 +16,7 @@ export interface BookmarkModuleConfig {
      *  SourceSystem used when creating a new bookmark,
      *  used as the identifier for the current client. Only used in app shell / portal configuration.
      */
-    sourceSystem: SourceSystem;
+    sourceSystem?: SourceSystem;
 
     /**
      *  The clintConfiguration consist of both Api client configuration and query client configuration
@@ -120,10 +120,6 @@ export class BookmarkModuleConfigurator implements IBookmarkModuleConfigurator {
             init,
             config.clientConfiguration,
         );
-
-        if (!config.sourceSystem) {
-            throw Error('missing sourceSystem configuration');
-        }
 
         return config as BookmarkModuleConfig;
     }

--- a/packages/modules/bookmark/src/types.ts
+++ b/packages/modules/bookmark/src/types.ts
@@ -16,7 +16,7 @@ export interface Bookmark<TData = unknown> {
     updatedBy: CreatedBy;
     created: string;
     updated: string;
-    sourceSystem: SourceSystem;
+    sourceSystem?: SourceSystem;
 }
 
 export type CreateBookmark<TData = unknown> = {


### PR DESCRIPTION
fixing the infinite loading if a bookmark is created in classic fusion.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes: 

The `sourceSystem` form fusion classic is undefined this results in a filter function failing and not returning any bookmarks resulting in a infinite spinner. This simple fix will fix it and return other bookmarks.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
