### PR TITLE
fix(utils-observable): fix action suffix matcher

### DIFF
--- a/.changeset/green-chicken-rush.md
+++ b/.changeset/green-chicken-rush.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+fixed issue with invalid regex pattern for matching suffix on actions

--- a/packages/utils/observable/src/create-action.ts
+++ b/packages/utils/observable/src/create-action.ts
@@ -255,7 +255,7 @@ export function createAction(type: string, prepareAction?: PrepareAction<any>): 
 export const actionSuffixDivider = '::';
 
 export const matchActionSuffix = (suffix: string) =>
-    new RegExp(`${actionSuffixDivider}\\${suffix}$`);
+    new RegExp(`${actionSuffixDivider}${suffix}$`);
 
 export const actionBaseType = (action: Action) =>
     action.type.replace(matchActionSuffix('\\w+$'), '');

--- a/packages/utils/observable/src/create-action.ts
+++ b/packages/utils/observable/src/create-action.ts
@@ -254,8 +254,7 @@ export function createAction(type: string, prepareAction?: PrepareAction<any>): 
 
 export const actionSuffixDivider = '::';
 
-export const matchActionSuffix = (suffix: string) =>
-    new RegExp(`${actionSuffixDivider}${suffix}$`);
+export const matchActionSuffix = (suffix: string) => new RegExp(`${actionSuffixDivider}${suffix}$`);
 
 export const actionBaseType = (action: Action) =>
     action.type.replace(matchActionSuffix('\\w+$'), '');


### PR DESCRIPTION
## Why

fix action suffix matcher

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
