### PR TITLE
fix(module-app): improve type of current application

### DIFF
--- a/.changeset/few-dragons-do.md
+++ b/.changeset/few-dragons-do.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+improve type of current application
+
+- result will be `undefined` if current application has never been set
+- result will be `IApplication` if current application is set
+- result will be `null` if current application is cleared

--- a/packages/modules/app/src/AppModuleProvider.ts
+++ b/packages/modules/app/src/AppModuleProvider.ts
@@ -32,7 +32,7 @@ export class AppModuleProvider {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     #configClient: Query<AppConfig<any>, { appKey: string; tag?: string }>;
 
-    #current$: BehaviorSubject<CurrentApp>;
+    #current$: BehaviorSubject<CurrentApp | null>;
 
     #subscription = new Subscription();
 
@@ -41,12 +41,15 @@ export class AppModuleProvider {
     /**
      * fetch an application by key
      * @param appKey - application key
+     * @remarks
+     * - null when current app is cleared
+     * - undefined if application never set
      */
-    get current(): CurrentApp {
+    get current(): CurrentApp | null | undefined {
         return this.#current$.value;
     }
 
-    get current$(): Observable<CurrentApp> {
+    get current$(): Observable<CurrentApp | null> {
         return this.#current$.pipe(
             distinctUntilChanged((prev, next) => {
                 if (prev && next) {


### PR DESCRIPTION
## Why

improve type of current application

- result will be `undefined` if current application has never been set
- result will be `IApplication` if current application is set
- result will be `null` if current application is cleared

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
