### PR TITLE
improve handling of initial value when using `useObservableState`

### DIFF
--- a/.changeset/breezy-points-beg.md
+++ b/.changeset/breezy-points-beg.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+improve handling of initial value when using `useObservableState`


### PR DESCRIPTION
## Why

hook return `undefined` as value in the first `tick` _(useLayoutEffect)_ 


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [x] Confirm project selected and category, actual, iteration are set
- [x] Confirm Milestone selected _(if any)_
