### PR TITLE
Fusion/issues/285

### DIFF
--- a/.changeset/funny-sheep-impress.md
+++ b/.changeset/funny-sheep-impress.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Added functionality for enabling feature flagging
+
+```ts
+import { enableFeatureFlag } from `@equinor/fusion-framework-react-app/feature-flag`
+enableFeatureFlag(confgurator, [{
+  id: 'my-flag',
+  title: 'My flag'
+}])
+```
+
+the user still needs to install `@equinor/fusion-framework-module-feature-flag`

--- a/.changeset/little-seas-brush.md
+++ b/.changeset/little-seas-brush.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-app": minor
+---
+
+removed `useFeatureFlags` from `AppConfigurator` since caused issued for users without installing feature-flag module

--- a/.changeset/rude-cheetahs-scream.md
+++ b/.changeset/rude-cheetahs-scream.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-feature-flag": patch
+---
+
+updated storybook for enabling feature flag

--- a/cookbooks/app-react-feature-flag/src/config.ts
+++ b/cookbooks/app-react-feature-flag/src/config.ts
@@ -1,9 +1,10 @@
 import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
+import { enableFeatureFlag } from '@equinor/fusion-framework-react-app/feature-flag';
 
 import { Feature } from './static';
 
 export const configure: AppModuleInitiator = (appConfigurator) => {
-    appConfigurator.useFeatureFlags([
+    enableFeatureFlag(appConfigurator, [
         {
             key: Feature.Basic,
             title: 'Basic',

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -4,35 +4,3 @@
 
 ## 📚 read the [Doc](https://equinor.github.io/fusion-framework/)
 
-## Feature Flag
-
-> [!IMPORTANT]
-> `@equinor/fusion-framework-module-feature-flag` must be installed to make this module available
-
-### Simple
-```ts
-export const configure: ModuleInitiator = (appConfigurator, args) => {
-  /** provide a list of features that should be available in the application */
-  appConfigurator.useFeatureFlags([
-    {
-      key: MyFeatures.MyFlag,
-      title: 'this is a flag',
-    },
-    {
-      key: MyFeatures.MyUrlFlag,
-      title: 'this feature can be toggled by ?my-url-flag=true',
-      allowUrl: true,
-    }
-  ]);
-}
-```
-
-### Custom
-```ts
-export const configure: ModuleInitiator = (appConfigurator, args) => {
-  appConfigurator.useFeatureFlags(builder => /** see module for building custom config */);
-}
-```
-
-[see module](../modules/feature-flag/README.md) for more technical information;
-

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,7 +40,6 @@
         "@equinor/fusion-framework-module-msal": "workspace:^"
     },
     "devDependencies": {
-        "@equinor/fusion-framework-module-feature-flag": "workspace:^",
         "typescript": "^5.1.3"
     },
     "peerDependencies": {

--- a/packages/react/app/README.md
+++ b/packages/react/app/README.md
@@ -90,3 +90,36 @@ const App = () => {
   
 }
 ```
+
+## Feature Flag
+
+> [!IMPORTANT]
+> `@equinor/fusion-framework-module-feature-flag` must be installed to make this module available
+
+### Simple
+```ts
+import { enableFeatureFlag } from '@equinor/fusion-framework-react-app/feature-flag'; 
+export const configure: ModuleInitiator = (appConfigurator, args) => {
+  /** provide a list of features that should be available in the application */
+  enableFeatureFlag(appConfigurator, [
+    {
+      key: MyFeatures.MyFlag,
+      title: 'this is a flag',
+    },
+    {
+      key: MyFeatures.MyUrlFlag,
+      title: 'this feature can be toggled by ?my-url-flag=true',
+      allowUrl: true,
+    }
+  ]);
+}
+```
+
+### Custom
+```ts
+export const configure: ModuleInitiator = (appConfigurator, args) => {
+  appConfigurator.useFeatureFlags(builder => /** see module for building custom config */);
+}
+```
+
+[see module](../modules/feature-flag/README.md) for more technical information;

--- a/packages/react/app/src/feature-flag/enable-feature-flag.ts
+++ b/packages/react/app/src/feature-flag/enable-feature-flag.ts
@@ -1,0 +1,76 @@
+import { type AppConfigurator, type IAppConfigurator } from '@equinor/fusion-framework-app';
+
+import {
+    enableFeatureFlagging,
+    type FeatureFlagBuilderCallback,
+    type IFeatureFlag,
+} from '@equinor/fusion-framework-module-feature-flag';
+
+import {
+    createLocalStoragePlugin,
+    createUrlPlugin,
+} from '@equinor/fusion-framework-module-feature-flag/plugins';
+
+/**
+ * Enables the specified feature flags.
+ *
+ * @param configurator - The AppConfigurator instance.
+ * @param flags - An array of feature flags to enable.
+ */
+export interface enableFeatureFlag {
+    (
+        configurator: IAppConfigurator,
+        flags: Array<IFeatureFlag<unknown> & { allowUrl?: boolean | undefined }>,
+    ): void;
+}
+
+/**
+ * Enables a feature flag by invoking the provided configurator and callback.
+ *
+ * @param configurator - The AppConfigurator responsible for configuring the feature flag.
+ * @param cb - The FeatureFlagBuilderCallback to be executed for the feature flag.
+ *
+ * @remarks
+ * Advance use __ONLY__
+ */
+export interface enableFeatureFlag {
+    (configurator: IAppConfigurator, cb: FeatureFlagBuilderCallback): void;
+}
+
+/**
+ * Enables feature flagging based on the provided configurator and flags callback.
+ * @param configurator The AppConfigurator instance.
+ * @param flags_cb Optional flags callback that can be an array of feature flags or a callback function.
+ */
+export function enableFeatureFlag(
+    configurator: IAppConfigurator,
+    flags_cb:
+        | Array<IFeatureFlag<unknown> & { allowUrl?: boolean | undefined }>
+        | FeatureFlagBuilderCallback,
+): void {
+    switch (typeof flags_cb) {
+        case 'function': {
+            enableFeatureFlagging(configurator, flags_cb);
+            break;
+        }
+        case 'object': {
+            const urlFlags: IFeatureFlag[] = [];
+            const localFlags = (flags_cb ?? []).map((flag) => {
+                const { allowUrl, ...localFlag } = flag;
+                if (allowUrl) {
+                    urlFlags.push(flag);
+                }
+                return localFlag;
+            });
+            enableFeatureFlagging(configurator, async (builder) => {
+                builder.addPlugin(
+                    createLocalStoragePlugin(localFlags, {
+                        name: (configurator as AppConfigurator).env?.manifest.key,
+                    }),
+                );
+                builder.addPlugin(createUrlPlugin(urlFlags));
+            });
+            break;
+        }
+    }
+}

--- a/packages/react/app/src/feature-flag/index.ts
+++ b/packages/react/app/src/feature-flag/index.ts
@@ -3,4 +3,7 @@ export {
     IFeatureFlagProvider,
     FeatureFlagModule,
 } from '@equinor/fusion-framework-module-feature-flag';
+
+export { enableFeatureFlag } from './enable-feature-flag';
+
 export { useFeature } from './useFeature';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       '@equinor/fusion-framework-module-event':
         specifier: workspace:^
         version: link:../modules/event
+      '@equinor/fusion-framework-module-feature-flag':
+        specifier: workspace:^
+        version: link:../modules/feature-flag
       '@equinor/fusion-framework-module-http':
         specifier: workspace:^
         version: link:../modules/http
@@ -450,9 +453,6 @@ importers:
         specifier: workspace:^
         version: link:../modules/msal
     devDependencies:
-      '@equinor/fusion-framework-module-feature-flag':
-        specifier: workspace:^
-        version: link:../modules/feature-flag
       typescript:
         specifier: ^5.1.3
         version: 5.3.3


### PR DESCRIPTION
## Why

### @equinor/fusion-framework-app - minor

removed `useFeatureFlags` from `AppConfigurator` since caused issued for users without installing feature-flag module

> [!CAUTION]
> breaking changes: assumes no one has implemented this yet

### @equinor/fusion-framework-react-app - patch

Added functionality for enabling feature flagging

```ts
import { enableFeatureFlag } from `@equinor/fusion-framework-react-app/feature-flag`
enableFeatureFlag(confgurator, [{
  id: 'my-flag',
  title: 'My flag'
}])
```

the user still needs to install `@equinor/fusion-framework-module-feature-flag`


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
