### PR TITLE
fix(cli): allow providing resources in defineAppManifest

### DIFF
--- a/.changeset/wicked-plants-joke.md
+++ b/.changeset/wicked-plants-joke.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+support resources in `defineAppManifest`
+
+ref [issue 286](https://github.com/equinor/fusion/issues/286#issuecomment-1923401234)

--- a/packages/cli/src/lib/app-manifest.ts
+++ b/packages/cli/src/lib/app-manifest.ts
@@ -30,6 +30,8 @@ export type AppManifest = {
     owners?: string[];
     main?: string;
     icon?: string;
+    /** this will be deprecated when new app management is live  */
+    resource?: string[];
 };
 
 export type AppManifestFn = (


### PR DESCRIPTION
## Why
missing legacy `resources` in defineAppManifest

see [issue 286](https://github.com/equinor/fusion/issues/286#issuecomment-1923401234)



### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
