### PR TITLE
fix(legacy-interopt): remove script injection

### DIFF
--- a/.changeset/hungry-needles-drop.md
+++ b/.changeset/hungry-needles-drop.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-legacy-interopt": major
+---
+
+`LegacyAppContainer` no longer injects script for loading application when setting current application
+
+> the application should be loaded by the app loader component, not the state container

--- a/packages/react/legacy-interopt/src/LegacyAppContainer.ts
+++ b/packages/react/legacy-interopt/src/LegacyAppContainer.ts
@@ -284,14 +284,6 @@ export class LegacyAppContainer extends EventEmitter<AppContainerEvents> {
 
     async setCurrentAppAsync(appKey: string | null): Promise<void> {
         if (appKey) {
-            const { AppComponent, render } = this.get(appKey) || {};
-            /**
-             * assume if the manifest missing AppComponent or render, that loading is required
-             */
-            if (!!AppComponent && !!render) {
-                await this.#loadScript(appKey);
-            }
-            await new Promise((resolve) => window.requestAnimationFrame(resolve));
             const manifest = this.get(appKey) as unknown as AppManifest;
             const appProvider = this.#framework.modules.app;
             const currentApp = appProvider.current;
@@ -347,8 +339,6 @@ export class LegacyAppContainer extends EventEmitter<AppContainerEvents> {
     }
 
     async #loadScript(appKey: string): Promise<void> {
-        // const { uri } = await this.#framework.modules.serviceDiscovery.resolveService('portal');
-        // const source = new URL(`/bundles/apps/${appKey}.js`, uri);
         return new Promise((resolve, reject) => {
             const script = document.createElement('script');
             script.async = true;


### PR DESCRIPTION
## Why
Some users on IE would get stuck in loading since `setCurrentAppAsync` await injection of script _(which might previously been loaded)_

> [!CAUTION]
> the host (portal) need to load the application script

closes:

BREAKING CHANGE: `setCurrentAppAsync` no longer injects script for loading application

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

#### Conditional
- [ ] Confirm project selected and category, actual, iteration are set
- [ ] Confirm Milestone selected _(if any)_
