### PR TITLE
docs: add reviewing guidelines

### DIFF
--- a/contributing/reviewing.md
+++ b/contributing/reviewing.md
@@ -1,0 +1,23 @@
+---
+title: reviewing
+---
+
+checklist:
+
+- [ ] The creator has created well-formed description
+  - The creator has checked all required checks
+  - Referenced associated issue(s)
+- [ ] All required checks passes
+- [ ] Check that the code contains [changeset](./changeset.md)
+- [ ] Make sure that the code is in the scope of the issue
+
+Code Quality:
+
+- [ ] All exported functionality has documentation
+- [ ] Does code follow best practices
+  - Keep it simple
+  - Complex implementations are documented
+  - Are all dependencies required?
+  - Potential breaking changes?
+  - Does the code potentially introduce bugs
+  


### PR DESCRIPTION
## Why
Ads reviewing guidelines
closes:


### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

