### PR TITLE
fix(exports): make sure all packages have proper export syntax

### DIFF
--- a/.changeset/tall-apples-build.md
+++ b/.changeset/tall-apples-build.md
@@ -1,0 +1,18 @@
+---
+"@equinor/fusion-framework-react-components-people-provider": patch
+"@equinor/fusion-framework-react-components-bookmark": patch
+"@equinor/fusion-framework-react-module-signalr": patch
+"@equinor/fusion-framework-react-module": patch
+"@equinor/fusion-framework-react-module-event": patch
+"@equinor/fusion-framework-module-services": patch
+"@equinor/fusion-framework-react": patch
+"@equinor/fusion-framework-module-event": patch
+"@equinor/fusion-framework-react-widget": patch
+"@equinor/fusion-framework": patch
+"@equinor/fusion-framework-react-app": patch
+"@equinor/fusion-framework-widget": patch
+"@equinor/fusion-framework-app": patch
+"@equinor/fusion-framework-cli": patch
+---
+
+Align package exports with node10+ documentation.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vitest-github-actions-reporter": "^0.11.1"
   },
   "peerDependencies": {
-    "typescript": ">=4.5"
+    "typescript": ">=4.8"
   },
   "workspaces": {
     "packages": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,10 +3,13 @@
     "version": "9.0.0",
     "description": "",
     "main": "dist/esm/index.js",
-    "exports": {
-        ".": "./dist/esm/index.js"
-    },
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/types/index.d.ts",
+            "import": "./dist/esm/index.js"
+        }
+    },
     "scripts": {
         "build": "tsc -b",
         "prepack": "pnpm build"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,17 +12,17 @@
         "access": "public"
     },
     "type": "module",
-    "main": "./bin/main.js",
     "bin": {
         "fusion-framework-cli": "./bin/cli.mjs"
     },
+    "main": "./bin/main.js",
+    "types": "./dist/types/lib/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/types/lib/index.d.ts",
             "import": "./dist/lib/index.js"
         }
     },
-    "types": "./dist/types/lib/index.d.ts",
     "scripts": {
         "prebuild": "pnpm build:source",
         "build": "pnpm build:source && pnpm build:dev-server",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -3,13 +3,13 @@
     "version": "7.1.0",
     "description": "",
     "main": "dist/esm/index.js",
+    "types": "dist/types/index.d.ts",
     "exports": {
         ".": {
             "import": "./dist/esm/index.js",
             "types": "./dist/types/index.d.ts"
         }
     },
-    "types": "dist/types/index.d.ts",
     "scripts": {
         "build": "tsc -b",
         "prepack": "pnpm build"

--- a/packages/modules/event/package.json
+++ b/packages/modules/event/package.json
@@ -4,6 +4,12 @@
     "description": "Fusion module for events",
     "main": "./dist/esm/index.js",
     "module": "./dist/esm/index.js",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
+    },
     "scripts": {
         "build": "tsc -b",
         "prepack": "pnpm build"

--- a/packages/modules/services/package.json
+++ b/packages/modules/services/package.json
@@ -54,17 +54,25 @@
             "import": "./dist/esm/context/index.js",
             "types": "./dist/types/context/index.d.ts"
         },
-        "./bookmark": {
+        "./context/get": {
+            "import": "./dist/esm/context/get/index.js",
+            "types": "./dist/types/context/get/index.d.ts"
+        },
+        "./context/query": {
+            "import": "./dist/esm/context/query/index.js",
+            "types": "./dist/types/context/query/index.d.ts"
+        },
+        "./context/related": {
+            "import": "./dist/esm/context/related/index.js",
+            "types": "./dist/types/context/related/index.d.ts"
+        },
+        "./bookmarks": {
             "import": "./dist/esm/bookmarks/index.js",
             "types": "./dist/types/bookmarks/index.d.ts"
         },
         "./notification": {
             "import": "./dist/esm/notification/index.js",
             "types": "./dist/types/notification/index.d.ts"
-        },
-        "./context/get": {
-            "import": "./dist/esm/context/get/index.js",
-            "types": "./dist/types/context/get/index.d.ts"
         },
         "./people": {
             "import": "./dist/esm/people/index.js",

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -42,6 +42,34 @@
             "import": "./dist/esm/widget/index.js"
         }
     },
+    "typesVersions": {
+        "*": {
+            "bookmark": [
+                "dist/types/bookmark/index.d.ts"
+            ],
+            "context": [
+                "dist/types/context/index.d.ts"
+            ],
+            "feature-flag": [
+                "dist/types/feature-flag/index.d.ts"
+            ],
+            "framework": [
+                "dist/types/framework/index.d.ts"
+            ],
+            "http": [
+                "dist/types/http/index.d.ts"
+            ],
+            "msal": [
+                "dist/types/msal/index.d.ts"
+            ],
+            "navigation": [
+                "dist/types/navigation/index.d.ts"
+            ],
+            "widget": [
+                "dist/types/widget/index.d.ts"
+            ]
+        }
+    },
     "scripts": {
         "build": "tsc -b",
         "prepack": "pnpm build"
@@ -83,9 +111,9 @@
     },
     "peerDependencies": {
         "@equinor/fusion-framework-module-msal": "workspace:^",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
         "rxjs": "^7.8.1"
     },
     "peerDependenciesMeta": {

--- a/packages/react/components/bookmark/package.json
+++ b/packages/react/components/bookmark/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {
@@ -44,8 +47,8 @@
         "@equinor/eds-icons": "^0.21.0",
         "@equinor/eds-tokens": "^0.9.2",
         "@equinor/eds-utils": "^0.8.3",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
         "styled-components": "^6.0.7"
     },
     "peerDependenciesMeta": {

--- a/packages/react/components/people-resolver/package.json
+++ b/packages/react/components/people-resolver/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {
@@ -40,8 +43,8 @@
         "typescript": "^5.4.2"
     },
     "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/react/framework/package.json
+++ b/packages/react/framework/package.json
@@ -4,13 +4,34 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js",
-        "./app": "./dist/esm/app/index.js",
-        "./feature-flag": "./dist/esm/feature-flag/index.js",
-        "./context": "./dist/esm/context/index.js",
-        "./hooks": "./dist/esm/hooks/index.js",
-        "./http": "./dist/esm/http/index.js",
-        "./signalr": "./dist/esm/signalr/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        },
+        "./app": {
+            "import": "./dist/esm/app/index.js",
+            "types": "./dist/types/app/index.d.ts"
+        },
+        "./feature-flag": {
+            "import": "./dist/esm/feature-flag/index.js",
+            "types": "./dist/types/feature-flag/index.d.ts"
+        },
+        "./context": {
+            "import": "./dist/esm/context/index.js",
+            "types": "./dist/types/context/index.d.ts"
+        },
+        "./hooks": {
+            "import": "./dist/esm/hooks/index.js",
+            "types": "./dist/types/hooks/index.d.ts"
+        },
+        "./http": {
+            "import": "./dist/esm/http/index.js",
+            "types": "./dist/types/http/index.d.ts"
+        },
+        "./signalr": {
+            "import": "./dist/esm/signalr/index.js",
+            "types": "./dist/types/signalr/index.d.ts"
+        }
     },
     "types": "dist/types/index.d.ts",
     "typesVersions": {

--- a/packages/react/modules/event/package.json
+++ b/packages/react/modules/event/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {
@@ -35,9 +38,9 @@
         "typescript": "^5.4.2"
     },
     "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/react/modules/module/package.json
+++ b/packages/react/modules/module/package.json
@@ -3,7 +3,10 @@
     "version": "3.1.0",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {
@@ -36,9 +39,9 @@
         "typescript": "^5.4.2"
     },
     "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/react/modules/signalr/package.json
+++ b/packages/react/modules/signalr/package.json
@@ -13,7 +13,10 @@
         }
     },
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "scripts": {
         "build": "tsc -b",
@@ -40,8 +43,8 @@
     },
     "peerDependencies": {
         "@equinor/fusion-framework-react-module": "workspace:^",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/react/widget/package.json
+++ b/packages/react/widget/package.json
@@ -4,6 +4,12 @@
     "description": "",
     "main": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
+    },
     "scripts": {
         "build": "tsc -b",
         "prepack": "pnpm build"

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -4,7 +4,10 @@
     "description": "",
     "main": "dist/esm/index.js",
     "exports": {
-        ".": "./dist/esm/index.js"
+        ".": {
+            "import": "./dist/esm/index.js",
+            "types": "./dist/types/index.d.ts"
+        }
     },
     "types": "./dist/types/index.d.ts",
     "scripts": {


### PR DESCRIPTION
## Why
Not all packages had correct exports defined according to node(10+) documentation.

This should make sure we support developers setting tsconfig moduleResolution to both node and node(16|Next).

Reference #1968 


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

