### PR TITLE
Fix/cli/css/section/zindex

### DIFF
--- a/.changeset/tidy-masks-occur.md
+++ b/.changeset/tidy-masks-occur.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Removes z-index from apploader section to make ContextSelector dropdown usable again

--- a/packages/cli/src/bin/dev-portal/Router.tsx
+++ b/packages/cli/src/bin/dev-portal/Router.tsx
@@ -27,7 +27,6 @@ const Styled = {
         overflow: auto;
         position: relative;
         max-width: 100%;
-        z-index: 1;
         display: grid;
     `,
 };


### PR DESCRIPTION
## Why
Fixes contextselector being hidden behind app section in CLI.

closes: https://github.com/equinor/fusion/issues/331

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

