### PR TITLE
Fix/modules/package type module

### DIFF
--- a/.changeset/young-coats-wonder.md
+++ b/.changeset/young-coats-wonder.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-http": patch
+---
+
+Removing type module in package.json

--- a/packages/modules/http/package.json
+++ b/packages/modules/http/package.json
@@ -4,7 +4,6 @@
     "description": "",
     "main": "dist/esm/index.js",
     "types": "index.d.ts",
-    "type": "module",
     "exports": {
         ".": {
             "import": "./dist/esm/index.js",


### PR DESCRIPTION
## Why
Removes ``"type": "module"`` in package.json in module-http
Caused issues on portal when building so no pr builds are getting trough.

Ref: [AB#48502](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/48502)

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

