### PR TITLE
fix: crashing if process.env is undefined

### DIFF
--- a/.changeset/metal-squids-give.md
+++ b/.changeset/metal-squids-give.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-query": patch
+---
+
+fix an issue where an exception was thrown if process.env was undefined

--- a/packages/utils/query/src/logger.ts
+++ b/packages/utils/query/src/logger.ts
@@ -56,7 +56,7 @@ export class ConsoleLogger implements ILogger {
         protected title: string,
         protected subtitle?: string,
     ) {
-        if (process.env.FUSION_LOG_LEVEL) {
+        if (process?.env?.FUSION_LOG_LEVEL) {
             this.level = parseInt(process.env.FUSION_LOG_LEVEL) as 0 | 1 | 2 | 3 | 4;
         } else {
             this.level = process.env.NODE_ENV === 'development' ? 3 : 1;


### PR DESCRIPTION
## Context:
Fixes a bug we encountered in equinor/cc-components where apps would fail in the test environment with an error message of failed to read property of undefined. process.env.....

Line that errored in production
![image](https://github.com/equinor/fusion-framework/assets/89254170/f69919f0-2fed-4d10-bdc9-7a36025d1b43)

## Solution
Added conditional access (?.) to process.env.fusion_log_level

## Impact
No changes required by consumers
