### PR TITLE
fix: update FUSION_LOG_LEVEL configuration in vite config generation

### DIFF
--- a/.changeset/tricky-carpets-rush.md
+++ b/.changeset/tricky-carpets-rush.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-query": patch
+"@equinor/fusion-framework-cli": patch
+---
+
+Fixed issue with missing process env `FUSION_LOG_LEVEL`
+
+- added default resolve value when generating base vite configuration
+- moved default query log level resolve outside class
+
+fixes: https://github.com/equinor/fusion/issues/343

--- a/packages/cli/src/lib/vite-config.ts
+++ b/packages/cli/src/lib/vite-config.ts
@@ -87,6 +87,8 @@ export const createViteConfig = async (
             tsconfigPaths(),
             viteEnv({
                 NODE_ENV: env.mode,
+                FUSION_LOG_LEVEL:
+                    process.env.FUSION_LOG_LEVEL ?? env.mode === 'development' ? '3' : '1',
             }),
         ],
         root,

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -13,10 +13,5 @@ export default defineConfig({
     build: {
         outDir: fileURLToPath(new URL('./dist/bin/public', import.meta.url)),
         emptyOutDir: true,
-        // minify: false,
-        // terserOptions: {
-            //     mangle: false,
-        // },
     },
-    // mode: 'development',
 });

--- a/packages/utils/query/README.md
+++ b/packages/utils/query/README.md
@@ -187,6 +187,22 @@ subscription.unsubscribe();
 query.complete();
 ```
 
+## Setup
+
+When compiling code the `FUSION_LOG_LEVEL` must be set (depending on build util, example shown for Vite)
+
+`Uncaught ReferenceError: process is not defined`
+
+```ts
+defineConfig({
+    plugins: [
+        tsconfigPaths(),
+        viteEnv({
+            FUSION_LOG_LEVEL: process.env.FUSION_LOG_LEVEL ?? process.env.NODE_ENV === 'development' ? '3' : '1'
+        }),
+    ]
+})
+
 ## Advanced Usage
 
 ### Queue Operators

--- a/packages/utils/query/src/logger.ts
+++ b/packages/utils/query/src/logger.ts
@@ -43,9 +43,15 @@ export interface ILogger {
     createSubLogger(domain: string): ILogger;
 }
 
+const defaultLogLevel = process.env.FUSION_LOG_LEVEL
+    ? (Number(process.env.FUSION_LOG_LEVEL) as 0 | 1 | 2 | 3 | 4)
+    : process.env.NODE_ENV === 'development'
+      ? 3
+      : 1;
+
 export class ConsoleLogger implements ILogger {
-    /** - 0-1-2-3 (error-warning-info-debug) if not provided only errors are logged */
-    public level: 0 | 1 | 2 | 3 | 4;
+    /** - 0-1-2-3 (off-error-warning-info-debug) if not provided only errors are logged */
+    public level: 0 | 1 | 2 | 3 | 4 = defaultLogLevel;
 
     /**
      * Constructs a new ConsoleLogger instance.
@@ -55,13 +61,7 @@ export class ConsoleLogger implements ILogger {
     constructor(
         protected title: string,
         protected subtitle?: string,
-    ) {
-        if (process.env.FUSION_LOG_LEVEL) {
-            this.level = parseInt(process.env.FUSION_LOG_LEVEL) as 0 | 1 | 2 | 3 | 4;
-        } else {
-            this.level = process.env.NODE_ENV === 'development' ? 3 : 1;
-        }
-    }
+    ) {}
 
     /**
      * Generates the formatted message to log, including the title, subtitle (if any), and the messages provided.


### PR DESCRIPTION
## Why

missing process env in production building of applications

closes: https://github.com/equinor/fusion/issues/343


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

