### PR TITLE
fix(pnpm): setting required pnpm to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "^18 || ^20",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">=8"
+    "pnpm": ">=9"
   },
   "packageManager": "pnpm@9.0.6",
   "scripts": {


### PR DESCRIPTION
## Why
set required pnpm version to 9.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

