### PR TITLE
feat(query): add persistentQuery method

### DIFF
--- a/.changeset/seven-pants-help.md
+++ b/.changeset/seven-pants-help.md
@@ -1,0 +1,68 @@
+---
+"@equinor/fusion-query": patch
+---
+
+---
+
+## "@equinor/fusion-query": minor
+
+This release introduces a new method `persistentQuery` to the `Query` class. This method allows for creating persistent queries that automatically update when the underlying cache entry changes.
+
+The `persistentQuery` method was added to simplify the process of creating queries that need to stay up-to-date with the latest data. Previously, developers had to manually handle cache updates and re-subscribe to the query observable when changes occurred. With `persistentQuery`, this process is automated, reducing boilerplate code and improving developer experience.
+
+To use the `persistentQuery` method, simply call it with the desired query arguments and options, similar to the existing `query` method:
+
+```typescript
+import { Query } from "@equinor/fusion-query";
+
+const query = new Query({
+  /* query options */
+});
+
+const persistentQuery$ = query.persistentQuery({ id: "123" });
+
+persistentQuery$.subscribe((result) => {
+  console.log("Persistent query result:", result);
+});
+```
+
+The persistentQuery method returns an observable that emits the cached result immediately if available. It then continues to emit new results whenever the cache entry changes, either due to a new query or a manual cache mutation.
+
+How to migrate
+If you have existing code that manually handles cache updates and re-subscribes to queries, you can migrate to the persistentQuery method by replacing the manual logic with a call to persistentQuery.
+
+For example, if you had code like this:
+
+```ts
+const query$ = query.query({ id: "123" });
+const subscription = query$.subscribe((result) => {
+  // Handle result
+});
+
+// Manually handle cache updates
+query.onMutate((event) => {
+  if (event.detail.current?.key === "cacheKeyFor123") {
+    subscription.unsubscribe();
+    const newSubscription = query.query({ id: "123" }).subscribe((result) => {
+      // Handle result
+    });
+  }
+});
+```
+
+You can replace it with the following:
+
+```ts
+const persistentQuery$ = query.persistentQuery({ id: "123" });
+const subscription = persistentQuery$.subscribe((result) => {
+  // Handle result
+});
+```
+
+The persistentQuery method handles the cache updates automatically, eliminating the need for manual logic and re-subscriptions.
+
+**Additional notes**
+
+The persistentQuery method uses the distinctUntilChanged operator to only emit new results when the cache entry's transaction or mutation status changes, reducing unnecessary emissions.
+If you need to customize the cache validation logic for the persistentQuery, you can pass a custom validate function in the cache options object, similar to the existing query method.
+The persistentQuery method internally uses the \_query and #generateCacheKey methods from the Query class, ensuring consistent behavior with the existing query functionality.

--- a/packages/utils/query/src/cache/QueryCache.ts
+++ b/packages/utils/query/src/cache/QueryCache.ts
@@ -82,6 +82,15 @@ export class QueryCache<TType, TArgs> {
     }
 
     /**
+     * Checks if an item exists in the query cache by key.
+     * @param {string} key - The key of the item to check.
+     * @returns {boolean} True if the item exists, otherwise false.
+     */
+    public has(key: string): boolean {
+        return key in this.#state.value;
+    }
+
+    /**
      * Sets the value of an item in the query cache.
      * @param {string} key - The key of the item to set.
      * @param {Pick<QueryCacheRecord<TType, TArgs>, 'value' | 'args' | 'transaction'>} record - The new value of the item.

--- a/packages/utils/query/src/cache/create-reducer.ts
+++ b/packages/utils/query/src/cache/create-reducer.ts
@@ -37,6 +37,8 @@ export default function <TType, TArgs>(
                         record.updated = Date.now();
                         record.updates ??= 0;
                         record.updates++;
+                        record.value = castDraft(entry.value);
+                        record.transaction = entry.transaction;
                         delete record.mutated;
                     } else {
                         // If the record does not exist, create a new one with the current timestamp.

--- a/packages/utils/query/tests/Query.persistentQuery.test.ts
+++ b/packages/utils/query/tests/Query.persistentQuery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Query } from '../src/Query';
+import { QueryTaskValue } from '../src/types';
+
+describe('Persistent queries', () => {
+    it('should emit when the cache is mutated', async () => {
+        vi.useFakeTimers();
+        // Initializes a new Query instance with a mock client, a key generator function, and an expiration time.
+        const query = new Query({
+            client: { fn: (value) => Promise.resolve(value) }, // Mock client function that resolves immediately with the provided value.
+            key: (id) => id, // Key generator function that returns the provided id.
+            expire: 1000, // Sets cache expiration time to 1000 milliseconds.
+        });
+
+        const result = [] as QueryTaskValue<string>[];
+
+        // First query execution, expected to complete and not use the cache.
+        query.persistentQuery('foo').subscribe((value) => result.push(value));
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        // mutate the cache
+        query.mutate('foo', { value: 'foobar' });
+        await vi.advanceTimersByTimeAsync(10);
+
+        // refresh the query
+        query.query('foo').subscribe();
+        await vi.advanceTimersByTimeAsync(100);
+
+        // await vi.advanceTimersToNextTimerAsync();
+        const expected = [
+            { status: 'complete', value: 'foo' },
+            { status: 'cache', value: 'foobar', updates: 1 },
+            { status: 'cache', value: 'foo', updates: 2 },
+        ];
+
+        expect(result).toMatchObject(expected);
+    });
+});


### PR DESCRIPTION
## Why
This PR introduces a new `persistentQuery` method to the `Query` class in the `@equinor/fusion-query` package. The new method simplifies the process of creating queries that need to stay up-to-date with the latest data, reducing boilerplate code and improving developer experience.

## What is the new behavior?
The `persistentQuery` method allows for creating persistent queries that automatically update when the underlying cache entry changes. It returns an observable that emits the cached result immediately if available, and then continues to emit new results whenever the cache entry changes, either due to a new query or a manual cache mutation.

The method handles cache updates automatically, eliminating the need for manual logic and re-subscriptions. It uses the `distinctUntilChanged` operator to only emit new results when the cache entry's transaction or mutation status changes, reducing unnecessary emissions.

## Does this PR introduce a breaking change?
No, this PR does not introduce a breaking change. It adds a new method to the `Query` class while maintaining backward compatibility with existing code.

## Other information?
This PR also includes minor changes to the `QueryCache` class, adding a `has` method to check if an item exists in the cache by key, and a change to the `create-reducer` utility function to update the `value` and `transaction` properties of the cache record when a mutation occurs.

Additionally, a new test file `Query.persistentQuery.test.ts` has been added to cover the behavior of the `persistentQuery` method.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

