### PR TITLE
feat(event): enhance FrameworkEventInitType type definition

### DIFF
--- a/.changeset/event-improve-type-resolve.md
+++ b/.changeset/event-improve-type-resolve.md
@@ -1,0 +1,22 @@
+---
+"@equinor/fusion-event": patch
+---
+
+## @equinor/fusion-event
+
+### Improved Type Resolution for `FrameworkEventInitType`
+
+The `FrameworkEventInitType` type has been enhanced to better resolve types for both `IFrameworkEvent` and `FrameworkEvent`.
+
+When defining events `FrameworkEventMap`, the dispatch type can now be inferred from the event type.
+
+#### Changes
+
+The type definition for `FrameworkEventInitType` has been updated as follows:
+
+```typescript
+export type FrameworkEventInitType<T> =
+    T extends IFrameworkEvent<infer U> ? U : T extends FrameworkEvent<infer U> ? U : never;
+```
+
+This change ensures that `FrameworkEventInitType` can now correctly infer the type for both `IFrameworkEvent` and `FrameworkEvent`.

--- a/packages/modules/event/src/event.ts
+++ b/packages/modules/event/src/event.ts
@@ -41,7 +41,8 @@ export type FrameworkEventInit<TDetail = any, TSource = any> = {
 };
 
 /** defer init type args of event */
-export type FrameworkEventInitType<T> = T extends IFrameworkEvent<infer U> ? U : never;
+export type FrameworkEventInitType<T> =
+    T extends IFrameworkEvent<infer U> ? U : T extends FrameworkEvent<infer U> ? U : never;
 
 /** defer name type of event */
 export type FrameworkEventType<T> =

--- a/packages/modules/event/src/index.ts
+++ b/packages/modules/event/src/index.ts
@@ -6,6 +6,7 @@ export type {
     FrameworkEventSource,
     FrameworkEventMap,
     FrameworkEventHandler,
+    FrameworkEventInitType,
 } from './event';
 
 export { IEventModuleConfigurator } from './configurator';


### PR DESCRIPTION
## Why
This PR introduces changes to the `FrameworkEventInitType` utility type in the `@equinor/fusion-framework` package. The current behavior is that the `FrameworkEventInitType` type only handles events that extend the `IFrameworkEvent` interface. The new behavior is that it also handles events that extend the `FrameworkEvent` class.

This change does not introduce a breaking change, as it only extends the functionality of the existing `FrameworkEventInitType` type.

closes: N/A (no issue referenced)

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).
