### PR TITLE
Feat(base config builder): allow async overrides

### DIFF
--- a/.changeset/allow-async-config-builder-overrides.md
+++ b/.changeset/allow-async-config-builder-overrides.md
@@ -1,0 +1,29 @@
+---
+"@equinor/modules": patch
+---
+
+## @equinor/modules
+
+### Changes to `BaseConfigBuilder`
+
+The `_createConfig` method in `BaseConfigBuilder` has been updated to return an `ObservableInput<TConfig>` instead of an `Observable<TConfig>`. 
+This allows for more flexibility in how the config is created, as the method can now return a Promise or other observable-like type.
+
+Additionally, the `_createConfig` method now uses `from()` to convert the result of `_buildConfig` to an observable stream.
+
+Here's an example of how the updated `_createConfig` method can be used:
+
+```typescript
+protected _createConfig(
+  init: ConfigBuilderCallbackArgs,
+  initial?: Partial<TConfig>
+): ObservableInput<TConfig> {
+  return from(this._buildConfig(init, initial)).pipe(
+    mergeMap((config) => this._processConfig(config, init))
+  );
+}
+```
+
+This change allows for asynchronous operations to be performed within the `_buildConfig` method, which can then be processed in the `_processConfig` method.
+
+Consumers of the `BaseConfigBuilder` class should not need to update their code, as the public API remains the same.

--- a/.changeset/improve-docs-baseconfig-builder.md
+++ b/.changeset/improve-docs-baseconfig-builder.md
@@ -1,0 +1,20 @@
+---
+"@equinor/fusion-framework": patch
+---
+
+## @equinor/fusion-framework
+
+### Improved documentation for `BaseConfigBuilder`
+
+The `BaseConfigBuilder` class has been updated with improved documentation to better explain its usage and capabilities.
+
+#### What changed?
+
+The `BaseConfigBuilder` class is an abstract class that provides a flexible and extensible way to build and configure modules. It allows you to define configuration callbacks for different parts of your module's configuration, and then combine and process these callbacks to generate the final configuration object.
+
+The documentation has been expanded to include:
+
+1. A detailed explanation of how the `BaseConfigBuilder` class is designed to be used, including an example of creating a configuration builder for a hypothetical `MyModule` module.
+2. Descriptions of the key methods and properties provided by the `BaseConfigBuilder` class, such as `createConfig`, `createConfigAsync`, `_set`, `_buildConfig`, and `_processConfig`.
+3. Guidance on how to override the `_processConfig` method to add additional logic or validation to the configuration object before it is returned.
+4. Examples of how to use the `BaseConfigBuilder` class to handle common configuration scenarios, such as setting default values or validating configuration properties.

--- a/.changeset/improve-extendability-config-builder.md
+++ b/.changeset/improve-extendability-config-builder.md
@@ -1,0 +1,50 @@
+---
+"@equinor/modules": patch
+---
+
+## @equinor/modules
+
+### Changes to `BaseConfigBuilder`
+
+The `BaseConfigBuilder` class has been updated to improve its extendability and provide better access to the internal configuration callbacks.
+
+#### Added `_get` and `_has` methods
+
+Two new protected methods have been added to the `BaseConfigBuilder` class:
+
+1. `_get<TTarget extends DotPath<TConfig>>(target: TTarget)`: This method retrieves the configuration callback for the specified target path in the configuration. It returns the callback or `undefined` if no callback is registered for the given target.
+
+2. `_has<TTarget extends DotPath<TConfig>>(target: TTarget)`: This method checks if the given target path exists in the configuration callbacks. It returns `true` if the target path exists, `false` otherwise.
+
+These methods allow subclasses of `BaseConfigBuilder` to easily access and check the existence of configuration callbacks for specific targets.
+
+#### Example usage
+
+Suppose you have a subclass of `BaseConfigBuilder` called `MyConfigBuilder`. You can use the new `_get` and `_has` methods like this:
+
+```typescript
+class MyConfigBuilder extends BaseConfigBuilder<MyConfig> {
+  // override the _buildConfig method
+  async _createConfig(
+      init: ConfigBuilderCallbackArgs,
+      initial?: Partial<TConfig>,
+  ): ObservableInput<TConfig> {
+      // Check if a callback is registered for the'my.custom.config' target
+      if (this._has('my.custom.config')) {
+        // register a fallback value for the'my.custom.config' target if no callback is registered
+        this._set('my.custom.config', async() => { return 42; });
+      } else {
+        // if a callback is registered, call it and log the result
+        configCallback = this._get('my.custom.config');
+        configValue$ = from(configCallback(init, initial));
+        console.log(await lastValueFrom(configValue$));
+      }
+      return lastValueFrom(from(super._createConfig(init, initial)));
+  }
+}
+```
+
+> [!WARNING]
+> the example code is not intended to be a working implementation of the `MyConfigBuilder` class. It is only intended to demonstrate how the new `_get` and `_has` methods can be used.
+
+This change allows for more flexibility and easier extensibility of the `BaseConfigBuilder` class.

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -174,6 +174,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param init config builder callback arguments
      * @param initial optional initial config
      * @returns observable configuration object
+     * @sealed
      */
     public createConfig(
         init: ConfigBuilderCallbackArgs,
@@ -189,6 +190,8 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param init - A callback function that is responsible for initializing the configuration object.
      * @param initial - An optional partial configuration object that will be merged with the result of the `init` callback.
      * @returns A Promise that resolves to the created configuration object of type `TConfig`.
+     * @protected
+     * @sealed
      */
     public async createConfigAsync(
         init: ConfigBuilderCallbackArgs,
@@ -203,7 +206,8 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param target - The target path in the configuration to set the callback for.
      * @param cb - The callback function to be executed when the configuration for the specified target path is updated.
      * @template TKey - a key of the config object
-     * @internal
+     * @protected
+     * @sealed
      */
     protected _set<TTarget extends DotPath<TConfig>>(
         target: TTarget,
@@ -217,6 +221,8 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      *
      * @param target - The target path in the configuration to retrieve the callback for.
      * @returns The configuration builder callback for the specified target, or `undefined` if no callback is registered.
+     * @protected
+     * @sealed
      */
     protected _get<TTarget extends DotPath<TConfig>>(
         target: TTarget,
@@ -230,6 +236,8 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * Checks if the given target path exists in the configuration callbacks.
      * @param target - The target path to check.
      * @returns `true` if the target path exists in the configuration callbacks, `false` otherwise.
+     * @protected
+     * @sealed
      */
     protected _has<TTarget extends DotPath<TConfig>>(target: TTarget): boolean {
         return target in this.#configCallbacks;
@@ -258,6 +266,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param init - The configuration builder callback arguments, which include the module context and other relevant data.
      * @param initial - An optional partial configuration object to use as the initial base for the configuration.
      * @returns An observable that emits the processed configuration.
+     * @protected
      */
     protected _createConfig(
         init: ConfigBuilderCallbackArgs,
@@ -281,6 +290,9 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param init - The initialization arguments passed to the configuration callbacks.
      * @param initial - An optional partial configuration object to use as the initial state.
      * @returns An observable that emits the final configuration object.
+     * @protected
+     * @sealed
+     * @readonly
      */
     protected _buildConfig(
         init: ConfigBuilderCallbackArgs,
@@ -330,6 +342,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
      * @param config - The partial configuration object to process.
      * @param _init - Additional configuration arguments (not used in this implementation).
      * @returns An observable input that emits the processed configuration object.
+     * @protected
      */
     protected _processConfig(
         config: Partial<TConfig>,

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -105,7 +105,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
         init: ConfigBuilderCallbackArgs,
         initial?: Partial<TConfig>,
     ): Observable<TConfig> {
-        return this._createConfig(init, initial);
+        return from(this._createConfig(init, initial));
     }
 
     /**
@@ -137,9 +137,8 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
     protected _createConfig(
         init: ConfigBuilderCallbackArgs,
         initial?: Partial<TConfig>,
-    ): Observable<TConfig> {
-        return this._buildConfig(init, initial).pipe(
-            mergeMap((config) => this._processConfig(config, init)),
+    ): ObservableInput<TConfig> {
+        return from(this._buildConfig(init, initial)).pipe(
         );
     }
 
@@ -149,7 +148,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
     protected _buildConfig(
         init: ConfigBuilderCallbackArgs,
         initial?: Partial<TConfig>,
-    ): Observable<Partial<TConfig>> {
+    ): ObservableInput<Partial<TConfig>> {
         return from(Object.entries<ConfigBuilderCallback>(this.#configCallbacks)).pipe(
             mergeMap(async ([target, cb]) => {
                 const value = await cb(init);

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -132,6 +132,29 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
     }
 
     /**
+     * Retrieves the configuration callback for the specified target path in the configuration.
+     *
+     * @param target - The target path in the configuration to retrieve the callback for.
+     * @returns The configuration builder callback for the specified target, or `undefined` if no callback is registered.
+     */
+    protected _get<TTarget extends DotPath<TConfig>>(
+        target: TTarget,
+    ): ConfigBuilderCallback<DotPathType<TConfig, TTarget>> | undefined {
+        return this.#configCallbacks[target] as ConfigBuilderCallback<
+            DotPathType<TConfig, TTarget>
+        >;
+    }
+
+    /**
+     * Checks if the given target path exists in the configuration callbacks.
+     * @param target - The target path to check.
+     * @returns `true` if the target path exists in the configuration callbacks, `false` otherwise.
+     */
+    protected _has<TTarget extends DotPath<TConfig>>(target: TTarget): boolean {
+        return target in this.#configCallbacks;
+    }
+
+    /**
      * @private internal creation of config
      */
     protected _createConfig(


### PR DESCRIPTION
## Why
This PR introduces changes to the `BaseConfigBuilder` class in the `@equinor/fusion-framework` package. The current behavior of the `BaseConfigBuilder` class is that it provides a way to build and configure modules by defining configuration callbacks for different parts of the module's configuration. However, the implementation has some limitations and lacks proper documentation.

The new behavior introduced by this PR is an improved and more flexible implementation of the `BaseConfigBuilder` class. It includes better handling of nested configurations, improved type safety, and more comprehensive documentation. Additionally, it introduces new helper methods for working with configuration callbacks and adds examples to illustrate the usage of the class.

This PR does not introduce any breaking changes, as it maintains backward compatibility with the existing API.

### Changes
- Improved documentation for the `BaseConfigBuilder` class, including a detailed example of how to use it.
- Added new methods `_get` and `_has` to retrieve and check for the existence of configuration callbacks.
- Improved the implementation of `_createConfig` to use `switchMap` instead of `mergeMap` for better handling of asynchronous operations.
- Updated the `_buildConfig` method to use more descriptive comments and better variable naming.
- Added an example for the `_processConfig` method to illustrate how it can be used for post-processing and validating the configuration.

### Benefits
- Improved code readability and maintainability through better documentation and code organization.
- Enhanced type safety and better handling of nested configurations.
- Provided more flexibility and control over the configuration building process through new helper methods.
- Added examples to make it easier for developers to understand and use the `BaseConfigBuilder` class.

## Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).
