### PR TITLE
fix(http)!: throw correct error in jsonSelector

### DIFF
--- a/.changeset/fifty-pianos-reflect.md
+++ b/.changeset/fifty-pianos-reflect.md
@@ -1,0 +1,41 @@
+---
+'@equinor/fusion-framework-module-http': patch
+---
+
+The `jsonSelector` function was not checking the error type in the `catch` block.
+This lead to not throwing the error with parsed data, but always throwing a parser error, where the correct error was `cause` in the `ErrorOptions`
+
+**BREAKING CHANGE:**
+
+If for some reason developers has catched the error and assumed the `cause` property would give the proper error data, this will no longer be the case.
+
+```ts
+try {
+    await jsonSelector(response);
+} catch (error) {
+    if (error instanceof HttpJsonResponseError) {
+        const { data, cause } = error;
+        if (data) {
+            console.error('the request was not `ok`, see provided error data', data);
+        } else {
+            console.error('failed to parse data from response, see provided cause', cause);
+        }
+    }
+}
+```
+
+```diff
+try {
+  await jsonSelector(response);
+} catch (error) {
+  if(error instanceof HttpJsonResponseError) {
+-    const data = error.cause instanceof HttpJsonResponseError ? err.cause.data : null;
++    const data = error instanceof HttpJsonResponseError ? error.data : null;
+    if(data) {
+      console.error('the request was not `ok`, see provided error data', data);
+    } else {
+      console.error('failed to parse data from response, see provided cause', error.cause);
+    }
+  }
+}
+```

--- a/packages/modules/http/src/lib/selectors/json-selector.ts
+++ b/packages/modules/http/src/lib/selectors/json-selector.ts
@@ -1,30 +1,46 @@
 import { HttpJsonResponseError } from '../../errors';
 
 /**
- * Converts the JSON response from an HTTP request into the specified type.
- * If the response is not OK or if there is an error parsing the response, an error is thrown.
- * If the response has a status code of 204 (No Content), a resolved Promise is returned.
+ * Asynchronously parses the JSON data from a given HTTP response.
  *
- * @param response The HTTP response object.
- * @returns A Promise that resolves to the parsed JSON data.
- * @throws {Error} If the network response is not OK.
- * @throws {HttpJsonResponseError} If there is an error parsing the response.
+ * If the response has a status code of 204 (No Content), this function will resolve with `undefined`.
+ *
+ * If the response is not successful (i.e. `response.ok` is `false`), this function will throw an `HttpJsonResponseError` with the response details and the parsed data (if any).
+ *
+ * If there is an error parsing the JSON data, this function will throw an `HttpJsonResponseError` with the parsing error and the original response.
+ *
+ * @template TType - The expected type of the parsed JSON data.
+ * @template TResponse - The type of the HTTP response object.
+ * @param response - The HTTP response to parse.
+ * @returns A promise that resolves with the parsed JSON data, or rejects with an `HttpJsonResponseError`.
  */
 export const jsonSelector = async <TType = unknown, TResponse extends Response = Response>(
     response: TResponse,
 ): Promise<TType> => {
-    /** Status code 204 is no content */
+    /** Status code 204 indicates no content in the response */
     if (response.status === 204) {
         return Promise.resolve() as Promise<TType>;
     }
 
     try {
+        // Parse the response JSON data
         const data = await response.json();
+
+        // Check if the response was successful
         if (!response.ok) {
+            // Throw an error with the response details
             throw new HttpJsonResponseError('network response was not OK', response, { data });
         }
+
+        // Return the parsed data
         return data;
     } catch (cause) {
+        // If the cause is an HttpJsonResponseError, rethrow it
+        if (cause instanceof HttpJsonResponseError) {
+            throw cause;
+        }
+
+        // Otherwise, throw a new HttpJsonResponseError with the parsing error
         throw new HttpJsonResponseError('failed to parse response', response, { cause });
     }
 };


### PR DESCRIPTION
## Why

This pull request introduces a fix to the `jsonSelector` function in the `@equinor/fusion-framework-module-http` package.

The current behavior is that the `jsonSelector` function was not properly checking the error type in the `catch` block. This led to always throwing a parser error, even when the correct error was in the `cause` property of the `HttpJsonResponseError`.

The new behavior is that the `jsonSelector` function now correctly checks if the error is an instance of `HttpJsonResponseError`, and then properly handles the error data and cause. This ensures that developers who have caught the error and assumed the `cause` property would give the proper error data, will now receive the correct information.

**This change might introduce breaking changes:**
If for some reason developers has catched the error and assumed the `cause` property would give the proper error data, this will no longer be the case.


```diff
try {
  await jsonSelector(response);
} catch (error) {
  if(error instanceof HttpJsonResponseError) {
-    const data = error.cause instanceof HttpJsonResponseError ? err.cause.data : null;
+    const data = error instanceof HttpJsonResponseError ? error.data : null;
    if(data) {
      console.error('the request was not `ok`, see provided error data', data);
    } else {
      console.error('failed to parse data from response, see provided cause', error.cause);
    }
  }
}
```

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

