### PR TITLE
docs: remove React version warning from getting started guide

### DIFF
--- a/.changeset/smooth-chefs-happen.md
+++ b/.changeset/smooth-chefs-happen.md
@@ -1,0 +1,15 @@
+---
+'@equinor/fusion-framework-docs': patch
+---
+
+## @equinor/fusion-framework-docs
+
+Removed an outdated warning message about React version support in the Fusion Portal getting started guide.
+
+### Why
+
+The warning message stated:
+
+> The Fusion Portal only supports React@17
+
+However, this is no longer accurate, as the Fusion Portal now supports newer versions of React beyond 17.

--- a/vue-press/src/guide/app/getting-started.md
+++ b/vue-press/src/guide/app/getting-started.md
@@ -11,10 +11,6 @@ tag:
 
 - [React 17+](https://reactjs.org/)
 
-::: warning Dependencies
-The Fusion Portal only supports React@17
-:::
-
 ## Setup
 
 ### CLI


### PR DESCRIPTION
## Why

Removed the warning block that stated the Fusion Portal only supports React 17, as this information is no longer relevant or accurate in the current state of the project. This change helps simplify the getting started guide and avoids confusion for users.

ref: https://github.com/equinor/fusion/issues/346

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

