### PR TITLE
Chore(ag grid): update to version 31.3

### DIFF
--- a/.changeset/purple-mice-know.md
+++ b/.changeset/purple-mice-know.md
@@ -1,0 +1,19 @@
+---
+'@equinor/fusion-framework-module-ag-grid': minor
+---
+
+Updated the `@ag-grid-enterprise/core` dependency to version `~31.3.2`. This is a patch version bump.
+
+**Sticky Group Total and Grand Total Rows**: Group and grand total rows can now be displayed as sticky rows at the top or bottom of the grid, making it easier to track total values in large datasets.
+
+**Theme Builder**: A new powerful styling tool that allows users to easily build highly-customized themes for AG Grid using presets and visual configurations.
+
+**Skeleton Content in Loading Grid Cells**: Skeleton loading placeholders are now displayed in grid cells while data is being loaded, providing a better user experience.
+
+**Background Image in Excel Exports**: Users can now add a background image to Excel files exported from AG Grid.
+
+**Global Grid Options**: A new feature that allows users to apply global configuration options to all AG Grid instances in their application.
+
+**Accessibility Improvements**: AG Grid 31.3 includes enhancements to keyboard navigation and overall accessibility support.
+
+[see full release note](https://blog.ag-grid.com/whats-new-in-ag-grid-31-3/)

--- a/.changeset/quiet-donuts-beg.md
+++ b/.changeset/quiet-donuts-beg.md
@@ -1,0 +1,11 @@
+---
+'@equinor/fusion-framework-cookbook-app-react-ag-grid': patch
+---
+
+**@equinor/fusion-framework-module-ag-grid**
+
+Updated ag-grid dependencies to latest minor versions:
+
+-   `@ag-grid-community/client-side-row-model` from `~31.2.0` to `~31.3.2`
+-   `@ag-grid-community/core` from `~31.2.0` to `~31.3.2`
+-   `@ag-grid-community/react` from `~31.2.0` to `~31.3.2`

--- a/cookbooks/app-react-ag-grid/package.json
+++ b/cookbooks/app-react-ag-grid/package.json
@@ -22,10 +22,10 @@
         "typescript": "^5.4.2"
     },
     "dependencies": {
-        "@ag-grid-community/client-side-row-model": "~31.2.0",
-        "@ag-grid-community/core": "~31.2.0",
-        "@ag-grid-community/react": "~31.2.0",
+        "@ag-grid-community/client-side-row-model": "~31.3.2",
+        "@ag-grid-community/core": "~31.3.2",
+        "@ag-grid-community/react": "~31.3.2",
         "@equinor/fusion-framework-module-ag-grid": "workspace:^",
-        "@equinor/fusion-react-ag-grid-styles": "^30.2.0"
+        "@equinor/fusion-react-ag-grid-styles": "^31.2.1"
     }
 }

--- a/packages/modules/ag-grid/package.json
+++ b/packages/modules/ag-grid/package.json
@@ -29,7 +29,7 @@
         "directory": "packages/modules/ag-grid"
     },
     "dependencies": {
-        "@ag-grid-enterprise/core": "~31.2.0"
+        "@ag-grid-enterprise/core": "~31.3.2"
     },
     "devDependencies": {
         "@equinor/fusion-framework-module": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,20 +109,20 @@ importers:
   cookbooks/app-react-ag-grid:
     dependencies:
       '@ag-grid-community/client-side-row-model':
-        specifier: ~31.2.0
-        version: 31.2.0
+        specifier: ~31.3.2
+        version: 31.3.2
       '@ag-grid-community/core':
-        specifier: ~31.2.0
-        version: 31.2.0
+        specifier: ~31.3.2
+        version: 31.3.2
       '@ag-grid-community/react':
-        specifier: ~31.2.0
-        version: 31.2.0(@ag-grid-community/core@31.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ~31.3.2
+        version: 31.3.2(@ag-grid-community/core@31.3.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@equinor/fusion-framework-module-ag-grid':
         specifier: workspace:^
         version: link:../../packages/modules/ag-grid
       '@equinor/fusion-react-ag-grid-styles':
-        specifier: ^30.2.0
-        version: 30.2.0(@ag-grid-community/styles@29.3.5)(@equinor/fusion-react-styles@0.6.2(@types/react@18.2.61)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        specifier: ^31.2.1
+        version: 31.2.1(@ag-grid-community/styles@29.3.5)(@equinor/fusion-react-styles@0.6.2(@types/react@18.2.61)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
     devDependencies:
       '@equinor/fusion-framework-cli':
         specifier: workspace:^
@@ -1723,19 +1723,16 @@ packages:
   '@actions/http-client@2.2.0':
     resolution: {integrity: sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==}
 
-  '@ag-grid-community/client-side-row-model@31.2.0':
-    resolution: {integrity: sha512-fiXFGUaOCZdJ5QSJaWIyeA+hzjOe0+KzU1PdxqUdUZiNmDv/MFQQd99Biyk76OS6i8eWDFcC1O/V7owfVTWflw==}
-
-  '@ag-grid-community/core@31.2.0':
-    resolution: {integrity: sha512-297AR2Z0i6zdpo+d1riWE9TpbsQ956Sd3rkgnjDaFzgGClsdy0SwInBs2281CHjaLQAhPzFelZ5XwcDTxHl4Tw==}
+  '@ag-grid-community/client-side-row-model@31.3.2':
+    resolution: {integrity: sha512-XFzq4BvPPEjf5HtC1VpruBESqvsJYfIcY1EC5CaY1hqV1NRp1JVImFrMdoxUuw9NsoucGneDT/DOj42WHweFIg==}
 
   '@ag-grid-community/core@31.3.2':
     resolution: {integrity: sha512-iab+xIPCvjzGkIBgo12IQNa9/ZGI4BmjsQz65+aipNXISbtGketkN5iO4OFQgafgf0f9JZVFOZ3EzCnMiVWLiQ==}
 
-  '@ag-grid-community/react@31.2.0':
-    resolution: {integrity: sha512-lOAoH0c2pGMQqxtEzhzXswf3HLeEVCnDM/TlHJpqKTcydhyW1Cfulr4/uJuZL7h28gLSpLawu+rlGCTgac8NKw==}
+  '@ag-grid-community/react@31.3.2':
+    resolution: {integrity: sha512-pGxW60itcWAKNBKOfi5oi0R9z6fEPME7V7vajz6cPafZCJ25ylTWxW4XLO2391tYNqorUbR5U3rOpaXkCtFCRQ==}
     peerDependencies:
-      '@ag-grid-community/core': 31.2.0
+      '@ag-grid-community/core': 31.3.2
       react: ^16.3.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0
 
@@ -2108,10 +2105,10 @@ packages:
       '@types/react':
         optional: true
 
-  '@equinor/fusion-react-ag-grid-styles@30.2.0':
-    resolution: {integrity: sha512-h2wUe9XHYDGPe2B34D/RijCwi5Fub5A8MbersMwRNO7QKr1q5xqy89m/NE9ZPfK3FnRt/6E3EQ0HXT9JEvxXEA==}
+  '@equinor/fusion-react-ag-grid-styles@31.2.1':
+    resolution: {integrity: sha512-AX52K3IV3FW10WMUYKc18JlAp2HPj12/ttawxalkBsPz4/Ebkte3m6ciaK5Ja70JjBMkbGiVCIwRa0sSrHpnSA==}
     peerDependencies:
-      '@ag-grid-community/styles': ~29.3.4
+      '@ag-grid-community/styles': 31.2.0
       '@equinor/fusion-react-styles': ^0.6.0
 
   '@equinor/fusion-react-checkbox@0.5.17':
@@ -8694,22 +8691,18 @@ snapshots:
       tunnel: 0.0.6
       undici: 5.28.3
 
-  '@ag-grid-community/client-side-row-model@31.2.0':
+  '@ag-grid-community/client-side-row-model@31.3.2':
     dependencies:
-      '@ag-grid-community/core': 31.2.0
-      tslib: 2.6.2
-
-  '@ag-grid-community/core@31.2.0':
-    dependencies:
+      '@ag-grid-community/core': 31.3.2
       tslib: 2.6.2
 
   '@ag-grid-community/core@31.3.2':
     dependencies:
       tslib: 2.6.2
 
-  '@ag-grid-community/react@31.2.0(@ag-grid-community/core@31.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@ag-grid-community/react@31.3.2(@ag-grid-community/core@31.3.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@ag-grid-community/core': 31.2.0
+      '@ag-grid-community/core': 31.3.2
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9375,7 +9368,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.61
 
-  '@equinor/fusion-react-ag-grid-styles@30.2.0(@ag-grid-community/styles@29.3.5)(@equinor/fusion-react-styles@0.6.2(@types/react@18.2.61)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@equinor/fusion-react-ag-grid-styles@31.2.1(@ag-grid-community/styles@29.3.5)(@equinor/fusion-react-styles@0.6.2(@types/react@18.2.61)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@ag-grid-community/styles': 29.3.5
       '@equinor/fusion-react-styles': 0.6.2(@types/react@18.2.61)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,8 +754,8 @@ importers:
   packages/modules/ag-grid:
     dependencies:
       '@ag-grid-enterprise/core':
-        specifier: ~31.2.0
-        version: 31.2.0
+        specifier: ~31.3.2
+        version: 31.3.2
     devDependencies:
       '@equinor/fusion-framework-module':
         specifier: workspace:^
@@ -1729,6 +1729,9 @@ packages:
   '@ag-grid-community/core@31.2.0':
     resolution: {integrity: sha512-297AR2Z0i6zdpo+d1riWE9TpbsQ956Sd3rkgnjDaFzgGClsdy0SwInBs2281CHjaLQAhPzFelZ5XwcDTxHl4Tw==}
 
+  '@ag-grid-community/core@31.3.2':
+    resolution: {integrity: sha512-iab+xIPCvjzGkIBgo12IQNa9/ZGI4BmjsQz65+aipNXISbtGketkN5iO4OFQgafgf0f9JZVFOZ3EzCnMiVWLiQ==}
+
   '@ag-grid-community/react@31.2.0':
     resolution: {integrity: sha512-lOAoH0c2pGMQqxtEzhzXswf3HLeEVCnDM/TlHJpqKTcydhyW1Cfulr4/uJuZL7h28gLSpLawu+rlGCTgac8NKw==}
     peerDependencies:
@@ -1739,8 +1742,8 @@ packages:
   '@ag-grid-community/styles@29.3.5':
     resolution: {integrity: sha512-Z1r6lKx0ds92SV5mX9ZsGFgiStktrRMrWGs92bz3rQN9uethsthIri4RfLaZYaZ03i3zw15peqJtmYEu+sGy/A==}
 
-  '@ag-grid-enterprise/core@31.2.0':
-    resolution: {integrity: sha512-YJaTsX10WPMqu9v1BzPgoLEypLVk1nMUcUCKyzaO0yU6920C+i1RaZJvf2fwUy7xTJs0Wb+1VF+ukEh7J6q7Iw==}
+  '@ag-grid-enterprise/core@31.3.2':
+    resolution: {integrity: sha512-eCcUsQNyIV7oh12HB2Fv8QiBIEwZUbIjKUZgOzgHwmjqzxuPk2r4Gg6/fg8agRgdaCBa5f4jeLSFzBRm1FTHVQ==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -8700,6 +8703,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
+  '@ag-grid-community/core@31.3.2':
+    dependencies:
+      tslib: 2.6.2
+
   '@ag-grid-community/react@31.2.0(@ag-grid-community/core@31.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@ag-grid-community/core': 31.2.0
@@ -8709,9 +8716,9 @@ snapshots:
 
   '@ag-grid-community/styles@29.3.5': {}
 
-  '@ag-grid-enterprise/core@31.2.0':
+  '@ag-grid-enterprise/core@31.3.2':
     dependencies:
-      '@ag-grid-community/core': 31.2.0
+      '@ag-grid-community/core': 31.3.2
 
   '@ampproject/remapping@2.3.0':
     dependencies:


### PR DESCRIPTION
This pull request updates the `@ag-grid-enterprise/core` dependency to version `~31.3.2` in the `@equinor/fusion-framework-module-ag-grid` package.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).