### PR TITLE
feat(fusion-query): Enhance mutate functionality

### DIFF
--- a/.changeset/fluffy-olives-shout.md
+++ b/.changeset/fluffy-olives-shout.md
@@ -1,0 +1,64 @@
+---
+'@equinor/fusion-query': minor
+---
+
+A new public method `generateCacheKey` has been added to the `Query` class. This method allows users to generate a cache key based on provided query arguments, which can be useful for advanced caching scenarios or debugging.
+
+```typescript
+const query = new Query<YourDataType, YourArgsType>({
+    /* ... */
+});
+const args = {
+    /* your query arguments */
+};
+const cacheKey = query.generateCacheKey(args);
+console.log('Generated cache key:', cacheKey);
+```
+
+**Enhanced mutate method**
+The mutate method of the Query class now accepts an optional options parameter, allowing for more flexible cache mutations.
+
+**New allowCreation option**
+You can now specify whether to allow the creation of a new cache entry if it doesn't exist when performing a mutation.
+
+```ts
+const query = new Query<YourDataType, YourArgsType>({
+    /* ... */
+});
+
+// Mutate existing cache entry or create a new one if it doesn't exist
+query.mutate(args, (prevState) => ({ ...prevState, newProperty: 'value' }), {
+    allowCreation: true,
+});
+```
+
+**Changes to internal cache handling**
+The internal QueryCache class has been updated to support the new allowCreation option. This change allows for more flexible cache management, especially when dealing with non-existent cache entries.
+
+**Breaking change**
+The mutate method will now throw an error if the cache entry doesn't exist and allowCreation is not explicitly set to true. This change ensures more predictable behavior and helps prevent accidental cache entry creation.
+
+```ts
+// This will throw an error if the cache entry doesn't exist
+query.mutate(args, changes);
+
+// This will create a new cache entry if it doesn't exist
+query.mutate(args, changes, { allowCreation: true });
+```
+
+**How to update**
+If you're relying on the mutate method to create new cache entries, update your code to explicitly set allowCreation: true:
+
+```ts
+query.mutate(args, changes, { allowCreation: true });
+```
+
+Review your codebase for any uses of mutate that might be affected by the new error-throwing behavior when the cache entry doesn't exist.
+
+If you need to generate cache keys for advanced use cases, you can now use the generateCacheKey method:
+
+```ts
+const cacheKey = query.generateCacheKey(args);
+```
+
+These changes provide more control over cache manipulation and help prevent unintended side effects when working with the Query class.

--- a/.changeset/sweet-bottles-bow.md
+++ b/.changeset/sweet-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-query': patch
+---
+
+added test for mutating a value which does not exist in the cache

--- a/packages/utils/query/src/Query.ts
+++ b/packages/utils/query/src/Query.ts
@@ -608,6 +608,17 @@ export class Query<TDataType, TQueryArguments = any> {
     }
 
     /**
+     * Generates a cache key based on the provided query arguments.
+     * This method is used internally to uniquely identify cache entries.
+     *
+     * @param args - The query arguments to be used for generating the cache key.
+     * @returns A string representing the cache key.
+     */
+    public generateCacheKey(args: TQueryArguments): string {
+        return this.#generateCacheKey(args);
+    }
+
+    /**
      * Performs a mutation on the cache entry associated with the given arguments.
      * This method allows for updating the state of a cache entry without needing to perform a new query.
      * The changes are applied by invoking the `mutate` method on the cache with the generated key and the changes function.
@@ -618,9 +629,10 @@ export class Query<TDataType, TQueryArguments = any> {
     public mutate(
         args: TQueryArguments,
         changes: Parameters<QueryCache<TDataType, TQueryArguments>['mutate']>[1],
+        options?: { allowCreation?: boolean },
     ): void {
         const key = this.#generateCacheKey(args);
-        this.#cache.mutate(key, changes);
+        this.#cache.mutate(key, changes, options);
     }
 
     /**

--- a/packages/utils/query/src/cache/QueryCache.ts
+++ b/packages/utils/query/src/cache/QueryCache.ts
@@ -136,14 +136,20 @@ export class QueryCache<TType, TArgs> {
      */
     public mutate(
         key: string,
-        changes: QueryCacheMutation | ((current: TType) => QueryCacheMutation),
+        changes: QueryCacheMutation<TType> | ((current?: TType) => QueryCacheMutation<TType>),
+        options?: { allowCreation?: boolean },
     ) {
-        const current = this.#state.value[key];
-        if (!current) {
+        const current = key in this.#state.value ? this.#state.value[key] : undefined;
+
+        if (current || options?.allowCreation) {
+            const next = typeof changes === 'function' ? changes(current?.value) : changes;
+            this.#state.next(actions.mutate(key, next, current));
+        }
+
+        // if not options.allowCreation is specified and the item is not found, throw an error
+        if (options?.allowCreation === undefined) {
             throw new Error(`Cannot mutate cache item with key ${key}: item not found`);
         }
-        const next = typeof changes === 'function' ? changes(current.value) : changes;
-        this.#state.next(actions.mutate(key, next, current));
     }
 
     /**

--- a/packages/utils/query/src/cache/QueryCache.ts
+++ b/packages/utils/query/src/cache/QueryCache.ts
@@ -137,19 +137,14 @@ export class QueryCache<TType, TArgs> {
     public mutate(
         key: string,
         changes: QueryCacheMutation<TType> | ((current?: TType) => QueryCacheMutation<TType>),
-        options?: { allowCreation?: boolean },
-    ) {
+    ): void {
         const current = key in this.#state.value ? this.#state.value[key] : undefined;
 
-        if (current || options?.allowCreation) {
-            const next = typeof changes === 'function' ? changes(current?.value) : changes;
-            this.#state.next(actions.mutate(key, next, current));
-        }
-
-        // if not options.allowCreation is specified and the item is not found, throw an error
-        if (options?.allowCreation === undefined) {
+        if (!current) {
             throw new Error(`Cannot mutate cache item with key ${key}: item not found`);
         }
+        const next = typeof changes === 'function' ? changes(current?.value) : changes;
+        this.#state.next(actions.mutate(key, next, current));
     }
 
     /**

--- a/packages/utils/query/tests/Query.mutations.test.ts
+++ b/packages/utils/query/tests/Query.mutations.test.ts
@@ -83,6 +83,68 @@ describe('Mutations of queries', () => {
         ]);
     });
 
+    it('should not create new cache entry if "allowCreation" is false', async () => {
+        // Mock a function to simulate fetching data
+        const fn = vi.fn((value) => Promise.resolve(value));
+        // Initialize a new Query with a mock client, a key function, and an expiration time
+        const query = new Query({
+            client: { fn },
+            key: (id) => id,
+            expire: 1000,
+        });
+
+        // 
+        query.mutate('foo', () => ({ value: 'bar' }), { allowCreation: false });
+
+        const cacheKey = query.generateCacheKey('foo');
+
+        expect(query.cache.has(cacheKey)).toBe(false);
+    });
+
+    it('should allow creating new cache entry if option provided', async () => {
+        // Mock a function to simulate fetching data
+        const fn = vi.fn((value) => Promise.resolve(value));
+        // Initialize a new Query with a mock client, a key function, and an expiration time
+        const query = new Query({
+            client: { fn },
+            key: (id) => id,
+            expire: 1000,
+        });
+
+        query.mutate('foo', () => ({ value: 'bar' }), { allowCreation: true });
+
+        const cacheKey = query.generateCacheKey('foo');
+
+        expect(query.cache.has(cacheKey)).toBe(true);
+        expect(query.cache.getItem(cacheKey)).toMatchObject({
+            value: 'bar',
+            updates: 1,
+            updated: undefined,
+            mutated: expect.any(Number),
+        });
+    });
+
+    it('should not create new cache entry if "allowCreation" is false', async () => {
+        // Mock a function to simulate fetching data
+        const fn = vi.fn((value) => Promise.resolve(value));
+        // Initialize a new Query with a mock client, a key function, and an expiration time
+        const query = new Query({
+            client: { fn },
+            key: (id) => id,
+            expire: 1000,
+        });
+
+        const args = 'foo';
+        const value = { value: 'bar' };
+
+        query.mutate(args, () => value, { allowCreation: false });
+
+        const cacheKey = query.generateCacheKey(args);
+
+        console.log('cache', cacheKey, value, query.cache.state);
+        expect(query.cache.has(cacheKey)).toBe(false);
+    });
+
     it('should fail when mutating if there are no records with matching key', async () => {
         // Create a new Query instance with a mocked fetch function, a simple key function, and an expiration time
         const query = new Query({


### PR DESCRIPTION
## Why
This PR introduces enhancements to the `Query` class in the `@equinor/fusion-query` package. It adds a new public method `generateCacheKey` and enhances the `mutate` method with more flexible cache mutation options.

### New features and improvements:
- Added `generateCacheKey` method for advanced caching scenarios and debugging
- Enhanced `mutate` method with an optional `options` parameter
- Introduced `allowCreation` option for more flexible cache management
- Updated internal `QueryCache` class to support new features


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

