### PR TITLE
Fix/include comments in types

### DIFF
--- a/.changeset/rich-elephants-shout.md
+++ b/.changeset/rich-elephants-shout.md
@@ -1,0 +1,79 @@
+---
+'@equinor/fusion-framework-module-ag-grid': patch
+'@equinor/fusion-framework-module': patch
+'@equinor/fusion-framework-module-event': patch
+'@equinor/fusion-framework-module-http': patch
+'@equinor/fusion-framework-app': patch
+'@equinor/fusion-framework-cli': patch
+'@equinor/fusion-framework': patch
+'@equinor/fusion-framework-module-app': patch
+'@equinor/fusion-framework-module-bookmark': patch
+'@equinor/fusion-framework-module-context': patch
+'@equinor/fusion-framework-module-feature-flag': patch
+'@equinor/fusion-framework-module-msal': patch
+'@equinor/fusion-framework-module-navigation': patch
+'@equinor/fusion-framework-module-service-discovery': patch
+'@equinor/fusion-framework-module-services': patch
+'@equinor/fusion-framework-module-signalr': patch
+'@equinor/fusion-framework-module-telemetry': patch
+'@equinor/fusion-framework-module-widget': patch
+'@equinor/fusion-framework-react-app': patch
+'@equinor/fusion-framework-react-components-bookmark': patch
+'@equinor/fusion-framework-react-components-people-provider': patch
+'@equinor/fusion-framework-react': patch
+'@equinor/fusion-framework-legacy-interopt': patch
+'@equinor/fusion-framework-react-module-bookmark': patch
+'@equinor/fusion-framework-react-module-context': patch
+'@equinor/fusion-framework-react-module-event': patch
+'@equinor/fusion-framework-react-module-http': patch
+'@equinor/fusion-framework-react-module': patch
+'@equinor/fusion-framework-react-module-signalr': patch
+'@equinor/fusion-framework-react-widget': patch
+'@equinor/fusion-log': patch
+'@equinor/fusion-observable': patch
+'@equinor/fusion-query': patch
+'@equinor/fusion-framework-widget': patch
+---
+
+Removed the `removeComments` option from the `tsconfig.base.json` file.
+
+Removing the `removeComments` option allows TypeScript to preserve comments in the compiled JavaScript output. This can be beneficial for several reasons:
+
+1. Improved debugging: Preserved comments can help developers understand the code better during debugging sessions.
+2. Documentation: JSDoc comments and other important code documentation will be retained in the compiled output.
+3. Source map accuracy: Keeping comments can lead to more accurate source maps, which is crucial for debugging and error tracking.
+
+No action is required from consumers of the library. This change affects the build process and doesn't introduce any breaking changes or new features.
+
+Before:
+
+```json
+{
+    "compilerOptions": {
+        "module": "ES2022",
+        "target": "ES6",
+        "incremental": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "sourceMap": true,
+        "moduleResolution": "node"
+    }
+}
+```
+
+After:
+
+```json
+{
+    "compilerOptions": {
+        "module": "ES2022",
+        "target": "ES6",
+        "incremental": true,
+        "preserveConstEnums": true,
+        "sourceMap": true,
+        "moduleResolution": "node"
+    }
+}
+```
+
+This change ensures that comments are preserved in the compiled output, potentially improving the development and debugging experience for users of the Fusion Framework.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
         "module": "ES2022",
         "target": "ES6",
         "incremental": true,
-        "removeComments": true,
         "preserveConstEnums": true,
         "sourceMap": true,
         "moduleResolution": "node",


### PR DESCRIPTION
## Why

This PR removes the `removeComments` option from the `tsconfig.base.json` file across multiple packages in the Fusion Framework. This change allows TypeScript to preserve comments in the compiled JavaScript output.

The current behavior removes comments during compilation. The new behavior will retain comments, which provides several benefits:

1. Improved debugging by preserving contextual information in comments
2. Retention of important code documentation like JSDoc comments
3. More accurate source maps for better debugging and error tracking

This PR does not introduce any breaking changes or new features. It only affects the build process.

### Changes

- Removed `"removeComments": true` from `tsconfig.base.json`
- Updated 35 packages to patch version

### Impact

This change will improve the development and debugging experience for users of the Fusion Framework by preserving helpful comments in the compiled output. No action is required from consumers of the library.


closes: N/A


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

