### PR TITLE
refactor(module): Update ConfigBuilderCallback to use ObservableInput

### DIFF
--- a/.changeset/cool-vans-worry.md
+++ b/.changeset/cool-vans-worry.md
@@ -1,0 +1,6 @@
+---
+'@equinor/fusion-framework-module': patch
+---
+
+`ConfigBuilderCallback` in `BaseConfigBuilder` has now type-guard for only accepting `ObservableInput` as the return type.
+The method never supported synchronous return types, but the type-guard was missing.

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -86,7 +86,7 @@ export type ConfigBuilderCallbackArgs<TConfig = unknown, TRef = unknown> = {
  */
 export type ConfigBuilderCallback<TReturn = unknown> = (
     args: ConfigBuilderCallbackArgs,
-) => TReturn | ObservableInput<TReturn>;
+) => ObservableInput<TReturn>;
 
 /**
  * The `BaseConfigBuilder` class is an abstract class that provides a flexible and extensible way to build and configure modules.


### PR DESCRIPTION
`ConfigBuilderCallback` in `BaseConfigBuilder` has now type-guard for only accepting `ObservableInput` as the return type.

The method never supported synchronous return types, but the type-guard was missing.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

