### PR TITLE
feat(module-event): allow event detail mutation

### DIFF
--- a/.changeset/popular-mangos-rescue.md
+++ b/.changeset/popular-mangos-rescue.md
@@ -1,0 +1,25 @@
+---
+'@equinor/fusion-framework-module-event': minor
+---
+
+Added feature for allowing the event listener to mutate the event details.
+
+**NOTE:** to not break the current behavior, the event creator needs to set the `allowMutate` flag to `true` in the event details.
+
+```ts
+/** example of event listener */
+eventModule.on('foo', (event) => {
+    event.updateDetails((details) => {
+        details.foo = 'bar';
+    });
+});
+
+/** example of event creation */
+const event = new CustomEvent({ foo: 'foo' }, { allowMutate: true });
+await eventModule.emit(event);
+
+console.log(event.details.foo); // bar
+console.log(event.originalDetails.foo); // foo
+```
+
+The package now uses `immer` to allow for immutability of the event details. This means that the event details can be mutated in the event listener without affecting the original event details.

--- a/packages/modules/event/package.json
+++ b/packages/modules/event/package.json
@@ -28,7 +28,8 @@
         "directory": "packages/modules/event"
     },
     "dependencies": {
-        "@equinor/fusion-framework-module": "workspace:^"
+        "@equinor/fusion-framework-module": "workspace:^",
+        "immer": "^9.0.16"
     },
     "devDependencies": {
         "rxjs": "^7.8.1",

--- a/packages/modules/event/src/event.ts
+++ b/packages/modules/event/src/event.ts
@@ -1,42 +1,92 @@
 import type { ModuleInstance } from '@equinor/fusion-framework-module';
 import type { IEventModuleProvider } from './provider';
 
+import { produce, type Draft } from 'immer';
+
 export declare interface FrameworkEventMap {
     onModulesLoaded: FrameworkEvent<FrameworkEventInit<ModuleInstance, IEventModuleProvider>>;
 }
 
+/**
+ * Represents a handler function for framework events.
+ * @template TType - The type of the framework event.
+ * @param event - The framework event object.
+ * @returns A promise that resolves when the handler has completed its execution, or void if no promise is returned.
+ */
 export type FrameworkEventHandler<TType extends IFrameworkEvent = IFrameworkEvent> = (
     event: TType,
 ) => Promise<void> | void;
 
+/**
+ * Represents a framework event.
+ *
+ * @template TInit - The type of the event initialization options.
+ * @template TType - The type of the event name.
+ */
 export interface IFrameworkEvent<
     TInit extends FrameworkEventInit = FrameworkEventInit,
     TType extends string = string,
 > {
-    /** name of event */
+    /** Name of the event. */
     readonly type: TType;
 
-    /** timestamp of creation */
+    /** Timestamp of creation. */
     readonly created: number;
 
-    /** payload of event */
+    /** Payload of the event. */
     readonly detail: FrameworkEventInitDetail<TInit>;
 
-    /** source of event (dispatcher) */
+    /** Original payload of the event. */
+    readonly originalDetail: FrameworkEventInitDetail<TInit>;
+
+    /** Source of the event (dispatcher). */
     readonly source?: FrameworkEventInitSource<TInit>;
 
+    /** Indicates whether the event can be canceled. */
     readonly cancelable?: boolean;
+
+    /** Indicates whether the event detail is mutable */
+    readonly allowEventDetailsMutation: boolean;
+
+    /** Indicates whether the event has been canceled and should not be processed further. */
     readonly canceled?: boolean;
+
+    /** Indicates whether the event can bubble up. */
     readonly bubbles?: boolean;
+
+    /**
+     * Updates the details of the framework event.
+     *
+     * @note updating the details should only be allowed if the event is mutable.
+     *
+     * @param fn - A function that takes the current draft of the event details and returns the updated details, or `void` to cancel the update.
+     */
+    updateDetails(
+        fn: (
+            details: Draft<FrameworkEventInitDetail<TInit>>,
+        ) => FrameworkEventInitDetail<TInit> | void | undefined,
+    ): void;
 }
 
-/** initial args of event  */
+/**
+ * initial args of event
+ *
+ * @template TDetail - type of event detail, event data payload
+ * @template TSource - type of event source
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FrameworkEventInit<TDetail = any, TSource = any> = {
+    /** Event data */
     detail: TDetail;
+    /** Flag for allowing to mutate event data */
+    mutableDetails?: boolean;
+    /** Source of the event trigger */
     source?: TSource;
+    /** Flag for allowing events to be canceled */
     cancelable?: boolean;
+    /** Timestamp of when event was created */
     created?: number;
+    /** Flag for allowing event to propagate to parent scope  */
     canBubble?: boolean;
 };
 
@@ -72,7 +122,22 @@ export interface FrameworkEvent<TInit extends FrameworkEventInit> {
 }
 
 /**
- * Event Object
+ * Represents a framework event with customizable details and behavior.
+ *
+ * The `FrameworkEvent` class implements the `IFrameworkEvent` interface and provides a way to create and manage events
+ * with custom details and behavior. It allows you to:
+ *
+ * - Specify the event type and initial event details
+ * - Access the event details, including the original details and any updates
+ * - Check if the event is cancelable and whether it has been canceled
+ * - Control whether the event can bubble up the event hierarchy
+ * - Update the event details during the event lifecycle
+ *
+ * The `FrameworkEvent` class is designed to be used as a base class for creating custom event types that fit the needs
+ * of your application or framework.
+ *
+ * @template TInit The type of the event details.
+ * @template TType The type of the event type.
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class FrameworkEvent<
@@ -81,9 +146,11 @@ export class FrameworkEvent<
 > implements IFrameworkEvent<TInit, TType>
 {
     #detail: FrameworkEventInitDetail<TInit>;
+    #originalDetail: FrameworkEventInitDetail<TInit>;
     #source?: FrameworkEventInitSource<TInit>;
     #canceled = false;
     #cancelable: boolean;
+    #mutableDetails: boolean;
     #canBubble: boolean;
     #created: number = Date.now();
 
@@ -91,50 +158,127 @@ export class FrameworkEvent<
         private __type: string,
         args: TInit,
     ) {
-        this.#detail = args.detail as FrameworkEventInitDetail<TInit>;
-        this.#source = args.source as FrameworkEventInitSource<TInit>;
+        this.#detail = produce(args.detail, () => {}) as FrameworkEventInitDetail<TInit>;
+        this.#mutableDetails = !!args.mutableDetails;
+        this.#originalDetail = produce(args.detail, () => {}) as FrameworkEventInitDetail<TInit>;
+        this.#source = produce(args.source, () => {}) as FrameworkEventInitSource<TInit>;
         this.#cancelable = !!args.cancelable;
         this.#canBubble = args.canBubble === undefined ? true : args.canBubble;
     }
 
-    /** flag for if the event can propagate */
+    /**
+     * Indicates whether the event can bubble up the event hierarchy.
+     * The event will only bubble if this property is `true` and the event has not been canceled.
+     * @returns {boolean} `true` if the event can bubble, `false` otherwise.
+     */
     public get bubbles(): boolean {
         return this.#canBubble && !this.#canceled;
     }
 
+    /**
+     * Gets the timestamp when the `FrameworkEvent` was created.
+     * @returns {number} The timestamp of when the `FrameworkEvent` was created.
+     */
     public get created(): number {
         return this.#created;
     }
 
+    /**
+     * Indicates whether the event is cancelable.
+     * If the event is cancelable, it can be prevented from occurring by calling the `preventDefault()` method.
+     * @returns {boolean} `true` if the event is cancelable, `false` otherwise.
+     */
     public get cancelable(): boolean {
         return this.#cancelable;
     }
 
+    /**
+     * Indicates whether the event has been canceled.
+     * If the event is cancelable and `preventDefault()` has been called, this property will be `true`.
+     * @returns {boolean} `true` if the event has been canceled, `false` otherwise.
+     */
     public get canceled(): boolean {
         return this.#canceled;
     }
 
+    /**
+     * Gets the current event details.
+     * @returns {FrameworkEventInitDetail<TInit>} The current event details.
+     */
     public get detail(): FrameworkEventInitDetail<TInit> {
         return this.#detail;
     }
 
+    /**
+     * Gets the original event details that were passed to the `FrameworkEvent` constructor.
+     * This property provides access to the original event details, which may have been modified by the `updateDetails` method.
+     * @returns {FrameworkEventInitDetail<TInit>} The original event details.
+     */
+    public get originalDetail(): FrameworkEventInitDetail<TInit> {
+        return this.#originalDetail;
+    }
+
+    /**
+     * Gets the source object that triggered the event.
+     * @returns {FrameworkEventInitSource<TInit> | undefined} The source object that triggered the event, or `undefined` if the source is not available.
+     */
     public get source(): FrameworkEventInitSource<TInit> | undefined {
         return this.#source;
     }
 
+    /**
+     * Gets the type of the `FrameworkEvent`.
+     * @returns {TType} The type of the `FrameworkEvent`.
+     */
     public get type(): TType {
         return this.__type as TType;
     }
 
-    /** cancel the event */
+    /**
+     * Indicates whether the event details can be mutated.
+     * If this property is `true`, the event details can be updated using the `updateDetails` method.
+     * @returns {boolean} `true` if the event details can be mutated, `false` otherwise.
+     */
+    public get allowEventDetailsMutation(): boolean {
+        return this.#mutableDetails;
+    }
+
+    /**
+     * Prevents the default action of the event from occurring, if the event is cancelable.
+     * If the event is cancelable, this method sets the `canceled` property to `true`.
+     */
     public preventDefault() {
         if (this.cancelable) {
             this.#canceled = true;
         }
     }
 
-    /** prevent event to bubble */
+    /**
+     * Prevents the event from bubbling up the DOM tree, effectively stopping its propagation.
+     * This method sets the `#canBubble` property to `false`, which indicates that the event should not be propagated further.
+     */
     public stopPropagation(): void {
         this.#canBubble = false;
+    }
+
+    /**
+     * Updates the event details using the provided function.
+     *
+     * @note If the event details are not mutable, an error will be thrown.
+     *
+     * @see {FrameworkEvent.originalDetail}
+     *
+     * @param fn - A function that takes the current event details and returns an updated version of the details.
+     * The function can return `void` or `undefined` to indicate that no changes should be made.
+     */
+    public updateDetails(
+        fn: (
+            details: Draft<FrameworkEventInitDetail<TInit>>,
+        ) => FrameworkEventInitDetail<TInit> | void | undefined,
+    ) {
+        if (!this.#mutableDetails) {
+            throw new Error('Event details are not mutable');
+        }
+        this.#detail = produce(this.#detail, fn) as FrameworkEventInitDetail<TInit>;
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,9 @@ importers:
       '@equinor/fusion-framework-module':
         specifier: workspace:^
         version: link:../module
+      immer:
+        specifier: ^9.0.16
+        version: 9.0.21
     devDependencies:
       rxjs:
         specifier: ^7.8.1


### PR DESCRIPTION
Add a feature enabling event listeners to mutate event details, controlled by a new `allowMutate` flag in the event creation process. This enhancement leverages `immer` for immutability, ensuring that original event details remain unaffected by mutations in listeners.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

