### PR TITLE
feat: Add try-catch block for creating immutable copies of event details

### DIFF
--- a/.changeset/forty-trees-flow.md
+++ b/.changeset/forty-trees-flow.md
@@ -1,0 +1,14 @@
+---
+'@equinor/fusion-framework-module-event': patch
+---
+
+Mutating complex objects like class instances would cause immer to throw an error. This change adds a try-catch block around the creation of immutable copies of event details to handle potential errors and disable mutations if the event details cannot be securely mutated.
+
+**added:**
+-   Imported `enableMapSet` from `immer` and invoked `enableMapSet()` to support Map and Set types in Immer drafts.
+-   Added a try-catch block around the creation of immutable copies of event details to handle potential errors and disable mutations if the event details cannot be securely mutated.
+
+**modified:**
+-   Removed the initial assignment of `#detail` and `#originalDetail` to the immutable copy produced by `immer`. Instead, they are initially assigned the raw `args.detail` value.
+-   The assignment of `#detail` and `#originalDetail` to an immutable copy is now done inside the try block, ensuring that mutations are only disabled upon failure to create an immutable copy.
+-   The assignment of `#source` is now done directly from `args.source` without attempting to create an immutable copy.


### PR DESCRIPTION
The code changes add a try-catch block around the creation of immutable copies of event details in order to handle potential errors and disable mutations if the event details cannot be securely mutated. Additionally, the changes import and invoke `enableMapSet` from `immer` to support Map and Set types in Immer drafts.

Modified:
- Removed the initial assignment of `#detail` and `#originalDetail` to the immutable copy produced by `immer`. Instead, they are initially assigned the raw `args.detail` value.
- The assignment of `#detail` and `#originalDetail` to an immutable copy is now done inside the try block, ensuring that mutations are only disabled upon failure to create an immutable copy.
- The assignment of `#source` is now done directly from `args.source` without attempting to create an immutable copy.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

