### PR TITLE
feat: Add new select method to FlowSubject

### DIFF
--- a/.changeset/real-pigs-destroy.md
+++ b/.changeset/real-pigs-destroy.md
@@ -1,0 +1,61 @@
+---
+'@equinor/fusion-observable': minor
+---
+
+Added new constructor overloads and a `select` method to `FlowSubject` for enhanced state management and selection capabilities.
+
+The `FlowSubject` class now supports constructor overloading, allowing for more flexible initialization with either a `ReducerWithInitialState<S, A>` or a `Reducer<S, A>` along with an `initialState`. This change enables users to set up the initial state of their `FlowSubject` instances in a way that best suits their application's needs.
+
+Additionally, a new `select` method has been introduced. This method allows users to select and emit derived states from the `FlowSubject`'s state based on custom logic. The `select` method takes a `selector` function for computing the derived state and an optional `comparator` function for custom comparison logic, making state management more versatile and efficient.
+
+The `selector` exposes an shorthand method for selecting derived states from the `FlowSubject`'s state without the need to import and use `map` and `distinctUntilChanged` operators from `RxJS`.
+
+Consumers should update their code to utilize the new constructor overloads for initializing `FlowSubject` instances as needed. For advanced state management scenarios, consider using the `select` method to work with derived states efficiently. These changes are backward compatible and aim to provide more flexibility and functionality to the `FlowSubject` class.
+
+```typescript
+/** Example of using the new constructor with a reducer with initial state */
+const reducerWithInitial = createReducer(
+    { count: 0 }, // initial state
+    (builder) => {
+        builder.addCase('increment', (state) => {
+            state.count += 1;
+        });
+        builder.addCase('decrement', (state) => {
+            state.count -= 1;
+        });
+    },
+);
+const subject = new FlowSubject(reducerWithInitial);
+```
+
+```typescript
+/** Example of using the new constructor with a plain reducer and initial state */
+const reducer = (state, action) => {
+  switch(action.type) {
+    case 'increment':
+      return { ...state, count: state.count + 1 };
+    case 'decrement':
+      return return { ...state, count: state.count - 1 };
+  }
+}
+const flowSubject = new FlowSubject(reducer, { count: 0 });
+```
+
+```typescript
+/** Example of using the new select method */
+flowSubject
+    .select(
+        /** selector function */
+        (state) => state.count,
+        /** comparator function, optional, will use equal by default */
+        (prev, next) => prev === next,
+    )
+    .subscribe(
+        /** subscriber function */
+        (count) => console.log(count),
+    );
+
+flowSubject.next({ type: 'increment' }); // logs 1
+flowSubject.next({ type: 'increment' }); // logs 2
+flowSubject.next({ type: 'decrement' }); // logs 1
+```

--- a/packages/utils/observable/src/FlowSubject.ts
+++ b/packages/utils/observable/src/FlowSubject.ts
@@ -12,6 +12,7 @@ import {
     catchError,
     distinctUntilChanged,
     filter,
+    map,
     mergeMap,
     observeOn,
     scan,
@@ -62,6 +63,19 @@ export class FlowSubject<S, A extends Action = Action> extends Observable<S> {
     }
 
     /**
+     * Creates a new instance of the FlowSubject class with an initial state reducer.
+     * @param reducer A reducer with an initial state or a reducer function.
+     */
+    constructor(reducer: ReducerWithInitialState<S, A>);
+
+    /**
+     * Create a new instance of the FlowSubject class with a reducer function and initial state.
+     * @param reducer state reducer
+     * @param initialState initial state
+     */
+    constructor(reducer: Reducer<S, A>, initialState: S);
+
+    /**
      * Initializes a new instance of the FlowSubject class.
      *
      * @param reducer A reducer with an initial state or a reducer function.
@@ -90,6 +104,20 @@ export class FlowSubject<S, A extends Action = Action> extends Observable<S> {
      */
     public next(action: A): void {
         this.#action.next(action);
+    }
+
+    /**
+     * Selects a derived state from the observable state and emits only when the selected state changes.
+     *
+     * @param selector - A function that takes the current state and returns a derived state.
+     * @param comparator - An optional function that compares the previous and current derived states to determine if a change has occurred.
+     * @returns An observable that emits the derived state whenever it changes.
+     */
+    public select<T>(
+        selector: (state: S) => T,
+        comparator?: (previous: T, current: T) => boolean,
+    ): Observable<T> {
+        return this.#state.pipe(map(selector), distinctUntilChanged(comparator));
     }
 
     /**


### PR DESCRIPTION
Adds new constructor overloads to the FlowSubject class, allowing for more flexible initialization with either a ReducerWithInitialState<S, A> or a Reducer<S, A> along with an initialState. It also introduces a new select method, which enables users to select and emit derived states from the FlowSubject's state based on custom logic. These changes enhance state management and selection capabilities in the FlowSubject class.



### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

