### PR TITLE
feat: Fix type inference for dot path in utils/dot-path.ts

### DIFF
--- a/.changeset/tidy-timers-think.md
+++ b/.changeset/tidy-timers-think.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module': patch
+---
+
+fixed type for infering dot path

--- a/packages/modules/module/src/utils/dot-path.ts
+++ b/packages/modules/module/src/utils/dot-path.ts
@@ -1,9 +1,7 @@
 export type DotPath<TObject extends object> = {
-    [Key in keyof TObject & string]: TObject[Key] extends CallableFunction
-        ? never
-        : TObject[Key] extends object
-          ? `${Key}` | `${Key}.${DotPath<TObject[Key]>}`
-          : `${Key}`;
+    [Key in keyof TObject & string]: TObject[Key] extends object
+        ? `${Key}` | `${Key}.${DotPath<TObject[Key]>}`
+        : `${Key}`;
 }[keyof TObject & string];
 
 export type DotPathType<TType, TPath extends string> = TPath extends keyof TType


### PR DESCRIPTION
### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

