### PR TITLE
feat(module): Improve handling of configuration callbacks

### DIFF
--- a/.changeset/empty-ants-remain.md
+++ b/.changeset/empty-ants-remain.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-module': patch
+---
+
+Improved Configuration Callback Handling
+
+BaseConfigBuilder.\_buildConfig will now correctly handle asynchronous configuration callbacks. This change simplifies the handling of asynchronous configuration callbacks by removing the `async` keyword and directly using RxJS operators.

--- a/packages/modules/module/src/BaseConfigBuilder.ts
+++ b/packages/modules/module/src/BaseConfigBuilder.ts
@@ -1,5 +1,5 @@
 import { from, lastValueFrom, of, type Observable, type ObservableInput } from 'rxjs';
-import { mergeMap, reduce, switchMap } from 'rxjs/operators';
+import { map, mergeMap, reduce, switchMap } from 'rxjs/operators';
 import { Modules, ModuleType } from './types';
 import { type DotPath, type DotPathType } from './utils/dot-path';
 
@@ -300,12 +300,7 @@ export abstract class BaseConfigBuilder<TConfig extends object = Record<string, 
     ): ObservableInput<Partial<TConfig>> {
         return from(Object.entries<ConfigBuilderCallback>(this.#configCallbacks)).pipe(
             // Transform each config callback into a target-value pair
-            mergeMap(async ([target, cb]) => {
-                // Execute callback with init and await result
-                const value = await cb(init);
-                // Return target-value pair
-                return { target, value };
-            }),
+            mergeMap(([target, cb]) => from(cb(init)).pipe(map((value) => ({ target, value })))),
             // Reduce the target-value pairs into a single configuration object
             reduce(
                 // Assign each value to the corresponding target in the accumulator


### PR DESCRIPTION
This commit improves the handling of asynchronous configuration callbacks in the BaseConfigBuilder class. The BaseConfigBuilder._buildConfig method now correctly handles asynchronous configuration callbacks by removing the 'async' keyword and directly using RxJS operators. This change simplifies the handling of asynchronous configuration callbacks and improves the overall code structure.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

