### PR TITLE
fix(utils/log): Remove formatting of log messages in ConsoleLogger

### DIFF
--- a/.changeset/nine-knives-reply.md
+++ b/.changeset/nine-knives-reply.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-log': minor
+---
+
+Removed formatting of messages in the `log` function. Now the messages are printed as they are, without any additional formatting. This is done to make the messages more readable and to avoid any additional formatting that might be added by the user. Formatting objects would result in the console outputting `[[object,object]]` which was not very helpful.

--- a/packages/utils/log/src/ConsoleLogger.ts
+++ b/packages/utils/log/src/ConsoleLogger.ts
@@ -62,23 +62,12 @@ export class ConsoleLogger extends Logger {
      * @returns An array of unknown, representing the formatted log message.
      */
     protected _createMessage(lvl: LogLevel, ...msg: unknown[]): unknown[] {
-        return this._formatMessage(lvl, this._formatTitle(lvl), ...msg);
+        return [this._formatTitle(lvl), ...msg];
     }
 
     protected _formatTitle(_lvl: LogLevel): string {
         const title = [this.title, this.subtitle].filter((x) => !!x).join(' - ');
         return chalk.magenta(title);
-    }
-
-    protected _formatMessage(lvl: LogLevel, ...msg: unknown[]): unknown[] {
-        switch (lvl) {
-            case LogLevel.Debug:
-                return [chalk.dim(...msg)];
-            case LogLevel.Warning:
-                return [chalk.bold(...msg)];
-            default:
-                return msg;
-        }
     }
 
     /**

--- a/packages/utils/log/src/ConsoleLogger.ts
+++ b/packages/utils/log/src/ConsoleLogger.ts
@@ -66,8 +66,13 @@ export class ConsoleLogger extends Logger {
     }
 
     protected _formatTitle(_lvl: LogLevel): string {
-        const title = [this.title, this.subtitle].filter((x) => !!x).join(' - ');
-        return chalk.magenta(title);
+        const title = chalk.magenta([this.title, this.subtitle].filter((x) => !!x).join(' - '));
+        switch (_lvl) {
+            case LogLevel.Warning:
+            case LogLevel.Error:
+                return chalk.bold(title);
+        }
+        return title;
     }
 
     /**

--- a/packages/utils/log/tests/ConsoleLogger.test.ts
+++ b/packages/utils/log/tests/ConsoleLogger.test.ts
@@ -11,7 +11,8 @@ describe('Console logger', () => {
         logger.level = LogLevel.Debug;
         logger.debug('This is a debug message');
         expect(spy).toHaveBeenCalledWith(
-            chalk.dim(chalk.magenta('MainLogger'), 'This is a debug message'),
+            chalk(chalk.magenta('MainLogger')),
+            'This is a debug message',
         );
     });
     it('should log info messages', () => {
@@ -28,7 +29,8 @@ describe('Console logger', () => {
         logger.level = LogLevel.Warning;
         logger.warn('This is a warning message');
         expect(spy).toHaveBeenCalledWith(
-            chalk.bold(chalk.magenta('MainLogger'), 'This is a warning message'),
+            chalk.bold.magenta('MainLogger'),
+            'This is a warning message',
         );
     });
 
@@ -37,7 +39,10 @@ describe('Console logger', () => {
         const logger = new ConsoleLogger('MainLogger');
         logger.level = LogLevel.Error;
         logger.error('This is an error message');
-        expect(spy).toHaveBeenCalledWith(chalk.magenta('MainLogger'), 'This is an error message');
+        expect(spy).toHaveBeenCalledWith(
+            chalk.bold.magenta('MainLogger'),
+            'This is an error message',
+        );
     });
 
     it('should log multiple messages', () => {


### PR DESCRIPTION
## Why

Browser console did not format correctly objects

<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

