### PR TITLE
feat(react-framework): Support framework creation with ref

### DIFF
--- a/.changeset/thirty-rats-exercise.md
+++ b/.changeset/thirty-rats-exercise.md
@@ -1,0 +1,19 @@
+---
+'@equinor/fusion-framework-react': minor
+---
+
+These changes ensure that the `Framework` component and `createFrameworkProvider` function are consistent with the updated configuration approach and support module instances from the parent context.
+
+**Updated Framework Component:**
+
+-   Added `useModules` hook to import modules from the parent context.
+-   Updated the `createFrameworkProvider` function to accept a `ref` parameter for module instances.
+
+**Updated create-framework-provider Function:**
+
+-   Added `ref` parameter to the `createFrameworkProvider` function to support module instances.
+-   Updated the example usage in the documentation to reflect the changes.
+
+**Misc:**
+
+-   Replaced deprecated import of `FusionConfigurator` with `FrameworkConfigurator` (renaming).

--- a/packages/react/framework/src/Framework.tsx
+++ b/packages/react/framework/src/Framework.tsx
@@ -1,8 +1,9 @@
-import { FusionConfigurator } from '@equinor/fusion-framework';
+import { FrameworkConfigurator } from '@equinor/fusion-framework';
 import { createFrameworkProvider } from './create-framework-provider';
 import { PropsWithChildren, ReactNode, Suspense, useMemo } from 'react';
+import { useModules } from '@equinor/fusion-framework-react-module';
 
-type ConfigureCallback = (configurator: FusionConfigurator) => void;
+type ConfigureCallback = (configurator: FrameworkConfigurator) => void;
 
 export const Framework = (
     props: PropsWithChildren<{
@@ -11,7 +12,9 @@ export const Framework = (
     }>,
 ) => {
     const { configure, fallback, children } = props;
-    const Component = useMemo(() => createFrameworkProvider(configure), [configure]);
+    //import modules from parent context
+    const ref = useModules<[]>();
+    const Component = useMemo(() => createFrameworkProvider(configure, ref), [configure, ref]);
     return (
         <Suspense fallback={fallback}>
             <Component>{children}</Component>

--- a/packages/react/framework/src/create-framework-provider.tsx
+++ b/packages/react/framework/src/create-framework-provider.tsx
@@ -1,9 +1,9 @@
 import React, { lazy } from 'react';
 import initFusion from '@equinor/fusion-framework';
-import { FusionConfigurator } from '@equinor/fusion-framework';
+import { FrameworkConfigurator } from '@equinor/fusion-framework';
 
 import { FrameworkProvider } from './context';
-import type { AnyModule } from '@equinor/fusion-framework-module';
+import type { AnyModule, ModulesInstanceType } from '@equinor/fusion-framework-module';
 import { ModuleProvider } from '@equinor/fusion-framework-react-module';
 
 /**
@@ -14,7 +14,7 @@ import { ModuleProvider } from '@equinor/fusion-framework-react-module';
  * @param configurator - callback for configuring modules
  * @example
  * ```tsx
- * const config: FusionConfigurator = (config) => {}
+ * const config: FrameworkConfigurator = (config) => {}
  * const Portal = () => {
  *   const Framework = createFrameworkProvider(config);
  *   return (
@@ -25,13 +25,18 @@ import { ModuleProvider } from '@equinor/fusion-framework-react-module';
  * };
  * ```
  */
-export const createFrameworkProvider = <TModules extends Array<AnyModule> = []>(
-    cb: (configurator: FusionConfigurator<TModules>) => void | Promise<void>,
+export const createFrameworkProvider = <
+    TModules extends Array<AnyModule> = [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TRef extends ModulesInstanceType<[AnyModule]> = any,
+>(
+    cb: (configurator: FrameworkConfigurator<TModules>, ref?: TRef) => void | Promise<void>,
+    ref?: TRef,
 ): React.LazyExoticComponent<React.FunctionComponent<React.PropsWithChildren<unknown>>> =>
     lazy(async () => {
-        const configurator = new FusionConfigurator<TModules>();
-        await cb(configurator);
-        const framework = await initFusion(configurator);
+        const configurator = new FrameworkConfigurator<TModules>();
+        await cb(configurator, ref);
+        const framework = await initFusion(configurator, ref);
         return {
             default: ({ children }: { children?: React.ReactNode }) => (
                 <FrameworkProvider value={framework}>


### PR DESCRIPTION
This commit updates the Framework component and createFrameworkProvider function to be consistent with the updated configuration approach and support module instances from the parent context. The following changes were made:

- Added useModules hook to import modules from the parent context in the Framework component.
- Updated the createFrameworkProvider function to accept a ref parameter for module instances.
- Replaced the deprecated import of FusionConfigurator with FrameworkConfigurator.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

