### PR TITLE
fix(module): Allow `void` in config callbacks 

### DIFF
--- a/.changeset/clean-fans-kick.md
+++ b/.changeset/clean-fans-kick.md
@@ -1,0 +1,57 @@
+**@equinor/fusion-framework-module:**
+
+Updated the `_buildConfig` method in `BaseConfigBuilder` to improve error handling and configuration merging.
+
+- Enhanced `_buildConfig` to log errors when a configuration callback fails, providing more detailed error messages.
+- Improved the merging process of configuration callbacks by filtering out undefined values and mapping them to target-value pairs.
+- Updated the `_buildConfig` method to initialize the accumulator with the initial configuration or an empty object.
+
+```ts
+type MyConfig = {
+  foo?: number;
+  bar?: string;
+}
+
+const initial = {foo: 1, bar: 'baz'};
+
+export class MyConfigurator extends BaseConfigBuilder<MyConfig> {
+  setFoo(cb: ConfigBuilderCallback<MyConfig['foo']>){
+    this._set('foo', cb);
+  }
+  setBar(cb: ConfigBuilderCallback<MyConfig['bar']>){
+    this._set('bar', cb);
+  }
+}
+
+const configurator =  MyConfigurator();
+
+configurator.setFoo(async () => {
+  if(someCondition) // do some async work
+});
+
+configurator.setBar(() => {
+  return 'override';
+});
+
+configurator.createConfig(initial).subscribe(console.log);
+```
+_Output:_
+
+```diff
+- {foo: undefined, bar: 'override'}
++ {foo: 1, bar: 'override'}
+```
+
+Example of a failed configuration callback:
+
+```ts
+configurator.setFoo(async () => {
+  throw new Error('Failed to set foo');
+});
+```
+
+_Output:_
+```diff
+- Configuration failed
++ {foo: 1, bar: 'override'}
+```


### PR DESCRIPTION
**@equinor/fusion-framework-module:**

Updated the `_buildConfig` method in `BaseConfigBuilder` to improve error handling and configuration merging.

- Enhanced `_buildConfig` to log errors when a configuration callback fails, providing more detailed error messages.
- Improved the merging process of configuration callbacks by filtering out undefined values and mapping them to target-value pairs.
- Updated the `_buildConfig` method to initialize the accumulator with the initial configuration or an empty object.

```ts
type MyConfig = {
  foo?: number;
  bar?: string;
}

const initial = {foo: 1, bar: 'baz'};

export class MyConfigurator extends BaseConfigBuilder<MyConfig> {
  setFoo(cb: ConfigBuilderCallback<MyConfig['foo']>){
    this._set('foo', cb);
  }
  setBar(cb: ConfigBuilderCallback<MyConfig['bar']>){
    this._set('bar', cb);
  }
}

const configurator =  MyConfigurator();

configurator.setFoo(async () => {
  if(someCondition) // do some async work
});

configurator.setBar(() => {
  return 'override';
});

configurator.createConfig(initial).subscribe(console.log);
```
_Output:_

```diff
- {foo: undefined, bar: 'override'}
+ {foo: 1, bar: 'override'}
```

Example of a failed configuration callback:

```ts
configurator.setFoo(async () => {
  throw new Error('Failed to set foo');
});
```

_Output:_
```diff
- Configuration failed
+ {foo: 1, bar: 'override'}
```

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

