### PR TITLE
feat(cli): create plugin for serving index.html from external public directory

### DIFF
--- a/.changeset/hot-ears-fix.md
+++ b/.changeset/hot-ears-fix.md
@@ -1,0 +1,30 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+**@equinor/fusion-framework-cli:**
+
+Create a plugin `externalPublicPlugin` to fix the issue with serving the `index.html` file from the specified external public directory. Vite mode `spa` will not serve the `index.html` file from the specified external public directory.
+
+-   Enhanced the middleware to intercept requests and serve the `index.html` file from the specified external public directory.
+-   Transformed the HTML using Vite's `transformIndexHtml` method.
+-   Applied appropriate content headers and additional configured headers before sending the response.
+
+```typescript
+const viteConfig = {
+  roo
+    plugins: [
+        // path wich contains the index.html file
+        externalPublicPlugin('./my-portal'),
+    ],
+};
+
+const viteConfig = defineConfig({
+    // vite configuration
+    root: './src', // this where vite will look for the index.html file
+    plugins: [
+        // path which contains the index.html file
+        externalPublicPlugin('./my-portal'),
+    ],
+});
+```

--- a/packages/cli/src/bin/plugins/external-public.ts
+++ b/packages/cli/src/bin/plugins/external-public.ts
@@ -1,0 +1,71 @@
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+import { type Plugin } from 'vite';
+
+/**
+ * Creates a plugin that serves an external public directory.
+ *
+ * This plugin is useful when you want to serve a static site from a different directory than the one where the Vite server is running.
+ * Vite`s built in `mode: 'spa'` will only look for the `index.html` file in the configured `root` directory,
+ * so this plugin is necessary to serve the `index.html` file from a different directory.
+ *
+ * @param path - The path to the external public directory.
+ * @returns A Plugin object configured to serve the specified public directory.
+ *
+ * The plugin:
+ * - Sets the `publicDir` configuration to the provided path.
+ * - Adds a middleware to the server that serves the `index.html` file from the specified path.
+ *
+ * The middleware:
+ * - Reads the `index.html` file from the specified path.
+ * - Transforms the HTML using the server's `transformIndexHtml` method.
+ * - Responds with the transformed HTML, setting appropriate headers.
+ */
+export const externalPublicPlugin = (path: string): Plugin => {
+    return {
+        name: 'fusion:external-public',
+        apply: 'serve',
+        config(config) {
+            config.publicDir = path;
+        },
+        configureServer(server) {
+            // intercept requests to serve the index.html file
+            server.middlewares.use(async (req, res, next) => {
+                if (
+                    // Only accept GET or HEAD
+                    (req.method !== 'GET' && req.method !== 'HEAD') ||
+                    // Only accept text/html
+                    !req.headers.accept?.includes('text/html')
+                ) {
+                    return next();
+                }
+                try {
+                    // load the raw html from provided path
+                    const htmlRaw = readFileSync(join(path, 'index.html'), 'utf-8');
+                    // transform the html, this is where vite plugin hooks are applied
+                    const html = await server.transformIndexHtml(
+                        req.url!,
+                        htmlRaw,
+                        req.originalUrl,
+                    );
+
+                    // apply content headers and configured additional headers
+                    res.writeHead(200, {
+                        'content-type': 'text/html',
+                        'content-length': Buffer.byteLength(html),
+                        'cache-control': 'no-cache',
+                        ...server.config.server.headers,
+                    });
+
+                    // send the transformed html and end the response
+                    res.end(html);
+                } catch (e) {
+                    next(e);
+                }
+            });
+        },
+    };
+};
+
+export default externalPublicPlugin;


### PR DESCRIPTION
<!-- What kind of change does this PR introduce? -->
This PR introduces a new plugin `externalPublicPlugin` for the `@equinor/fusion-framework-cli`.

<!-- What is the current behavior? -->
Currently, Vite's `spa` mode does not serve the `index.html` file from the specified external public directory.

<!-- What is the new behavior? -->
The new plugin `externalPublicPlugin` fixes this issue by:
- Enhancing the middleware to intercept requests and serve the `index.html` file from the specified external public directory.
- Transforming the HTML using Vite's `transformIndexHtml` method.
- Applying appropriate content headers and additional configured headers before sending the response.

<!-- Does this PR introduce a breaking change? -->
No, this PR does not introduce a breaking change.

<!-- Other information? -->
closes:

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).