### PR TITLE
refactor(module): fixed issue where post handlers where empty

### DIFF
--- a/.changeset/spotty-eels-care.md
+++ b/.changeset/spotty-eels-care.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module': patch
+---
+
+fixed issue where post handlers where empty


### PR DESCRIPTION
## Why

module configurator would throw error if post configure handlers where empty

replaced `scan` with `reduce` in `configurator.initialize`, since reduce always will emit at least initial value, while scan only emits if source emits values.

fixed handlers for `configurator._postInitialize`
```diff
- await lastVelaueFrom(postInitialize$)
+ await new Promise((resolve, reject) => {
+   postInitialize$.subscribe({complete: () => resolve(true), error: reject });
+ });
```

`lastVelaueFrom(postInitialize$)`would fail since `postInitialize$` did not emit any values


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

