### PR TITLE
feat(http): Add support for resolving URLs with a base URL that contains a path

### DIFF
--- a/.changeset/rotten-drinks-sneeze.md
+++ b/.changeset/rotten-drinks-sneeze.md
@@ -1,0 +1,21 @@
+---
+'@equinor/fusion-framework-module-http': minor
+---
+
+**@equinor/fusion-framework-module-http**
+
+`HttpClient._resolveUrl` now supports resolving URLs with a base URL that contains a path.
+
+before:
+
+```typescript
+const client = new HttpClient('https://example.com/test/me');
+client.fetch('/api'); // https://example.com/api
+```
+
+now:
+
+```typescript
+const client = new HttpClient('https://example.com/test/me');
+client.fetch('/api'); // https://example.com/test/me/api
+```

--- a/packages/modules/http/src/lib/client/client.ts
+++ b/packages/modules/http/src/lib/client/client.ts
@@ -347,7 +347,8 @@ export class HttpClient<
      * @returns The full URL for the given path.
      */
     protected _resolveUrl(path: string): string {
-        const baseUrl = this.uri || window.location.origin;
-        return new URL(path, baseUrl).href;
+        const { origin, pathname: basePath } = new URL(this.uri || window.location.origin);
+        const pathname = [basePath, path].join('/').replace(/\/{2,}/g, '/');
+        return new URL(pathname, origin).href;
     }
 }


### PR DESCRIPTION
This PR adds a new feature to the `HttpClient` class in the `@equinor/fusion-framework-module-http` package. The `HttpClient._resolveUrl` method now supports resolving URLs with a base URL that contains a path.

Before this change, when using the `HttpClient` to fetch a relative path, the base URL was not taken into account. With this change, the `HttpClient` correctly resolves the URL by appending the relative path to the base URL.

before:

```typescript
const client = new HttpClient('https://example.com/test/me');
client.fetch('/api'); // https://example.com/api
```

now:

```typescript
const client = new HttpClient('https://example.com/test/me');
client.fetch('/api'); // https://example.com/test/me/api
```

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

