### PR TITLE
fix(http): Update baseUri to use origin of URL

### DIFF
--- a/.changeset/plenty-horses-accept.md
+++ b/.changeset/plenty-horses-accept.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+changed service discover url to match #c776845e753acf4a0bceda1c59d31e5939c44c31

--- a/packages/cli/src/bin/dev-portal/config.ts
+++ b/packages/cli/src/bin/dev-portal/config.ts
@@ -15,7 +15,7 @@ export const configure = async (config: FrameworkConfigurator) => {
 
     config.configureServiceDiscovery({
         client: {
-            baseUri: import.meta.url,
+            baseUri: new URL(import.meta.url).origin,
             defaultScopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
         },
     });


### PR DESCRIPTION
## Why

changed service discover url to match #2452

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

