### PR TITLE
feat(service-discovery): Align service discovery with API service

### DIFF
--- a/.changeset/angry-cows-lay.md
+++ b/.changeset/angry-cows-lay.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-widget': patch
+---
+
+Update defaultScopes in WidgetConfigurator

--- a/.changeset/funny-pumpkins-train.md
+++ b/.changeset/funny-pumpkins-train.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-legacy-interopt': minor
+---
+
+Updated createServiceResolver to match service discovery module
+
+**BREAKING CHANGES:**
+
+now requires `@equinor/fusion-framework-module-service-discovery^8`

--- a/.changeset/moody-parents-confess.md
+++ b/.changeset/moody-parents-confess.md
@@ -1,0 +1,14 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+**@equinor/fusion-framework-cli**
+
+Updated the CLI to use the new service discovery API.
+
+> [!NOTE]
+> This is a quick fix until the new major version of the CLI is released.
+
+-   Updated the `baseUri` to use a more specific URL path for service discovery.
+-   Changed from `new URL(import.meta.url).origin` to `String(new URL('/_discovery/environments/current', import.meta.url))`.
+-   Changed parsing of service discovery response to match new API format.

--- a/.changeset/nervous-clocks-rest.md
+++ b/.changeset/nervous-clocks-rest.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-module-signalr': patch
+---
+
+Update configureFromFramework to handle authentication scopes

--- a/.changeset/violet-phones-hang.md
+++ b/.changeset/violet-phones-hang.md
@@ -1,0 +1,65 @@
+---
+'@equinor/fusion-framework-module-service-discovery': major
+---
+
+The Service Discovery module has been totally revamped to provide a more flexible and robust solution for service discovery in the Fusion Framework.
+The module now relies on the Fusion Service Discovery API to fetch services and their configurations, which allows for more dynamic and real-time service discovery.
+
+The module now follows the "best practices" for configuration and usage, and it is now easier to configure and use the Service Discovery module in your applications. But this also means that the module has breaking changes that may require updates to existing implementations.
+
+> [!NOTE]
+> This module can still be configured to resolve custom services, as long as the client implements the `IServiceDiscoveryClient` interface.
+
+**Documentation Updates**
+
+-   The README file has been updated to reflect the new configuration options and usage patterns for the Service Discovery module.
+-   Added sections for simple and advanced configurations, including examples of how to override the default HTTP client key and set a custom service discovery client.
+
+**Code Changes:**
+
+-   🔨 package.json: Added `zod` as a new dependency for schema validation.
+-   💫 api-schema.ts: Added schema for the expected response from the `ServiceProviderClient`
+-   💫 client.ts: Created `serviceResponseSelector` for parsing and validating client respons.
+-   🔨 client.ts: Updated `IServiceDiscoveryClient` interface to include methods for resolving services and fetching services from the API.
+-   🔨 client.ts: Updated `ServiceDiscoveryClient` to use the new `serviceResponseSelector`
+-   💫 configurator.ts: Introduced new methods for setting and configuring the service discovery client.
+-   🔨 configurator.ts: Updated `ServiceDiscoveryConfigurator` to extend the `BaseConfigBuilder`
+-   🔨 configurator.ts: Added error handling and validation for required configurations.
+
+**BREAKING CHANGES:**
+
+-   The type `Service` has deprecated the `defaultScopes` property in favor of `scopes`.
+-   The `IServiceDiscoveryClient` interface has been updated, which may require changes in implementations that use this interface.
+-   The `ServiceDiscoveryConfigurator` now extends `BaseConfigBuilder`, which will affect existing configurations.
+-   The `ServiceDiscoveryProvider.resolveServices` method now returns `Service[]` (previously `Environment`).
+
+> [!NOTE]
+> Only the `ServiceDiscoveryProvider.resolveServices` should affect end-users,
+> as it changes the return type of the method.
+> The other changes are internal and should not affect existing implementations.
+
+**Consumer Migration Guide:**
+
+`defaultScopes` has been replaced with `scopes` in the `Service` type. Update your code to use the new property.
+
+If you are using the `ServiceDiscoveryProvider.resolveServices` method, update your code to expect an array of `Service` objects instead of an `Environment` object.
+
+```typescript
+// Before
+const { services } = await serviceDiscoveryProvider.resolveServices('my-service');
+// After
+const services = await serviceDiscoveryProvider.resolveServices('my-service');
+```
+
+> [!WARNING]
+> The preious `Environment` object had a `clientId` property, which is now removed, since every service can have its own client id, hence the `scopes` property in the `Service` object.
+
+**Configuration Migration Guide:**
+
+> If you are consuming the `@equinor/fusion-framework` and only configuring the http client, no changes are required.
+
+If you are manually enabling the Service Discovery module, update your configuration to use the new methods provided by `ServiceDiscoveryConfigurator`.
+Refer to the updated README for detailed configuration examples and usage patterns.
+
+> [!WARNING]
+> The `ServiceDiscoveryConfigurator` now extends `BaseConfigBuilder`, which means that the configuration methods have changed.

--- a/packages/cli/src/bin/dev-portal/config.ts
+++ b/packages/cli/src/bin/dev-portal/config.ts
@@ -15,7 +15,7 @@ export const configure = async (config: FrameworkConfigurator) => {
 
     config.configureServiceDiscovery({
         client: {
-            baseUri: new URL(import.meta.url).origin,
+            baseUri: String(new URL('/_discovery/environments/current', import.meta.url)),
             defaultScopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
         },
     });

--- a/packages/modules/service-discovery/README.md
+++ b/packages/modules/service-discovery/README.md
@@ -1,24 +1,133 @@
-# Fusion Service Provider
+# Fusion Service Discovery Module
+
+This module is for resolving service endpoints from a service discovery service.
+
+> [!WARNING]
+> This module requires `@equinor/fusion-framework-module-http` to to create http clients, so the module must be enabled in runtime.
 
 ## Configure
 
-```ts
+This module requires a http client to be configured. The http client should be configured with a key that is used to resolve the service endpoints.
 
-/** configure the client which should fetch service descriptions */ 
-config.http.configureClient('my_service_discovery', {
-  baseUri: 'https://foo.bar',
-  defaultScopes: ['321312bab2-3213123bb-321312aa2/.default'],
+> [!NOTE]
+> The Service Discovery Module inherits configuration when used in sub-modules (ex. Application), which means that the http client should be configured in the root module (ex Portal).
+> 
+> Skip this step if the http client is already configured.
+
+```typescript
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+const configurator = new ModulesConfigurator();
+configurator.addConfig(
+    configureHttpClient(
+      'service_discovery', 
+      { /* http config */ }
+    )
+);
+```
+
+### Simple Configuration
+
+In the simplest form, the service discovery module can be enabled with the following code:
+
+```typescript
+import enableServiceDiscovery from '@equinor/fusion-framework-service-discovery';
+
+// the module will setup the service discovery client with default configuration
+// Assumes that http client is configured with key 'service_discovery'
+enableServiceDiscovery(configurator);
+```
+
+#### Override default http client key
+
+If the http client is configured with a different key, the key can be specified as follows:
+
+```typescript
+enableServiceDiscovery(
+  configurator, 
+  async(builder: ServiceDiscoveryConfigurator) => {
+    builder.configureServiceDiscoveryClientByClientKey(
+      // assume that http client is configured with this key
+      'service_discovery_custom', 
+      // optional endpoint path
+      '/custom/services' 
+    );
 });
+```
 
-/** key of configured http client, default `service_discovery` */
-config.serviceDiscovery.clientKey = 'my_service_discovery'
+### Advanced Configuration
 
-/** endpoint for fetching services */
-config.serviceDiscovery.uri = 'api/services';
+#### Override default http client
 
-/** parse http response to service discovery environment */
-config.serviceDiscovery.selector = async (response: Response): Promise<Environment> => {
-  const services = await response.json() as Service[];
-  return services.reduce((acc, service) => Object.assign(acc, {[service.key]: service}), {});
-}
+If a custom http client is required, the client can be configured as follows:
+
+```typescript
+enableServiceDiscovery(
+  configurator, 
+  async(builder: ServiceDiscoveryConfigurator) => {
+    builder.configureServiceDiscoveryClient(
+      // configurator callback
+      async (args: ConfigBuilderCallbackArgs) => {
+        // using build environment to create a http client
+        const httpProvider = await requireInstance('http');
+        const httpClient = httpProvider.createClient('some_key');
+        return { 
+          httpClient: httpProvider.createClient('some_key'),
+          endpoint: '/custom/services'
+        };
+      }
+    );
+});
+```
+
+#### Setting a custom service discovery client
+
+If a custom service discovery client is required, the client can be configured as follows:
+
+```typescript
+enableServiceDiscovery(
+  configurator, 
+  async(builder: ServiceDiscoveryConfigurator) => {
+    builder.setServiceDiscoveryClient(
+      {
+        resolveServices() {
+          return [
+            { 
+              key: 'service1', 
+              url: 'http://service1.com' 
+            },
+            { 
+              key: 'service2', 
+              url: 'http://service2.com' 
+            }
+          ]
+        },
+        resolveService(key: string): Promise<ServiceEndpoint> {
+          return this.services.find(s => s.key === key);
+        }
+      }
+    );
+});
+```
+
+If custom logic for creating the service discovery client is required, the client can be configured as follows:
+
+```typescript
+enableServiceDiscovery(
+  configurator, 
+  async(builder: ServiceDiscoveryConfigurator) => {
+    builder.setServiceDiscoveryClient(
+      async(args: ConfigBuilderCallbackArgs) => {
+        const httpProvider = await requireInstance('http');
+        const httpClient = httpProvider.createClient('my_key');
+        return {
+          resolveServices() {
+            return httpClient.get('/services');
+          },
+          resolveService(key: string): Promise<ServiceEndpoint> {
+            return httpClient.get(`/services/${key}`);
+          }
+        };
+      }
+    );
+});
 ```

--- a/packages/modules/service-discovery/package.json
+++ b/packages/modules/service-discovery/package.json
@@ -29,7 +29,8 @@
         "@equinor/fusion-framework-module": "workspace:^",
         "@equinor/fusion-framework-module-http": "workspace:^",
         "@equinor/fusion-query": "workspace:^",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "zod": "^3.23.8"
     },
     "devDependencies": {
         "typescript": "^5.5.4"

--- a/packages/modules/service-discovery/src/api-schema.ts
+++ b/packages/modules/service-discovery/src/api-schema.ts
@@ -1,0 +1,42 @@
+import z from 'zod';
+
+/**
+ * Represents a service from the service discovery API.
+ */
+const ApiService = z
+    .object({
+        key: z.string().describe('The key used to identify the service'),
+        uri: z.string().describe('The URI of the service'),
+        id: z.string().optional().describe('The ID of the service'),
+        environment: z.string().optional().describe('The environment of the service'),
+        name: z.string().optional().describe('The name of the service'),
+        scopes: z
+            .array(z.string())
+            .optional()
+            .default([])
+            .describe('Endpoint authentication scopes'),
+        tags: z.array(z.string()).optional().describe('Tags for the service'),
+    })
+    .describe('A service from the service discovery API')
+    .transform((value) => ({
+        ...value,
+        /** @deprecated use `scopes`  */
+        get defaultScopes() {
+            console.warn('The `defaultScopes` property is deprecated. Use `scopes` instead.');
+            return value.scopes ?? [];
+        },
+    }));
+
+/**
+ * Represents a list of services from the service discovery API.
+ *
+ * This constant is an array of `ApiService` objects, which are defined
+ * elsewhere in the codebase. It uses the `z.array` method from the Zod
+ * library to enforce that the array contains only `ApiService` objects.
+ *
+ * @constant
+ * @description A list of services from the service discovery API.
+ */
+export const ApiServices = z
+    .array(ApiService)
+    .describe('A list of services from the service discovery API');

--- a/packages/modules/service-discovery/src/configurator.ts
+++ b/packages/modules/service-discovery/src/configurator.ts
@@ -1,54 +1,118 @@
-import { ModulesInstanceType } from '@equinor/fusion-framework-module';
-import { HttpModule, IHttpClient } from '@equinor/fusion-framework-module-http';
+import { from, lastValueFrom, ObservableInput } from 'rxjs';
 
-import type { IServiceDiscoveryClient, IServiceDiscoveryClientCtor } from './client';
+import {
+    BaseConfigBuilder,
+    type ConfigBuilderCallback,
+    type ConfigBuilderCallbackArgs,
+} from '@equinor/fusion-framework-module';
 
-export interface IServiceDiscoveryConfigurator {
-    /** name of HttpClient */
-    clientKey?: string;
+import { type IHttpClient } from '@equinor/fusion-framework-module-http';
 
-    endpoint?: string;
+import { type IServiceDiscoveryClient, ServiceDiscoveryClient } from './client';
 
-    clientCtor: IServiceDiscoveryClientCtor;
-
-    createHttpClientClient: (
-        http: ModulesInstanceType<[HttpModule]>['http'],
-    ) => Promise<IHttpClient>;
-
-    createClient: (http: IHttpClient) => Promise<IServiceDiscoveryClient>;
+export interface ServiceDiscoveryConfig {
+    /** Service Discovery client */
+    discoveryClient: IServiceDiscoveryClient;
 }
 
-export class ServiceDiscoveryConfigurator implements IServiceDiscoveryConfigurator {
-    public clientKey?: string;
-    public endpoint?: string;
-    clientCtor: IServiceDiscoveryClientCtor;
+export class ServiceDiscoveryConfigurator extends BaseConfigBuilder<ServiceDiscoveryConfig> {
+    protected async _createConfig(
+        init: ConfigBuilderCallbackArgs,
+        initial?: Partial<ServiceDiscoveryConfig> | undefined,
+    ): Promise<ServiceDiscoveryConfig> {
+        if (!init.hasModule('http')) {
+            throw new Error('http module is required');
+        }
 
-    constructor(args: {
-        clientCtor: IServiceDiscoveryClientCtor;
-        clientKey?: string;
-        endpoint?: string;
-    }) {
-        this.clientKey = args.clientKey;
-        this.endpoint = args.endpoint;
-        this.clientCtor = args.clientCtor;
+        // check if http module has a client with key 'service_discovery'
+        const httpProvider = await init.requireInstance('http');
+        if (httpProvider.hasClient('service_discovery')) {
+            this.configureServiceDiscoveryClientByClientKey('service_discovery');
+        }
+
+        // convert parent to promise
+        return lastValueFrom(from(super._createConfig(init, initial)));
     }
 
-    async createHttpClientClient(
-        http: ModulesInstanceType<[HttpModule]>['http'],
-    ): Promise<IHttpClient> {
-        if (!this.clientKey) {
-            throw Error('no http client for service discovery is provided!');
+    /**
+     * Processes the service discovery configuration.
+     *
+     * @param config - A partial configuration object for service discovery.
+     * @param init - Initialization arguments for the configuration builder callback.
+     * @returns An observable input of the complete service discovery configuration.
+     * @throws Will throw an error if `discoveryClient` is not configured.
+     */
+    protected _processConfig(
+        config: Partial<ServiceDiscoveryConfig>,
+        init: ConfigBuilderCallbackArgs,
+    ): ObservableInput<ServiceDiscoveryConfig> {
+        if (!config.discoveryClient) {
+            throw new Error('discoveryClient is required, please configure it');
         }
-        return http.createClient(this.clientKey);
+        return super._processConfig(config, init);
     }
 
-    async createClient(http: IHttpClient): Promise<IServiceDiscoveryClient> {
-        if (!this.endpoint) {
-            throw Error('no endpoint defined!');
-        }
-        return new this.clientCtor({
-            http,
-            endpoint: this.endpoint,
+    /**
+     * Sets the service discovery client.
+     *
+     * @param discoveryClient - An instance of `IServiceDiscoveryClient` or a callback function that returns an instance of `IServiceDiscoveryClient`.
+     *
+     * This method configures the service discovery client by either directly setting the provided instance or by invoking the provided callback function to obtain the instance.
+     */
+    setServiceDiscoveryClient(
+        discoveryClient: IServiceDiscoveryClient | ConfigBuilderCallback<IServiceDiscoveryClient>,
+    ): void {
+        this._set(
+            'discoveryClient',
+            typeof discoveryClient === 'function' ? discoveryClient : async () => discoveryClient,
+        );
+    }
+
+    /**
+     * Configures the Service Discovery Client with the provided configuration callback.
+     *
+     * @param configCallback - A callback function that takes an argument of type `{ httpClient: IHttpClient; endpoint?: string }`
+     * and returns a configuration object. The `httpClient` is required, while the `endpoint` is optional.
+     *
+     * @throws {Error} Throws an error if `httpClient` is not provided in the configuration.
+     */
+    configureServiceDiscoveryClient(
+        configCallback: ConfigBuilderCallback<{ httpClient: IHttpClient; endpoint?: string }>,
+    ): void {
+        this.setServiceDiscoveryClient(async (args) => {
+            const { httpClient, endpoint } =
+                (await lastValueFrom(from(configCallback(args)))) ?? {};
+            if (httpClient) {
+                return new ServiceDiscoveryClient({
+                    http: httpClient,
+                    endpoint,
+                });
+            }
+            throw Error('httpClient is required');
+        });
+    }
+
+    /**
+     * Configures a service discovery client using the provided client key and optional endpoint.
+     *
+     * @param clientKey - The key used to identify the client.
+     * @param endpoint - An optional endpoint to be used by the service discovery client.
+     *
+     * @remarks
+     * The http module must have a configured client which match provided `clientKey`.
+     *
+     * This method sets up the service discovery client by requiring an HTTP provider instance,
+     * creating an HTTP client with the given client key, and returning an object containing
+     * the HTTP client and the optional endpoint.
+     */
+    configureServiceDiscoveryClientByClientKey(clientKey: string, endpoint?: string): void {
+        this.configureServiceDiscoveryClient(async ({ requireInstance }) => {
+            const httpProvider = await requireInstance('http');
+            const httpClient = httpProvider.createClient(clientKey);
+            return {
+                httpClient,
+                endpoint,
+            };
         });
     }
 }

--- a/packages/modules/service-discovery/src/constants.ts
+++ b/packages/modules/service-discovery/src/constants.ts
@@ -1,1 +1,0 @@
-export const moduleName = 'serviceDiscovery';

--- a/packages/modules/service-discovery/src/index.ts
+++ b/packages/modules/service-discovery/src/index.ts
@@ -4,6 +4,11 @@
  */
 
 export * from './types';
-export { IServiceDiscoveryConfigurator, ServiceDiscoveryConfigurator } from './configurator';
+export { ServiceDiscoveryConfigurator } from './configurator';
 export { IServiceDiscoveryProvider, ServiceDiscoveryProvider } from './provider';
-export { default, ServiceDiscoveryModule, setupServiceDiscoveryModule } from './module';
+export {
+    default,
+    ServiceDiscoveryModule,
+    configureServiceDiscovery,
+    enableServiceDiscovery,
+} from './module';

--- a/packages/modules/service-discovery/src/module.ts
+++ b/packages/modules/service-discovery/src/module.ts
@@ -1,43 +1,116 @@
-import { IServiceDiscoveryConfigurator, ServiceDiscoveryConfigurator } from './configurator';
+import { ServiceDiscoveryConfigurator } from './configurator';
 import { IServiceDiscoveryProvider, ServiceDiscoveryProvider } from './provider';
 
-import type { Module, ModulesConfigType } from '@equinor/fusion-framework-module';
+import type {
+    IModuleConfigurator,
+    Module,
+    ModulesConfigurator,
+} from '@equinor/fusion-framework-module';
 import type { HttpModule } from '@equinor/fusion-framework-module-http';
-import { ServiceDiscoveryClient } from './client';
-import { moduleName } from './constants';
+
+export const moduleName = 'serviceDiscovery';
 
 export type ServiceDiscoveryModule = Module<
     typeof moduleName,
     IServiceDiscoveryProvider,
-    IServiceDiscoveryConfigurator,
+    ServiceDiscoveryConfigurator,
     [HttpModule]
 >;
 
 /**
- *  Configure http-client
+ * Represents the Service Discovery module configuration.
+ *
+ * @remarks
+ * This module is responsible for configuring and initializing the service discovery mechanism.
+ * It ensures that the service discovery configuration is created and the necessary dependencies
+ * are initialized before providing the service discovery provider.
+ *
+ * @returns {Promise<ServiceDiscoveryProvider>} - Returns a promise that resolves to the service discovery provider.
+ *
+ * @remarks
+ * The initialization process involves creating the service discovery configuration, which may include
+ * inheriting configurations from a parent module. This pattern, while allowing reuse of cache and ensuring
+ * up-to-date configurations, can be risky as it exposes the child module to potential breaking changes
+ * from the parent module's client.
+ *
+ * Additionally, the service discovery module requires the HTTP module to be initialized before it can
+ * function properly.
  */
 export const module: ServiceDiscoveryModule = {
     name: moduleName,
-    // deps: ['http'],
-    configure: () =>
-        new ServiceDiscoveryConfigurator({
-            clientCtor: ServiceDiscoveryClient,
-            clientKey: 'service_discovery',
-            endpoint: '/_discovery/environments/current',
-        }),
-    initialize: async ({ config, requireInstance }) => {
+    configure: () => new ServiceDiscoveryConfigurator(),
+    initialize: async (init) => {
+        const { requireInstance, ref } = init;
+
+        // create service discovery configuration
+        const config = await init.config.createConfigAsync(init, {
+            /**
+             * @remarks
+             * This is a dangerous pattern, as it allows the child module to access the parent module's client.
+             * The client client could implement breaking changes that would affect the child module.
+             * On the positive side, it allows the child module to reuse cache and always be up to date.
+             */
+            ...ref?.serviceDiscovery?.config,
+        });
+
+        // service discovery requires http module to be initialized
         const httpModule = await requireInstance('http');
-        const httpClient = await config.createHttpClientClient(httpModule);
-        const discoClient = await config.createClient(httpClient);
-        return new ServiceDiscoveryProvider(discoClient, httpModule);
+
+        // return service discovery provider
+        return new ServiceDiscoveryProvider(config, httpModule);
     },
 };
 
-export const setupServiceDiscoveryModule = (
-    config: ModulesConfigType<[ServiceDiscoveryModule]>,
-    callback: (config: IServiceDiscoveryConfigurator) => void,
-): void | Promise<void> => {
-    callback(config.serviceDiscovery);
+/**
+ * Configures the Service Discovery module.
+ *
+ * @template TRef - The type reference for the module configurator.
+ * @param callback - A function that takes a `ServiceDiscoveryConfigurator` and returns a promise that resolves when the configuration is complete.
+ * @returns An object implementing `IModuleConfigurator` for the `ServiceDiscoveryModule` with the provided configuration.
+ *
+ * @example
+ * ```typescript
+ * import { configureServiceDiscovery } from '@equinor/fusion-framework-module-service-discovery';
+ *
+ * const config = (configurator: ModuleConfigurator) => {
+ *  configurator.addConfig(configureServiceDiscovery(async (config) => {
+ *      // custom configuration
+ * });
+ * ```
+ */
+export const configureServiceDiscovery = <TRef>(
+    callback: (config: ServiceDiscoveryConfigurator) => Promise<void>,
+): IModuleConfigurator<ServiceDiscoveryModule, TRef> => ({
+    module,
+    configure: (config: ServiceDiscoveryConfigurator) => callback(config),
+});
+
+/**
+ * Enables the service discovery module by adding its configuration to the provided configurator.
+ *
+ * @param configurator - The configurator to which the service discovery configuration will be added.
+ * @param callback - An optional callback function that can be used to customize the service discovery configuration.
+ *
+ * @example
+ * ```typescript
+ * import { enableServiceDiscovery } from '@equinor/fusion-framework-module-service-discovery';
+ *
+ * const config = (configurator: ModuleConfigurator) => {
+ *     // simple
+ *     enableServiceDiscovery(configurator);
+ *
+ *     // with custom configuration
+ *     enableServiceDiscovery(configurator, async (config) => {
+ *         config.configureServiceDiscoveryClientByClientKey('service-discovery-custom');
+ *     });
+ * };
+ * ```
+ */
+export const enableServiceDiscovery = (
+    configurator: ModulesConfigurator<[HttpModule]>,
+    callback?: (config: ServiceDiscoveryConfigurator) => Promise<void>,
+): void => {
+    configurator.addConfig(configureServiceDiscovery(callback ?? (() => Promise.resolve())));
 };
 
 declare module '@equinor/fusion-framework-module' {

--- a/packages/modules/service-discovery/src/types.ts
+++ b/packages/modules/service-discovery/src/types.ts
@@ -1,21 +1,13 @@
-export type EnvironmentResponse = {
-    clientId: string;
-    services: Array<{
-        key: string;
-        uri: string;
-        defaultScopes?: Array<string>;
-    }>;
-};
-
-export type Environment = {
-    type?: string;
-    clientId: string;
-    services: Record<string, Service>;
-};
-
 export type Service = {
-    name?: null | string;
-    clientId?: string;
+    key: string;
     uri: string;
+    scopes?: string[];
+    id?: string;
+    name?: string;
+    tags?: string[];
+
+    /**
+     * @deprecated use scopes instead
+     */
     defaultScopes: string[];
 };

--- a/packages/modules/signalr/src/lib/utils/configure-from-framework.ts
+++ b/packages/modules/signalr/src/lib/utils/configure-from-framework.ts
@@ -14,8 +14,13 @@ export const configureFromFramework = async (
         url: new URL(args.path, service.uri).toString(),
         options: {
             accessTokenFactory: async () => {
+                if (!service.scopes) {
+                    throw Error(
+                        `service [${service.name}] does not have authentication scopes, please configure an endpoint with scopes`,
+                    );
+                }
                 const token = await authProvider.acquireAccessToken({
-                    scopes: service.defaultScopes,
+                    scopes: service.scopes ?? service.defaultScopes,
                 });
                 if (!token) {
                     throw Error('failed to acquire access token');

--- a/packages/react/legacy-interopt/src/create-service-resolver.ts
+++ b/packages/react/legacy-interopt/src/create-service-resolver.ts
@@ -4,8 +4,20 @@ import { PortalFramework } from './types';
 export const createServiceResolver = async (
     provider: PortalFramework['modules']['serviceDiscovery'],
     authContainer: LegacyAuthContainer,
+    clientId: string = window.clientId,
 ) => {
-    const { services, clientId } = await provider.resolveServices();
+    if (!clientId) {
+        throw new Error('clientId is required');
+    }
+    const services = await provider.resolveServices().then((services) =>
+        services.reduce(
+            (acc, service) => {
+                acc[service.key] = service;
+                return acc;
+            },
+            {} as Record<string, { uri: string }>,
+        ),
+    );
     /** register for legacy auth token */
     await authContainer.registerAppAsync(
         clientId,

--- a/packages/widget/src/WidgetConfigurator.ts
+++ b/packages/widget/src/WidgetConfigurator.ts
@@ -102,7 +102,7 @@ export class WidgetConfigurator<
                 }
                 config.configureClient(serviceName, {
                     baseUri: service.uri,
-                    defaultScopes: service.defaultScopes,
+                    defaultScopes: service.scopes ?? service.defaultScopes,
                 });
             },
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,6 +1011,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       typescript:
         specifier: ^5.5.4
@@ -8490,6 +8493,9 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -17164,3 +17170,5 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
+
+  zod@3.23.8: {}


### PR DESCRIPTION
The Service Discovery module has been totally revamped to provide a more flexible and robust solution for service discovery in the Fusion Framework.
The module now relies on the Fusion Service Discovery API to fetch services and their configurations, which allows for more dynamic and real-time service discovery.

The module now follows the "best practices" for configuration and usage, and it is now easier to configure and use the Service Discovery module in your applications. But this also means that the module has breaking changes that may require updates to existing implementations.

> [!NOTE]
> This module can still be configured to resolve custom services, as long as the client implements the `IServiceDiscoveryClient` interface.

**Documentation Updates**

-   The README file has been updated to reflect the new configuration options and usage patterns for the Service Discovery module.
-   Added sections for simple and advanced configurations, including examples of how to override the default HTTP client key and set a custom service discovery client.

**Code Changes:**

-   🔨 package.json: Added `zod` as a new dependency for schema validation.
-   💫 api-schema.ts: Added schema for the expected response from the `ServiceProviderClient`
-   💫 client.ts: Created `serviceResponseSelector` for parsing and validating client respons.
-   🔨 client.ts: Updated `IServiceDiscoveryClient` interface to include methods for resolving services and fetching services from the API.
-   🔨 client.ts: Updated `ServiceDiscoveryClient` to use the new `serviceResponseSelector`
-   💫 configurator.ts: Introduced new methods for setting and configuring the service discovery client.
-   🔨 configurator.ts: Updated `ServiceDiscoveryConfigurator` to extend the `BaseConfigBuilder`
-   🔨 configurator.ts: Added error handling and validation for required configurations.

**BREAKING CHANGES:**

-   The type `Service` has deprecated the `defaultScopes` property in favor of `scopes`.
-   The `IServiceDiscoveryClient` interface has been updated, which may require changes in implementations that use this interface.
-   The `ServiceDiscoveryConfigurator` now extends `BaseConfigBuilder`, which will affect existing configurations.
-   The `ServiceDiscoveryProvider.resolveServices` method now returns `Service[]` (previously `Environment`).

> [!NOTE]
> Only the `ServiceDiscoveryProvider.resolveServices` should affect end-users,
> as it changes the return type of the method.
> The other changes are internal and should not affect existing implementations.

**Consumer Migration Guide:**

`defaultScopes` has been replaced with `scopes` in the `Service` type. Update your code to use the new property.

If you are using the `ServiceDiscoveryProvider.resolveServices` method, update your code to expect an array of `Service` objects instead of an `Environment` object.

```typescript
// Before
const { services } = await serviceDiscoveryProvider.resolveServices('my-service');
// After
const services = await serviceDiscoveryProvider.resolveServices('my-service');
```

> [!WARNING]
> The preious `Environment` object had a `clientId` property, which is now removed, since every service can have its own client id, hence the `scopes` property in the `Service` object.

**Configuration Migration Guide:**

> If you are consuming the `@equinor/fusion-framework` and only configuring the http client, no changes are required.

If you are manually enabling the Service Discovery module, update your configuration to use the new methods provided by `ServiceDiscoveryConfigurator`.
Refer to the updated README for detailed configuration examples and usage patterns.

> [!WARNING]
> The `ServiceDiscoveryConfigurator` now extends `BaseConfigBuilder`, which means that the configuration methods have changed.
