### PR TITLE
Refactor(app): Update AppBuildManifest and AppManifest types

### DIFF
--- a/.changeset/pink-laws-cough.md
+++ b/.changeset/pink-laws-cough.md
@@ -1,0 +1,19 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+** @equinor/fusion-framework-cli**
+
+**Changes:**
+
+Updated commands in CLI to reflect purpose of the command:
+- renamed `config` to `build-config` to generate build config of an application.
+- renamed `pack`to `build-pack` to bundle an application.
+- added `build-manifest` command to generate build manifest of an application.
+
+> [!WARNING]
+> Config callback for `manifest` and `config` now allows `void` return type. 
+> Return value from callback is now merged with default config instead of replacing it, this might be a breaking change for some applications.
+
+> [!NOTE]
+> This mean that `mergeAppConfig` and `mergeManifestConfig` functions are no longer needed and can be removed from the application.

--- a/cookbooks/app-react/app.config.ts
+++ b/cookbooks/app-react/app.config.ts
@@ -1,12 +1,11 @@
 // demo
-import { mergeAppConfigs, defineAppConfig } from '@equinor/fusion-framework-cli';
-export default defineAppConfig((_nev, { base }) =>
-    mergeAppConfigs(base, {
-        environment: {},
+import { defineAppConfig } from '@equinor/fusion-framework-cli';
+export default defineAppConfig((_nev) => {
+    return {
         endpoints: {
             api: {
                 url: 'https://foo.bars',
             },
         },
-    }),
-);
+    };
+});

--- a/cookbooks/app-react/app.manifest.config.ts
+++ b/cookbooks/app-react/app.manifest.config.ts
@@ -1,9 +1,9 @@
-import { defineAppManifest, mergeManifests } from '@equinor/fusion-framework-cli';
+import { defineAppManifest } from '@equinor/fusion-framework-cli';
 
-export default defineAppManifest((env, { base }) => {
+export default defineAppManifest(async (env) => {
     if (env.command === 'serve') {
-        return mergeManifests(base, {});
+        return {
+            appKey: 'app-react',
+        };
     }
-
-    return base;
 });

--- a/packages/cli/src/bin/build-application.ts
+++ b/packages/cli/src/bin/build-application.ts
@@ -49,10 +49,17 @@ export const buildApplication = async (options: {
 
     viteConfig.build.outDir = outDir.trim();
 
+    spinner.attachConsole = true;
+
+    console.log('Building application...');
+
     const viteBuild = await build(viteConfig);
+
+    spinner.attachConsole = false;
 
     return {
         viteConfig,
         viteBuild,
+        pkg,
     };
 };

--- a/packages/cli/src/bin/bundle-application.ts
+++ b/packages/cli/src/bin/bundle-application.ts
@@ -3,11 +3,10 @@ import AdmZip from 'adm-zip';
 import { dirname, resolve } from 'node:path';
 import { mkdir } from 'node:fs/promises';
 
-import { loadPackage } from './utils/load-package.js';
 import { chalk, formatByteSize, formatPath } from './utils/format.js';
 import { Spinner } from './utils/spinner.js';
 import { buildApplication } from './build-application.js';
-import createExportManifest from './create-export-manifest.js';
+import { createBuildManifest } from './create-export-manifest.js';
 import { fileExistsSync } from '../lib/utils/file-exists.js';
 
 export const bundleApplication = async (options: { outDir: string; archive: string }) => {
@@ -15,16 +14,13 @@ export const bundleApplication = async (options: { outDir: string; archive: stri
 
     const spinner = Spinner.Global({ prefixText: chalk.dim('pack') });
 
-    const pkg = await loadPackage();
-
     spinner.start('build application');
-    await buildApplication({ outDir });
+    const { pkg } = await buildApplication({ outDir });
     spinner.succeed();
 
     spinner.start('generate manifest');
-    const manifest = await createExportManifest({ outputFile: `${outDir}/app-manifest.json` });
-    spinner.succeed();
-    console.log(chalk.dim(JSON.stringify(manifest, undefined, 2)));
+    const buildManifest = await createBuildManifest({ outputFile: `${outDir}/app-manifest.json` });
+    spinner.succeed('generated manifest:', '\n' + JSON.stringify(buildManifest, undefined, 2));
 
     const bundle = new AdmZip();
 
@@ -58,6 +54,9 @@ export const bundleApplication = async (options: { outDir: string; archive: stri
     }
 
     bundle.writeZip(archive);
-    spinner.info(formatPath(archive), formatByteSize(archive));
-    spinner.succeed();
+    spinner.succeed(
+        'Bundle complete',
+        formatPath(archive, { relative: true }),
+        formatByteSize(archive),
+    );
 };

--- a/packages/cli/src/bin/create-export-manifest.ts
+++ b/packages/cli/src/bin/create-export-manifest.ts
@@ -12,7 +12,7 @@ import { loadAppManifest } from './utils/load-manifest.js';
 import { ConfigExecuterEnv } from '../lib/utils/config.js';
 import { loadPackage } from './utils/load-package.js';
 import { dirname } from 'node:path';
-import type { AppManifestExport } from '../lib/app-manifest.js';
+import type { AppManifest } from '@equinor/fusion-framework-module-app';
 
 // TODO  why do we do this??? can`t backend parse semver?
 export const normalizeVersion = (version: string) => {
@@ -23,19 +23,59 @@ export const normalizeVersion = (version: string) => {
     return { major, minor, patch };
 };
 
-export const createExportManifest = async (options?: {
+type CreateManifestOptions = {
     command?: ConfigExecuterEnv['command'];
     configFile?: string;
     outputFile?: string;
-}): Promise<AppManifestExport> => {
-    const { command = 'build', outputFile } = options ?? {};
+    onlyBuild?: boolean;
+};
 
-    const spinner = Spinner.Global({ prefixText: chalk.dim('manifest') });
+export const createAppManifest = async (options?: CreateManifestOptions) => {
+    Spinner.Global({ prefixText: chalk.dim('app manifest') });
+    const manifest = await createManifest(options);
+    if (options?.outputFile) {
+        await writeManifestToDisk(manifest, options.outputFile);
+    } else {
+        console.log(JSON.stringify(manifest, undefined, 2));
+    }
+    return manifest;
+};
 
+export const createBuildManifest = async (options?: CreateManifestOptions) => {
+    Spinner.Global({ prefixText: chalk.dim('build manifest') });
+    const { build } = await createManifest(options);
+    if (options?.outputFile) {
+        await writeManifestToDisk(build, options.outputFile);
+    } else {
+        console.log(JSON.stringify(build, undefined, 2));
+    }
+    return build;
+};
+
+const writeManifestToDisk = async (
+    content: AppManifest | AppManifest['build'],
+    outputFile: string,
+): Promise<void> => {
+    const spinner = Spinner.Clone();
+    spinner.start(`Exporting manifest to ${formatPath(outputFile)}`);
+    try {
+        const dir = dirname(outputFile).trim();
+        if (!nodeFs.existsSync(dirname(outputFile))) {
+            nodeFs.mkdirSync(dir, { recursive: true });
+        }
+        await writeFile(outputFile, JSON.stringify(content));
+        spinner.succeed();
+    } catch (err) {
+        spinner.fail();
+        throw err;
+    }
+};
+
+const createManifest = async (options?: CreateManifestOptions): Promise<AppManifest> => {
     const pkg = await loadPackage();
 
     const env: ConfigExecuterEnv = {
-        command,
+        command: options?.command ?? 'build',
         mode: process.env.NODE_ENV ?? 'development',
         root: pkg.root,
     };
@@ -44,23 +84,5 @@ export const createExportManifest = async (options?: {
         file: options?.configFile,
     });
 
-    if (outputFile) {
-        spinner.start(`outputting manifest to ${formatPath(outputFile)}`);
-        try {
-            const dir = dirname(outputFile).trim();
-            if (!nodeFs.existsSync(dirname(outputFile))) {
-                nodeFs.mkdirSync(dir, { recursive: true });
-            }
-            await writeFile(outputFile, JSON.stringify(manifest));
-            spinner.succeed();
-        } catch (err) {
-            spinner.fail();
-            throw err;
-        }
-    } else {
-        console.log(manifest);
-    }
     return manifest;
 };
-
-export default createExportManifest;

--- a/packages/cli/src/bin/main.app.ts
+++ b/packages/cli/src/bin/main.app.ts
@@ -7,7 +7,7 @@ import { uploadApplication } from './upload-application.js';
 import { tagApplication } from './tag-application.js';
 
 import { formatPath, chalk } from './utils/format.js';
-import createExportManifest from './create-export-manifest.js';
+import { createAppManifest, createBuildManifest } from './create-export-manifest.js';
 import { bundleApplication } from './bundle-application.js';
 import { createExportConfig } from './create-export-config.js';
 import { fileURLToPath } from 'node:url';
@@ -67,6 +67,17 @@ export default (program: Command) => {
             });
         });
 
+    app.command('manifest')
+        .description('Generate manifest')
+        .option('-o, --output <string>', 'output file')
+        .option('-c, --config <string>', 'manifest config file')
+        .action((opt) => {
+            createAppManifest({
+                outputFile: opt.output,
+                configFile: opt.config,
+            });
+        });
+
     app.command('build')
         .description('Builds application')
         .option('-o, --outDir, <string>', 'output directory of package', 'dist')
@@ -96,7 +107,7 @@ export default (program: Command) => {
             });
         });
 
-    app.command('config')
+    app.command('build-config')
         .description('Generate config')
         .option('-o, --output <string>', 'output file')
         .option('-c, --config <string>', 'application config file')
@@ -121,18 +132,19 @@ export default (program: Command) => {
                 service: opt.service,
             });
         });
-    app.command('manifest')
+
+    app.command('build-manifest')
         .description('Generate manifest')
         .option('-o, --output <string>', 'output file')
         .option('-c, --config <string>', 'manifest config file')
         .action((opt) => {
-            createExportManifest({
+            createBuildManifest({
                 outputFile: opt.output,
                 configFile: opt.config,
             });
         });
 
-    app.command('pack')
+    app.command('build-pack')
         .description('Create  distributable app bundle of the application')
         .option('-o, --outDir, <string>', 'output directory of package', 'dist')
         .option('-a, --archive, <string>', 'output filename', 'app-bundle.zip')
@@ -141,7 +153,7 @@ export default (program: Command) => {
             bundleApplication({ archive, outDir });
         });
 
-    app.command('publish')
+    app.command('build-publish')
         .description('Publish application to app api')
         .option(
             '-t, --tag, <string>',
@@ -161,7 +173,7 @@ export default (program: Command) => {
             publishApplication({ tag, env, service });
         });
 
-    app.command('upload')
+    app.command('build-upload')
         .description('Upload packaged app bundle to app api')
         .option(
             '-b, --bundle, <string>',
@@ -181,7 +193,7 @@ export default (program: Command) => {
             uploadApplication({ bundle, env, service });
         });
 
-    app.command('tag')
+    app.command('build-tag')
         .description('Tag a published version')
         .option(
             '-t, --tag, <string>',

--- a/packages/cli/src/bin/utils/load-app-config.ts
+++ b/packages/cli/src/bin/utils/load-app-config.ts
@@ -15,6 +15,9 @@ export const loadAppConfig = async (
     const spinner = Spinner.Current;
     try {
         spinner.start('create application configuration');
+        spinner.info(
+            `generating config with ${chalk.red.dim(env.command)} command in ${chalk.green.dim(env.mode)} mode`,
+        );
         const baseAppConfig = createAppConfigFromPackage(pkg);
         const appConfig = await createAppConfig(env, baseAppConfig, { file: options?.file });
         spinner.succeed();

--- a/packages/cli/src/bin/utils/spinner.ts
+++ b/packages/cli/src/bin/utils/spinner.ts
@@ -3,11 +3,22 @@ import ora, { Options, type Ora } from 'ora';
 const parseArgs = (args: string[]): string | undefined =>
     args.length ? args.join(' ') : undefined;
 
+const originalConsole = console;
+
 export class Spinner {
     #ora: Ora;
 
     get ora(): Ora {
         return this.#ora;
+    }
+
+    set attachConsole(value: boolean) {
+        if (value) {
+            console.log = this.info.bind(this);
+            console.info = this.info.bind(this);
+        } else {
+            console = originalConsole;
+        }
     }
 
     static Global(options?: Options) {

--- a/packages/cli/src/lib/app-config.ts
+++ b/packages/cli/src/lib/app-config.ts
@@ -20,7 +20,7 @@ type FindAppConfigOptions = FindConfigOptions & {
 export type AppConfigFn = (
     env: ConfigExecuterEnv,
     args: { base: AppConfig },
-) => AppConfig | Promise<AppConfig>;
+) => AppConfig | Promise<AppConfig | void> | void;
 export type AppConfigExport = AppConfig | AppConfigFn;
 
 export const appConfigFilename = 'app.config';
@@ -72,7 +72,7 @@ export const createAppConfig = async (
 ): Promise<{ config: AppConfig; path?: string }> => {
     const resolved = await resolveAppConfig(options);
     if (resolved) {
-        const config = await initiateConfig(resolved.config, env, { base });
+        const config = (await initiateConfig(resolved.config, env, { base })) ?? {};
         assertAppConfig(config);
         return { config, path: resolved.path };
     } else if (options?.file) {

--- a/packages/cli/src/lib/app-package.ts
+++ b/packages/cli/src/lib/app-package.ts
@@ -58,10 +58,7 @@ export const resolveEntryPoint = (packageJson: PackageJson, pkgPath: string = ''
     ]
         .filter((x): x is string => !!x)
         .map((x): string => relative(dirname(pkgPath), x))
-        .find((entry) => {
-            console.log(entry, existsSync(entry));
-            return existsSync(entry);
-        });
+        .find((entry) => existsSync(entry));
 
     assert(entrypoint, 'failed to resolve entrypoint');
 

--- a/packages/cli/src/lib/utils/config.ts
+++ b/packages/cli/src/lib/utils/config.ts
@@ -108,13 +108,15 @@ export const loadConfig = async <TType>(file: string): Promise<ConfigExecuter<TT
         case '.json': {
             return async () => JSON.parse(await readFile(file, 'utf-8'));
         }
+        default:
+            throw Error('unsupported file type');
     }
 };
 
 export function initiateConfig<TConfig extends ConfigExecuter>(
     config: TConfig,
     ...args: Parameters<TConfig>
-): Promise<ConfigExecuterType<TConfig>> {
+): Promise<ConfigExecuterType<TConfig> | void> {
     return Promise.resolve(config(...(args as ConfigExecuterArgs)));
 }
 

--- a/packages/cli/src/lib/vite-config.ts
+++ b/packages/cli/src/lib/vite-config.ts
@@ -50,10 +50,10 @@ export const createAppViteConfig = async (
     options?: FindConfigOptions & {
         file?: string;
     },
-): Promise<{ config: UserConfig; path?: string } | void> => {
+): Promise<{ config?: UserConfig; path?: string } | void> => {
     const resolved = await resolveViteConfig(options);
     if (resolved) {
-        const config = await initiateConfig(resolved.config, env);
+        const config = (await initiateConfig(resolved.config, env)) ?? {};
         return { config, path: resolved.path };
     } else if (options?.file) {
         throw new AssertionError({

--- a/packages/modules/app/src/types.ts
+++ b/packages/modules/app/src/types.ts
@@ -50,6 +50,7 @@ export type AppBuildManifest = {
     commitSha?: string;
     githubRepo?: string;
     projectPage?: string;
+    annotations?: Record<string, string>;
     uploadedBy?: {
         azureUniqueId: string;
         displayName?: string;
@@ -62,7 +63,7 @@ export type AppBuildManifest = {
 
 export interface AppManifest {
     /** @deprecated will be removed, use appKey */
-    key: string;
+    key?: string;
     appKey: string;
     /** @deprecated will be removed, use displayName */
     name?: string;


### PR DESCRIPTION
** @equinor/fusion-framework-cli**

**Changes:**

Updated commands in CLI to reflect purpose of the command:
- renamed `config` to `build-config` to generate build config of an application.
- renamed `pack`to `build-pack` to bundle an application.
- added `build-manifest` command to generate build manifest of an application.

> [!WARNING]
> Config callback for `manifest` and `config` now allows `void` return type. 
> Return value from callback is now merged with default config instead of replacing it, this might be a breaking change for some applications.

> [!NOTE]
> This mean that `mergeAppConfig` and `mergeManifestConfig` functions are no longer needed and can be removed from the application.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

