### PR TITLE
fix(cli): app-config.ts scopes optional

### DIFF
--- a/.changeset/tidy-countries-beg.md
+++ b/.changeset/tidy-countries-beg.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+Make `app.config.ts` definition scopes optional by updating the `AppConfigFn` type to use `z.input<typeof ApiAppConfigSchema>`.

--- a/packages/cli/src/lib/app-config.ts
+++ b/packages/cli/src/lib/app-config.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
     loadConfig,
     type ResolvedConfig,
@@ -18,7 +19,7 @@ type FindAppConfigOptions = FindConfigOptions & {
 export type AppConfigFn = (
     env: ConfigExecuterEnv,
     args: { base: ApiAppConfig },
-) => ApiAppConfig | Promise<ApiAppConfig | void> | void;
+) => z.input<typeof ApiAppConfigSchema> | Promise<z.input<typeof ApiAppConfigSchema> | void> | void;
 export type AppConfigExport = ApiAppConfig | AppConfigFn;
 
 export const appConfigFilename = 'app.config';


### PR DESCRIPTION
Make `app.config.ts` definition scopes optional by updating the `AppConfigFn` type to use `z.input<typeof ApiAppConfigSchema>`.