### PR TITLE
docs(vue-press): updating getting started

### DIFF
--- a/.changeset/tidy-countries-beg.md
+++ b/.changeset/tidy-countries-beg.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+Make `app.config.ts` definition scopes optional by updating the `AppConfigFn` type to use `z.input<typeof ApiAppConfigSchema>`.

--- a/.changeset/wild-chairs-confess.md
+++ b/.changeset/wild-chairs-confess.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-docs': patch
+---
+
+Updated `getting-started.md` documentation to:
+
+- Correct JSON code block formatting.
+- Update `app.config.ts` example to use `defineAppConfig` directly without `mergeAppConfigs`.
+- Provide an example of configuring an HTTP client with endpoint details from environment configuration.

--- a/packages/cli/src/lib/app-config.ts
+++ b/packages/cli/src/lib/app-config.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
     loadConfig,
     type ResolvedConfig,
@@ -18,7 +19,7 @@ type FindAppConfigOptions = FindConfigOptions & {
 export type AppConfigFn = (
     env: ConfigExecuterEnv,
     args: { base: ApiAppConfig },
-) => ApiAppConfig | Promise<ApiAppConfig | void> | void;
+) => z.input<typeof ApiAppConfigSchema> | Promise<z.input<typeof ApiAppConfigSchema> | void> | void;
 export type AppConfigExport = ApiAppConfig | AppConfigFn;
 
 export const appConfigFilename = 'app.config';

--- a/vue-press/src/guide/app/getting-started.md
+++ b/vue-press/src/guide/app/getting-started.md
@@ -112,18 +112,19 @@ export default configure;
 @tab app.config.ts
 
 ```ts
-import { mergeAppConfigs, defineAppConfig } from '@equinor/fusion-framework-cli';
+import { defineAppConfig } from '@equinor/fusion-framework-cli';
 export default defineAppConfig((_nev, { base }) =>
-    mergeAppConfigs(base, {
+    return {
         environment: {
-            scope: 'foobar',
+           foo: 'foobar',
         },
         endpoints: {
             api: {
                 url: 'https://foo.bars',
+                scopes: ['myscope/.default']
             },
         },
-    }),
+    },
 );
 
 ```
@@ -177,7 +178,7 @@ upload this config to the application admin under `configs`
 
 [read more about authentication](./authentication.md)
 
-```json dsadsa 
+```json
 // config.ENV.json
 {
   "services": {
@@ -193,8 +194,12 @@ configure application to create a http client based on dynamic config from app s
 ```ts
 // config.ts
 export const configure: AppModuleInitiator = (configurator, { env }) => {
-  configurator.configureHttpClient("myApi",  env.config.environment.myApi);
-};
+  const endpointApi = env.config?.getEndpoint('myApi');
+  configurator.configureHttpClient('myApi', {
+      baseUri: endpointApi?.url,
+      defaultScopes: endpointApi?.scopes,
+  });
+  // ... other config setting
 ```
 
 create a util hook for accessing custom http client
@@ -236,7 +241,6 @@ export const configure = (configurator, { env: { basename } }) => {
   enableNavigation(configurator, basename);
 }
 ```
-
 
 ### Enable context
 


### PR DESCRIPTION
Updated `getting-started.md` documentation to:

- Correct JSON code block formatting.
- Update `app.config.ts` example to use `defineAppConfig` directly without `mergeAppConfigs`.
- Provide an example of configuring an HTTP client with endpoint details from environment configuration.