### PR TITLE
doc(vue-press): improving moduleBadge component and its use

### DIFF
--- a/.changeset/hot-weeks-hope.md
+++ b/.changeset/hot-weeks-hope.md
@@ -1,0 +1,16 @@
+---
+'@equinor/fusion-framework-docs': patch
+---
+
+### Changes:
+
+- Fixed indentation in `ModuleBadge.vue`.
+- Updated `packageName` method in `ModuleBadge.vue` to replace all '/' with '-'.
+- Updated `ModuleBadge` component usage in various README files to use the correct module paths:
+  - `modules/app`
+  - `modules/feature-flag`
+  - `modules/navigation`
+  - `modules/service-discovery`
+  - `modules/services`
+  - `modules/widget`
+- Added `ModuleBadge` component to `feature-flag/module.md` and `feature-flag/react.md`.

--- a/vue-press/src/.vuepress/components/ModuleBadge.vue
+++ b/vue-press/src/.vuepress/components/ModuleBadge.vue
@@ -17,7 +17,7 @@ export default {
       type: String,
       required: true
     },
-     package: {
+    package: {
       type: String,
     },
     layout: {
@@ -37,7 +37,7 @@ export default {
       return url.toString();
     },
     packageName() {
-      return this.package || `@equinor/fusion-framework-${this.module}`;
+      return this.package || `@equinor/fusion-framework-${this.module.replaceAll('/', '-')}`;
     },
     npmUrl() {
       return `https://www.npmjs.com/package/${this.packageName}`;

--- a/vue-press/src/modules/app/README.md
+++ b/vue-press/src/modules/app/README.md
@@ -9,7 +9,7 @@ tag:
   - application module instance
 ---
 
-<ModuleBadge module="module-app" />
+<ModuleBadge module="modules/app" />
 
 This module purpose is:
 - [x] load application manifest.

--- a/vue-press/src/modules/feature-flag/module.md
+++ b/vue-press/src/modules/feature-flag/module.md
@@ -1,4 +1,7 @@
 ---
 title: Feature flag module
 ---
+
+<ModuleBadge module="modules/feature-flag" />
+
 <!-- @include: ../../../../packages/modules/feature-flag/README.md -->

--- a/vue-press/src/modules/feature-flag/react.md
+++ b/vue-press/src/modules/feature-flag/react.md
@@ -2,6 +2,8 @@
 title: Feature flag React
 ---
 
+<ModuleBadge module="react/framework" package="@equinor/fusion-framework-react" />
+
 Helpers and wrappers for using Feature flags in React
 
 ## App

--- a/vue-press/src/modules/navigation/README.md
+++ b/vue-press/src/modules/navigation/README.md
@@ -7,6 +7,8 @@ tag:
   - react-router
 ---
 
+<ModuleBadge module="modules/navigation" />
+
 Simple module which allows to monitor navigation events
 
 > [!CAUTION]

--- a/vue-press/src/modules/service-discovery/README.md
+++ b/vue-press/src/modules/service-discovery/README.md
@@ -8,5 +8,7 @@ tag:
   - core
 ---
 
+<ModuleBadge module="modules/service-discovery" />
+
 ## Services
 @[code](./services.json)

--- a/vue-press/src/modules/services/README.md
+++ b/vue-press/src/modules/services/README.md
@@ -7,7 +7,7 @@ tag:
     - api
 ---
 
-<ModuleBadge module="module-services" />
+<ModuleBadge module="modules/services" />
 
 ## Configuration
 

--- a/vue-press/src/modules/widget/README.md
+++ b/vue-press/src/modules/widget/README.md
@@ -7,7 +7,7 @@ tag:
     - builder
 ---
 
-<ModuleBadge module="module-widget" />
+<ModuleBadge module="modules/widget" />
 
 ## Configuration
 


### PR DESCRIPTION
Changes in docs (vue-press)

- Fixed indentation in `ModuleBadge.vue`.
- Updated `packageName` method in `ModuleBadge.vue` to replace all '/' with '-'.
- Updated `ModuleBadge` component usage in various README files to use the correct module paths:
  - `modules/app`
  - `modules/feature-flag`
  - `modules/navigation`
  - `modules/service-discovery`
  - `modules/services`
  - `modules/widget`
- Added `ModuleBadge` component to `feature-flag/module.md` and `feature-flag/react.md`.