### PR TITLE
fix(module-app): expanding apps endpoint to be the same as persons/me…

### DIFF
--- a/.changeset/tall-ants-trade.md
+++ b/.changeset/tall-ants-trade.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-module-app': patch
+---
+
+### Changes:
+
+- Updated `AppClient` class to improve the query for fetching app manifests:
+  - Adjusted the query path manifests method to include `$expand=category,admins,owners,keywords` when `filterByCurrentUser` is not specified.
+  - Minor formatting changes for better readability.

--- a/packages/modules/app/src/AppClient.ts
+++ b/packages/modules/app/src/AppClient.ts
@@ -103,7 +103,9 @@ export class AppClient implements IAppClient {
         this.#manifests = new Query<AppManifest[], { filterByCurrentUser?: boolean } | undefined>({
             client: {
                 fn: (filter) => {
-                    const path = filter?.filterByCurrentUser ? '/persons/me/apps' : '/apps';
+                    const path = filter?.filterByCurrentUser
+                        ? '/persons/me/apps'
+                        : '/apps?=$expand=category,admins,owners,keywords';
                     return client.json(path, {
                         headers: {
                             'Api-Version': '1.0',


### PR DESCRIPTION
### Changes:

- Updated `AppClient` class to improve the query for fetching app manifests:
  - Adjusted the query path manifests method to include `$expand=category,admins,owners,keywords` when `filterByCurrentUser` is not specified.
  - Minor formatting changes for better readability.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

