### PR TITLE
Feat/module app/person specific manifest

### DIFF
--- a/.changeset/red-ducks-battle.md
+++ b/.changeset/red-ducks-battle.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-module-app': patch
+---
+
+### Changes:
+- Updated the `AppClient` class to modify the query path in the `fn` method for fetching app manifests:
+  - Changed the path from `/apps/${appKey}` to `/persons/me/apps/${appKey}`.

--- a/packages/modules/app/src/AppClient.ts
+++ b/packages/modules/app/src/AppClient.ts
@@ -68,7 +68,7 @@ export class AppClient implements IAppClient {
         this.#manifest = new Query<AppManifest, { appKey: string }>({
             client: {
                 fn: ({ appKey }) => {
-                    return client.json(`/apps/${appKey}`, {
+                    return client.json(`/persons/me/apps/${appKey}`, {
                         headers: {
                             'Api-Version': '1.0',
                         },


### PR DESCRIPTION
### Changes:
- Updated the `AppClient` class to modify the query path in the `fn` method for fetching app manifests:
  - Changed the path from `/apps/${appKey}` to `/persons/me/apps/${appKey}`.