### PR TITLE
Fix/legacy-interopt/service-resolver

### DIFF
--- a/.changeset/lazy-games-clap.md
+++ b/.changeset/lazy-games-clap.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-legacy-interopt': patch
+---
+
+Fixed `LegacyAuthContainer.registerAppAsync` to not create duplicate AuthApps when additional resources are added to the app.

--- a/.changeset/little-gifts-chew.md
+++ b/.changeset/little-gifts-chew.md
@@ -1,0 +1,10 @@
+---
+'@equinor/fusion-framework-legacy-interopt': patch
+---
+
+Fixed `createServiceResolver` to extract app client id from each services.
+Previously we assumed that all services registered to the legacy auth container would use the same scope as all other services. This is not the case, as each service can have its own scope. This change allows us to extract the client id from the service definition, which is then used to create the service resolver.
+
+Resources are indexed by the client id, so when acquiring a resource, the legacy auth container will use the client id to generate an auth token. This token is then used to authenticate the request to the resource.
+
+**NOTE:** This will and should be deprecated in the future! This "bug" was discovered while an application used a mixed of legacy and new Framework, which caused the application to fail to authenticate requests to the resource (wrong audience).

--- a/packages/react/legacy-interopt/src/LegacyAuthContainer.ts
+++ b/packages/react/legacy-interopt/src/LegacyAuthContainer.ts
@@ -124,10 +124,14 @@ export class LegacyAuthContainer extends AuthContainer {
             return super.registerAppAsync(clientId, resources);
         }
         resources = resources.filter(Boolean);
-        const app = this.resolveApp(clientId) ?? new AuthApp(clientId, resources);
-        app.updateResources(resources);
-        this._registeredApps[clientId] = app;
-        this.apps.push(app);
+        const app = this.resolveApp(clientId);
+        if (app) {
+            app.updateResources(resources);
+            return true;
+        }
+
+        const newApp = new AuthApp(clientId, resources);
+        this.apps.push(newApp);
         return true;
     }
 


### PR DESCRIPTION
## Why

Issue when merging services from service discovery and legacy auth container (incorrect audience/scope)

### LegacyAuthContainer

Fixed `LegacyAuthContainer.registerAppAsync` to not create duplicate AuthApps when additional resources are added to the app.

### createServiceResolver

Fixed `createServiceResolver` to extract app client id from each services.
Previously we assumed that all services registered to the legacy auth container would use the same scope as all other services. This is not the case, as each service can have its own scope. This change allows us to extract the client id from the service definition, which is then used to create the service resolver.

Resources are indexed by the client id, so when acquiring a resource, the legacy auth container will use the client id to generate an auth token. This token is then used to authenticate the request to the resource.

**NOTE:** This will and should be deprecated in the future! This "bug" was discovered while an application used a mixed of legacy and new Framework, which caused the application to fail to authenticate requests to the resource (wrong audience).


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

