### PR TITLE
fix(legacy-interopt): fixes missing call to handleWindowCallbackAsync

### DIFF
--- a/.changeset/slow-dodos-tease.md
+++ b/.changeset/slow-dodos-tease.md
@@ -1,0 +1,16 @@
+---
+'@equinor/fusion-framework-legacy-interopt': patch
+---
+
+#### Updated Files:
+- `packages/react/legacy-interopt/src/create-fusion-context.ts`
+- `packages/react/legacy-interopt/src/create-service-resolver.ts`
+
+#### Changes:
+
+1. **create-fusion-context.ts**
+   - Added a call to `authContainer.handleWindowCallbackAsync()` before initializing `TelemetryLogger`.
+
+2. **create-service-resolver.ts**
+
+   - Changed the third parameter of authContainer.registerAppAsync from false to true.

--- a/packages/react/legacy-interopt/src/create-fusion-context.ts
+++ b/packages/react/legacy-interopt/src/create-fusion-context.ts
@@ -55,6 +55,8 @@ export const createFusionContext = async (args: {
 
     const authContainer = new LegacyAuthContainer({ auth: framework.modules.auth });
 
+    await authContainer.handleWindowCallbackAsync();
+
     const telemetryLogger = new TelemetryLogger(telemetry?.instrumentationKey ?? '', authContainer);
 
     const abortControllerManager = new AbortControllerManager(new EventHub());

--- a/packages/react/legacy-interopt/src/create-service-resolver.ts
+++ b/packages/react/legacy-interopt/src/create-service-resolver.ts
@@ -44,7 +44,7 @@ export const createServiceResolver = async (
             return authContainer.registerAppAsync(
                 id,
                 uris.map((x) => x.uri),
-                false,
+                true,
             );
         }),
     );


### PR DESCRIPTION
#### Updated Files:
- `packages/react/legacy-interopt/src/create-fusion-context.ts`
- `packages/react/legacy-interopt/src/create-service-resolver.ts`

#### Changes:

1. **create-fusion-context.ts**
   - Added a call to `authContainer.handleWindowCallbackAsync()` before initializing `TelemetryLogger`.

2. **create-service-resolver.ts**

   - Changed the third parameter of authContainer.registerAppAsync from false to true.