### PR TITLE
feat: add configurable paths for app proxy plugin

### DIFF
--- a/.changeset/tidy-buttons-clean.md
+++ b/.changeset/tidy-buttons-clean.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-framework-cli': minor
+---
+
+Added functionality for allow providing paths for `config`, `manifest` and bundle in `app-proxy-plugin`. This is useful for plugins that need to load resources from a specific path.
+
+This was required since the AppClient was changed in [#2520](https://github.com/equinor/fusion-framework/pull/2520) which broke the ability to load resources from the plugin.

--- a/packages/cli/src/bin/create-dev-serve.ts
+++ b/packages/cli/src/bin/create-dev-serve.ts
@@ -111,6 +111,7 @@ export const createDevServer = async (options: {
                     version: String(pkg.packageJson.version),
                     generateConfig,
                     generateManifest,
+                    manifestPath: `persons/me/apps/${appKey}`,
                 },
             }),
             // Restart the server when config changes or the dev portal source is updated


### PR DESCRIPTION
## Why
Added functionality for allow providing paths for `config`, `manifest` and bundle in `app-proxy-plugin`. This is useful for plugins that need to load resources from a specific path.

This was required since the AppClient was changed in [#2520](https://github.com/equinor/fusion-framework/pull/2520) which broke the ability to load resources from the plugin.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

