### PR TITLE
fix: update import path for BookmarkCreateArgs in useBookmark

### DIFF
--- a/.changeset/lemon-coats-buy.md
+++ b/.changeset/lemon-coats-buy.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-react-module-bookmark': patch
+---
+
+fixed import path in `useBookmark` hook

--- a/packages/react/modules/bookmark/src/useBookmark.ts
+++ b/packages/react/modules/bookmark/src/useBookmark.ts
@@ -15,7 +15,7 @@ import {
 import { useObservableState } from '@equinor/fusion-observable/react';
 
 import { useBookmarkProvider } from './useBookmarkProvider';
-import { BookmarkCreateArgs } from '@equinor/fusion-framework-module-bookmark/src/BookmarkProvider';
+import { BookmarkCreateArgs } from '@equinor/fusion-framework-module-bookmark';
 
 export type useBookmarkArgs = {
     provider?: BookmarkProvider;


### PR DESCRIPTION
## Why

update import path for BookmarkCreateArgs in useBookmark

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

