### PR TITLE
fix(cli): apploader only emits the latest result

### DIFF
--- a/.changeset/thin-baboons-doubt.md
+++ b/.changeset/thin-baboons-doubt.md
@@ -1,0 +1,12 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+### Modified Files
+
+`AppLoader.tsx`
+
+### Changes
+
+- Added import for last operator from rxjs/operators.
+- Updated the initialize subscription to use the last operator.


### PR DESCRIPTION
Prevent mounting the app 2 times.

### Modified Files

`AppLoader.tsx`

### Changes

- Added import for last operator from rxjs/operators.
- Updated the initialize subscription to use the last operator.