### PR TITLE
feat(query): add callback for rollback of mutation on query cache

### DIFF
--- a/.changeset/gentle-fans-rule.md
+++ b/.changeset/gentle-fans-rule.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-query': minor
+---
+
+Added callback function for rollback of mutation on query cache

--- a/packages/utils/query/src/Query.ts
+++ b/packages/utils/query/src/Query.ts
@@ -630,7 +630,7 @@ export class Query<TDataType, TQueryArguments = any> {
         args: TQueryArguments,
         changes: Parameters<QueryCache<TDataType, TQueryArguments>['mutate']>[1],
         options?: { allowCreation?: boolean },
-    ): void {
+    ): VoidFunction {
         const key = this.#generateCacheKey(args);
         if (key in this.cache.state === false) {
             if (options?.allowCreation === undefined) {
@@ -639,7 +639,7 @@ export class Query<TDataType, TQueryArguments = any> {
                 );
             } else if (options.allowCreation === false) {
                 /** does not allow creation, can not mutate */
-                return;
+                return () => {};
             }
             const { value } = typeof changes === 'function' ? changes() : changes;
             this.cache.setItem(key, {
@@ -648,7 +648,7 @@ export class Query<TDataType, TQueryArguments = any> {
                 value,
             });
         }
-        this.#cache.mutate(key, changes);
+        return this.#cache.mutate(key, changes);
     }
 
     /**

--- a/packages/utils/query/src/cache/QueryCache.ts
+++ b/packages/utils/query/src/cache/QueryCache.ts
@@ -100,7 +100,7 @@ export class QueryCache<TType, TArgs> {
         record: Pick<QueryCacheRecord<TType, TArgs>, 'value' | 'args' | 'transaction'>,
     ): void {
         const { args, transaction, value } = record;
-        this.#state.next(actions.set(key, { args, transaction, value }));
+        this.#state.next(actions.insert(key, { args, transaction, value }));
     }
 
     /**
@@ -137,7 +137,7 @@ export class QueryCache<TType, TArgs> {
     public mutate(
         key: string,
         changes: QueryCacheMutation<TType> | ((current?: TType) => QueryCacheMutation<TType>),
-    ): void {
+    ): VoidFunction {
         const current = key in this.#state.value ? this.#state.value[key] : undefined;
 
         if (!current) {
@@ -145,6 +145,7 @@ export class QueryCache<TType, TArgs> {
         }
         const next = typeof changes === 'function' ? changes(current?.value) : changes;
         this.#state.next(actions.mutate(key, next, current));
+        return () => this.#state.next(actions.set(key, current));
     }
 
     /**

--- a/packages/utils/query/src/cache/actions.ts
+++ b/packages/utils/query/src/cache/actions.ts
@@ -15,11 +15,21 @@ export default function createActions<TType = any, TArgs = any>() {
          * Action to set a cache entry.
          *
          * @param key The cache key.
+         * @param record The cache record to set.
+         * @returns An action object with the cache key and record.
+         */
+        set: createAction('cache/set', (key: string, record: QueryCacheRecord<TType, TArgs>) => ({
+            payload: { key, record },
+        })),
+        /**
+         * Action to set a cache entry.
+         *
+         * @param key The cache key.
          * @param entry The cache entry, including value, arguments, and transaction identifier.
          * @returns An action object with the cache key and entry.
          */
-        set: createAction(
-            'cache/set',
+        insert: createAction(
+            'cache/insert',
             (key: string, entry: { value: TType; args: TArgs; transaction: string }) => {
                 return { payload: { key, entry } };
             },

--- a/packages/utils/query/src/cache/create-reducer.ts
+++ b/packages/utils/query/src/cache/create-reducer.ts
@@ -27,8 +27,12 @@ export default function <TType, TArgs>(
         initial,
         (builder) =>
             builder
-                // Handles the 'set' action to update or add a cache record.
                 .addCase(actions.set, (state, action) => {
+                    const { key, record } = action.payload;
+                    state[key] = castDraft(record);
+                })
+                // Handles the 'set' action to update or add a cache record.
+                .addCase(actions.insert, (state, action) => {
                     const { key, entry } = action.payload;
                     const record = state[key];
 


### PR DESCRIPTION
## Why

Allow rollback of cache setting.
When calling `mutate` the query will return a callback function which will set the state back to before the mutation happend

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

