### PR TITLE
fix(cli): resolve app key from manifest during publishing

### DIFF
--- a/.changeset/pink-trees-visit.md
+++ b/.changeset/pink-trees-visit.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-framework-cli': patch
+---
+
+Fixed resolving of app key from manifest when publishing (earlier only resolved from package)

--- a/packages/cli/src/bin/publish-application.ts
+++ b/packages/cli/src/bin/publish-application.ts
@@ -1,7 +1,7 @@
 import { chalk } from './utils/format.js';
 import { Spinner } from './utils/spinner.js';
 import { bundleApplication } from './bundle-application.js';
-import { resolveAppPackage, resolveAppKey } from '../lib/app-package.js';
+import { resolveAppPackage } from '../lib/app-package.js';
 
 import {
     isAppRegistered,
@@ -9,6 +9,7 @@ import {
     requireToken,
     tagAppBundle,
     uploadAppBundle,
+    loadAppManifest,
 } from './utils/index.js';
 import type { FusionEnv } from './utils/index.js';
 
@@ -41,7 +42,8 @@ export const publishApplication = async (options: {
     }
 
     const pkg = await resolveAppPackage();
-    const appKey = resolveAppKey(pkg.packageJson);
+    const { manifest } = await loadAppManifest({ command: 'build', mode: 'prod' }, pkg);
+    const { appKey } = manifest;
 
     try {
         spinner.info('Verifying that App is registered');


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

