### PR TITLE
fix(bookmarks): resolve request method issue and improve response handling

### DIFF
--- a/.changeset/rare-flies-talk.md
+++ b/.changeset/rare-flies-talk.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-framework-module-services': patch
+---
+
+Fixed `isBookmarkInFavorites` by altering `generateRequestParameters` which had a copy paste bug (wrong request method). Also disabled the `validate_api_request` response operation for now, it was throwing an error on all response code which waas not **OK**.
+
+> in a future update, the `ResponseHandler` will provide the operators with the `Request` object, so they can access the request method and other request properties.
+
+Also fixed the `headSelector` to only check response code, since a `HEAD` request does not return a body.

--- a/packages/modules/services/src/bookmarks/endpoints/user-bookmark-favourite.head.ts
+++ b/packages/modules/services/src/bookmarks/endpoints/user-bookmark-favourite.head.ts
@@ -57,9 +57,8 @@ const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
     switch (version) {
         case ApiVersion.v1: {
             const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
-                method: 'POST',
+                method: 'HEAD',
                 selector: headSelector,
-                body: args,
             };
             return Object.assign({}, baseInit, init);
         }

--- a/packages/modules/services/src/bookmarks/selectors.ts
+++ b/packages/modules/services/src/bookmarks/selectors.ts
@@ -1,4 +1,4 @@
-import { HttpJsonResponseError } from '@equinor/fusion-framework-module-http';
+import { HttpJsonResponseError, HttpResponseError } from '@equinor/fusion-framework-module-http';
 import { type ResponseSelector } from '@equinor/fusion-framework-module-http/selectors';
 
 /**
@@ -35,15 +35,12 @@ export const statusSelector: ResponseSelector<boolean> = async (res) => {
  * @returns `true` if the response is successful, `false` if the response has a 404 status code, otherwise throws an `HttpJsonResponseError`.
  * @throws {HttpJsonResponseError} If the response is not successful and does not have a 404 status code, with the error message, response, and any additional data or cause.
  */
-export const headSelector: ResponseSelector<boolean> = (res) => {
-    try {
-        return statusSelector(res);
-    } catch (error) {
-        if (error instanceof HttpJsonResponseError) {
-            if (error.response.status === 404) {
-                return Promise.resolve(false);
-            }
-        }
-        throw error;
+export const headSelector: ResponseSelector<boolean> = async (res) => {
+    if (res.ok) {
+        return true;
     }
+    if (res.status === 404) {
+        return false;
+    }
+    throw new HttpResponseError(`Failed to execute request. Status code: ${res.status}`, res);
 };

--- a/packages/modules/services/src/provider.ts
+++ b/packages/modules/services/src/provider.ts
@@ -96,7 +96,9 @@ export class ApiProvider<TClient extends IHttpClient = IHttpClient>
         method: TMethod,
     ): Promise<BookmarksApiClient<TMethod, TClient>> {
         const httpClient = await this._createClientFn('bookmarks');
-        httpClient.responseHandler.add('validate_api_request', validateResponse);
+        // TODO: update when new ResponseOperator is available
+        // will fail because 'HEAD' will return 404 when no bookmarks are found
+        // httpClient.responseHandler.add('validate_api_request', validateResponse);
         return new BookmarksApiClient(httpClient, method);
     }
 


### PR DESCRIPTION
## Why
Fixed `isBookmarkInFavorites` by altering `generateRequestParameters` which had a copy paste bug (wrong request method). Also disabled the `validate_api_request` response operation for now, it was throwing an error on all response code which waas not **OK**.

> in a future update, the `ResponseHandler` will provide the operators with the `Request` object, so they can access the request method and other request properties.

Also fixed the `headSelector` to only check response code, since a `HEAD` request does not return a body.


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

