### PR TITLE
fix(module-app): reverts the changes to manifests selector to only re…

### DIFF
--- a/.changeset/stupid-camels-check.md
+++ b/.changeset/stupid-camels-check.md
@@ -1,0 +1,12 @@
+---
+'@equinor/fusion-framework-module-app': patch
+---
+
+Reverting update to the `manifests` call `selector` function in `AppClient` to use `jsonSelector` and parse the response with `ApplicationSchema`.
+
+**Modified files:**
+- `packages/modules/app/src/AppClient.ts`
+
+**Changes:**
+- Replaced `res.json()` with `jsonSelector(res)`
+- Parsed the response using `ApplicationSchema.array().parse(response.value)`

--- a/packages/modules/app/src/AppClient.ts
+++ b/packages/modules/app/src/AppClient.ts
@@ -109,8 +109,8 @@ export class AppClient implements IAppClient {
                             'Api-Version': '1.0',
                         },
                         selector: async (res: Response) => {
-                            const body = await res.json();
-                            return body;
+                            const response = (await jsonSelector(res)) as { value: AppManifest[] };
+                            return ApplicationSchema.array().parse(response.value);
                         },
                     });
                 },


### PR DESCRIPTION

### changes `@equinor/fusion-framework-module-app`

Reverting update to the `manifests` call `selector` function in `AppClient` to use `jsonSelector` and parse the response with `ApplicationSchema`.

**Modified files:**
- `packages/modules/app/src/AppClient.ts`

**Changes:**
- Replaced `res.json()` with `jsonSelector(res)`
- Parsed the response using `ApplicationSchema.array().parse(response.value)`