### PR TITLE
feat(cli): adds option for --noOpen to not open dev-server in browser

### DIFF
--- a/.changeset/honest-grapes-deliver.md
+++ b/.changeset/honest-grapes-deliver.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Added `noOpen` option to the development server configuration.
+
+**Modified files:**
+- `packages/cli/src/bin/create-dev-serve.ts`
+- `packages/cli/src/bin/main.app.ts`
+
+**Changes:**
+- Added `noOpen` boolean option to `createDevServer` function.
+- Updated the server configuration to conditionally open the app in the default browser based on the `noOpen` option.
+- Added `-n, --noOpen` option to the CLI command for starting the development server.

--- a/packages/cli/src/bin/create-dev-serve.ts
+++ b/packages/cli/src/bin/create-dev-serve.ts
@@ -42,8 +42,9 @@ export const createDevServer = async (options: {
     devPortalPath: string;
     port?: number;
     library?: 'react';
+    noOpen: boolean;
 }) => {
-    const { configSourceFiles, library, port, devPortalPath } = options;
+    const { configSourceFiles, library, port, devPortalPath, noOpen } = options;
 
     const spinner = Spinner.Global({ prefixText: chalk.dim('dev-server') });
 
@@ -94,7 +95,7 @@ export const createDevServer = async (options: {
         publicDir: devPortalPath,
         appType: 'custom',
         server: {
-            open: `/apps/${appKey}`,
+            open: !noOpen ? `/apps/${appKey}` : false,
             port: port ?? (await portFinder.getPortPromise({ port: 3000 })),
         },
         plugins: [

--- a/packages/cli/src/bin/main.app.ts
+++ b/packages/cli/src/bin/main.app.ts
@@ -23,6 +23,7 @@ export default (program: Command) => {
         .description('Start development server for application')
         .option('-p, --port <number>', 'dev-server port')
         .option('-P, --portal <string>', 'fusion portal host')
+        .option('-n, --noOpen', 'Do not open app in default browser automatically', false)
         .option(
             '-c, --config <file>',
             `use specified application config, by default search for ${formatPath(
@@ -63,6 +64,7 @@ export default (program: Command) => {
                 library: opt.framework,
                 port: opt.port,
                 devPortalPath: devPortalPath,
+                noOpen: opt.noOpen,
             });
         });
 


### PR DESCRIPTION
Added `noOpen` option to the development server configuration.

**Modified files:**
- `packages/cli/src/bin/create-dev-serve.ts`
- `packages/cli/src/bin/main.app.ts`

**Changes:**
- Added `noOpen` boolean option to `createDevServer` function.
- Updated the server configuration to conditionally open the app in the default browser based on the `noOpen` option.
- Added `-n, --noOpen` option to the CLI command for starting the development server.