### PR TITLE
Fix/module app/set module version

### DIFF
--- a/.changeset/little-carrots-kneel.md
+++ b/.changeset/little-carrots-kneel.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+Added versioning support to `AppModuleProvider`.
+
+**Modified files:**
+- `packages/modules/app/src/AppModuleProvider.ts`
+
+**Changes:**
+- Imported `SemanticVersion` from `@equinor/fusion-framework-module`.
+- Imported `version` from `./version`.
+- Added a `version` getter to `AppModuleProvider` that returns a `SemanticVersion` instance.

--- a/packages/modules/app/src/AppModuleProvider.ts
+++ b/packages/modules/app/src/AppModuleProvider.ts
@@ -18,6 +18,8 @@ import { App, filterEmpty, IApp } from './app/App';
 import { AppModuleConfig } from './AppConfigurator';
 import { AppBundleStateInitial } from './app/types';
 import { IAppClient } from './AppClient';
+import { SemanticVersion } from '@equinor/fusion-framework-module';
+import { version } from './version';
 
 export class AppModuleProvider {
     static compareAppManifest<T extends AppManifest>(a?: T, b?: T): boolean {
@@ -33,6 +35,13 @@ export class AppModuleProvider {
     #subscription = new Subscription();
 
     #event?: ModuleType<EventModule>;
+
+    /**
+     * Get module version
+     */
+    get version(): SemanticVersion {
+        return new SemanticVersion(version);
+    }
 
     /**
      * fetch an application by key


### PR DESCRIPTION
Added versioning support to `AppModuleProvider`.

**Modified files:**
- `packages/modules/app/src/AppModuleProvider.ts`

**Changes:**
- Imported `SemanticVersion` from `@equinor/fusion-framework-module`.
- Imported `version` from `./version`.
- Added a `version` getter to `AppModuleProvider` that returns a `SemanticVersion` instance.