### PR TITLE
refactor: Conform to Biome `linter.correctness.noVoidTypeReturn` and remove unnecessary return statements

### DIFF
--- a/.changeset/cold-animals-tease.md
+++ b/.changeset/cold-animals-tease.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-navigation": patch
+---
+
+Conformed to Biome `linter.correctness.noVoidTypeReturn`

--- a/biome.json
+++ b/biome.json
@@ -27,11 +27,6 @@
         "useLiteralKeys": "warn",
         "useOptionalChain": "warn"
       },
-      "correctness": {
-        "noUndeclaredVariables": "warn",
-        "noUnusedVariables": "warn",
-        "noVoidTypeReturn": "warn"
-      },
       "performance": {
         "noAccumulatingSpread": "warn",
         "noDelete": "warn"

--- a/packages/modules/navigation/src/lib/provider/NavigationProvider.ts
+++ b/packages/modules/navigation/src/lib/provider/NavigationProvider.ts
@@ -86,11 +86,11 @@ export class NavigationProvider
   }
 
   public push(to: To, state?: unknown): void {
-    return this.#navigator.push(this._createToPath(to), state);
+    this.#navigator.push(this._createToPath(to), state);
   }
 
   public replace(to: To, state?: unknown): void {
-    return this.#navigator.replace(this._createToPath(to), state);
+    this.#navigator.replace(this._createToPath(to), state);
   }
 
   protected _localizePath(location: Path): Path {

--- a/packages/modules/navigation/src/navigator.ts
+++ b/packages/modules/navigation/src/navigator.ts
@@ -159,7 +159,7 @@ export class Navigator<T extends NavigationUpdate = NavigationUpdate>
   public push(to: To, state?: unknown): void {
     const skip = isLocation(to) && this._isDuplicateLocation(to);
     if (!skip) {
-      return this.#history.push(to, state);
+      this.#history.push(to, state);
     }
   }
 
@@ -171,7 +171,7 @@ export class Navigator<T extends NavigationUpdate = NavigationUpdate>
   public replace(to: To, state?: unknown): void {
     const skip = isLocation(to) && this._isDuplicateLocation(to);
     if (!skip) {
-      return this.#history.replace(to, state);
+      this.#history.replace(to, state);
     }
   }
 


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

