### PR TITLE
hotfix: msal auth provider

### DIFF
--- a/.changeset/odd-trees-wear.md
+++ b/.changeset/odd-trees-wear.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-msal": patch
+---
+
+hotfix: added `defaultConfig` to `AuthProvider.createProxyProvider` to allow legacy child providers to access the `config` object.

--- a/packages/modules/msal/src/v2/provider.ts
+++ b/packages/modules/msal/src/v2/provider.ts
@@ -10,7 +10,11 @@ import { SemanticVersion } from '@equinor/fusion-framework-module';
 
 export interface IAuthProvider {
   // readonly defaultClient: AuthClient;
-  // readonly defaultConfig: AuthClientOptions | undefined;
+  /**
+   * @deprecated
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: this is deprecated
+  readonly defaultConfig: any | undefined;
   readonly defaultAccount: AccountInfo | undefined;
 
   /**
@@ -147,6 +151,8 @@ export class AuthProvider implements IAuthProvider, IProxyProvider {
             return target.version;
           case 'defaultAccount':
             return target.defaultAccount;
+          case 'defaultConfig':
+            return target.defaultConfig;
           case 'acquireToken':
             return target.acquireToken.bind(target);
           case 'acquireAccessToken':


### PR DESCRIPTION
## Why
add `defaultConfig` to `AuthProvider.createProxyProvider` for legacy child provider access.
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

