### PR TITLE
Fix theme cloning issue by copying parts to new theme

### DIFF
--- a/.changeset/rude-mugs-dream.md
+++ b/.changeset/rude-mugs-dream.md
@@ -1,0 +1,8 @@
+---
+"@equinor/fusion-framework-module-ag-grid": patch
+---
+
+Fixed a bug where when creating a new theme, parts where not added from the source theme to the new theme.
+
+This was due to the fact that the `parts` attribute was not being copied over to the new theme,
+since `withPart` is an immutable operation and the result was not being assigned to the new theme.

--- a/packages/modules/ag-grid/src/themes.ts
+++ b/packages/modules/ag-grid/src/themes.ts
@@ -1,16 +1,50 @@
-import { type Theme, themeAlpine, createTheme, createPart } from 'ag-grid-community';
+import { type Part, type Theme, themeAlpine, createTheme, createPart } from 'ag-grid-community';
 
+/**
+ * The Fusion theme for AG Grid.
+ */
 export const fusionTheme: Theme = themeAlpine.withParams({
   fontFamily: 'Equinor, sans-serif',
 });
 
+/**
+ * Creates a new theme based on an existing theme.
+ *
+ * @note
+ * Cloning a theme is necessary to create a local instance of the theme,
+ * as AG Grid performs internal `instanceof` checks on the theme object and its parts.
+ *
+ * When consuming an incoming theme object, it is likely to be a different instance,
+ * since AG Grid might have been created in a different context (e.g., portal implementation).
+ *
+ * @example
+ * ```ts
+ * // portal
+ * enableAgGrid(configurator, async (builder) => {
+ *  builder.withTheme(fusionTheme);
+ * });
+ *
+ * // consumer
+ * enableAgGrid(configurator, async (builder) => {
+ *  // parent is a reference to the portal ag-grid module instance
+ *  const theme = createThemeFromTheme(parent.getTheme());
+ *  builder.withTheme(theme);
+ * });
+ * ```
+ *
+ * @param theme - The theme to clone
+ * @returns A new theme with the same parts as the input theme
+ */
 export const createThemeFromTheme = (theme: Theme): Theme => {
-  const newTheme = createTheme();
-  if ('parts' in theme && Array.isArray(theme.parts)) {
-    for (const part of theme.parts) {
-      newTheme.withPart(createPart(part));
-    }
-  }
+  // biome-ignore lint/suspicious/noExplicitAny: fails to infer type of theme.parts
+  const parts = (theme as Theme & { parts: Part<any>[] }).parts ?? [];
+
+  // convert each part to a new part and add it to the new theme
+  const newTheme = parts.reduce((acc, part) => {
+    // convert part to a new part, to ensure it's a PartImpl
+    return acc.withPart(createPart(part));
+  }, createTheme());
+
   return newTheme;
 };
 

--- a/packages/modules/ag-grid/src/themes.ts
+++ b/packages/modules/ag-grid/src/themes.ts
@@ -1,4 +1,4 @@
-import { type Part, type Theme, themeAlpine, createTheme, createPart } from 'ag-grid-community';
+import { type Part, type Theme, createPart, createTheme, themeAlpine } from 'ag-grid-community';
 
 /**
  * The Fusion theme for AG Grid.


### PR DESCRIPTION
Resolve a bug that prevented parts from being added to a newly created theme by ensuring the `parts` attribute is properly copied over during the cloning process.