### PR TITLE
Update `noBannedTypes` rule to error and adjust linting exceptions

### DIFF
--- a/.changeset/crazy-ghosts-smile.md
+++ b/.changeset/crazy-ghosts-smile.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+fixed `noBannedTypes` Biome rules

--- a/biome.json
+++ b/biome.json
@@ -23,8 +23,6 @@
     "rules": {
       "recommended": true,
       "complexity": {
-        "noBannedTypes": "warn",
-        "useLiteralKeys": "error",
         "useOptionalChain": "warn"
       },
       "performance": {

--- a/packages/utils/observable/src/create-reducer.ts
+++ b/packages/utils/observable/src/create-reducer.ts
@@ -2,17 +2,16 @@ import { produce as createNextState, isDraft, isDraftable } from 'immer';
 
 import type { Draft } from 'immer';
 
-import type { NoInfer, TypeGuard } from './types/ts-helpers';
-import type { Action, ActionType, ActionTypes, AnyAction, ExtractAction } from './types/actions';
+import type { TypeGuard } from './types/ts-helpers';
+import type { Action, ActionType, AnyAction, ExtractAction } from './types/actions';
 import type { ReducerWithInitialState } from './types/reducers';
-import { ac } from 'vitest/dist/chunks/reporters.C_zwCd4j';
 
 function freezeDraftable<T>(val: T) {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  // biome-ignore lint/suspicious/noEmptyBlockStatements: This is a valid use case for an empty block statement
   return isDraftable(val) ? createNextState(val, () => {}) : val;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// biome-ignore lint/complexity/noBannedTypes: This is a valid use case for an empty object type
 type NotFunction<T = unknown> = T extends Function ? never : T;
 
 function isStateFunction<S>(x: unknown): x is () => S {
@@ -24,11 +23,11 @@ export type ActionMatcherDescription<S, A extends AnyAction> = {
   reducer: CaseReducer<S, NoInfer<A>>;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: This is a valid use case for any
 type ActionMatcherDescriptionCollection<S> = Array<ActionMatcherDescription<S, any>>;
 
 interface TypedActionCreator<Type extends string> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: This is a valid use case for any
   (...args: any[]): Action<Type>;
   type: Type;
 }
@@ -36,9 +35,11 @@ interface TypedActionCreator<Type extends string> {
 type CaseReducer<S = unknown, A extends Action = AnyAction> = (
   state: Draft<S>,
   action: A,
+  // biome-ignore lint/suspicious/noConfusingVoidType: This is a valid use case for void
 ) => S | void | Draft<S>;
 
 type CaseReducers<S, AS extends Record<string, Action>> = {
+  // biome-ignore lint/suspicious/noConfusingVoidType: This is a valid use case for void
   [T in keyof AS]: AS[T] extends Action ? CaseReducer<S, AS[T]> : void;
 };
 

--- a/packages/utils/observable/src/types/actions.ts
+++ b/packages/utils/observable/src/types/actions.ts
@@ -15,7 +15,7 @@ export type Action<T extends TypeConstant = TypeConstant> = { type: T };
  */
 export interface AnyAction extends Action {
   // Allows any extra properties to be defined in an action.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: This is a valid use case for an explicit `any` type
   [extraProps: string]: any;
 }
 
@@ -26,7 +26,7 @@ export interface AnyAction extends Action {
  * @param args - The arguments used to construct the action object.
  * @returns An action of type `T`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: This is a valid use case for an explicit `any` type
 export type ActionCreator<T extends Action = AnyAction> = (...args: any[]) => T;
 
 /**
@@ -121,13 +121,13 @@ export type PayloadAction<P = void, T extends string = string, M = never, E = ne
   payload: P;
   type: T;
 } & ([M] extends [never]
-  ? // eslint-disable-next-line @typescript-eslint/ban-types
+  ? // biome-ignore lint/complexity/noBannedTypes: This is a valid use case for an empty object type
     {}
   : {
       meta: M;
     }) &
   ([E] extends [never]
-    ? // eslint-disable-next-line @typescript-eslint/ban-types
+    ? // biome-ignore lint/complexity/noBannedTypes: This is a valid use case for an empty object type
       {}
     : {
         error: E;

--- a/packages/utils/observable/src/types/ts-helpers.ts
+++ b/packages/utils/observable/src/types/ts-helpers.ts
@@ -28,19 +28,9 @@ export type IfVoid<P, True, False> = [void] extends [P] ? True : False;
  */
 export type IsUnknownOrNonInferrable<T, True, False> = IsUnknown<T, True, False>;
 
-/**
- * Helper type. Passes T out again, but boxes it in a way that it cannot
- * "widen" the type by accident if it is a generic that should be inferred
- * from elsewhere.
- *
- * ref https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-322267089
- *
- */
-export type NoInfer<T> = [T][T extends any ? 0 : never];
-
 export type TypeGuard<T> = (value: any) => value is T;
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// biome-ignore lint/complexity/noBannedTypes: This is a valid use case for an empty object type
 export type NotFunction<T = unknown> = T extends Function ? never : T;
 
 export type NestedKeys<TObject extends object> = {


### PR DESCRIPTION
Change the `noBannedTypes` rule in Biome to error and update linting exceptions to allow specific cases.