### PR TITLE
fix(framework): webpackIgnore

### DIFF
--- a/.changeset/dry-papers-joke.md
+++ b/.changeset/dry-papers-joke.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+Add `webpackIgnore` to module import for application

--- a/packages/modules/app/src/app/flows.ts
+++ b/packages/modules/app/src/app/flows.ts
@@ -175,7 +175,7 @@ export const handleImportApplication =
       switchMap(({ payload }) => {
         const endpoint = [provider.assetUri, payload].join('/').replace(/\/{2,}/g, '/');
         // dynamically import the application script
-        return from(import(/* @vite-ignore */ endpoint)).pipe(
+        return from(import(/* @vite-ignore */ /* webpackIgnore: true */ endpoint)).pipe(
           // dispatch success action
           map(actions.importApp.success),
           // catch any error and dispatch failure action


### PR DESCRIPTION
## Why
What kind of change does this PR introduce?
Add `webpackIgnore` to module import for application

What is the current behavior?
When using `initialize()` after creating app, returns an error while trying to run app modules

What is the new behavior?
you can now run `initialize()`

Does this PR introduce a breaking change?
No

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

