### PR TITLE
fix(help-proxy): avoid breaking other proxy paths by removing res.end()

### DIFF
--- a/.changeset/fifty-zoos-unite.md
+++ b/.changeset/fifty-zoos-unite.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Limit token interception to OPTIONS requests on help-proxy path
+
+The previous implementation of the help-proxy middleware would intercept all requests under `/help-proxy` with an `Authorization` header and immediately end the response. This inadvertently affected other routes such as `/app-proxy` by short-circuiting legitimate proxy requests.
+
+This change limits the interception logic to only handle `OPTIONS` requests specifically targeting `/help-proxy` paths. This ensures token preservation for preflight requests without interfering with other proxy paths or general request flows.
+
+This provides a more targeted fix while retaining the intended functionality.

--- a/packages/cli/src/lib/plugins/help-proxy/help-proxy-plugin.ts
+++ b/packages/cli/src/lib/plugins/help-proxy/help-proxy-plugin.ts
@@ -88,11 +88,11 @@ export const helpProxyPlugin = (options: HelpProxyPluginOptions): Plugin => {
     },
     configureServer(server) {
       server.middlewares.use(proxyPath, async (req, res, next) => {
-        if (req.headers.authorization) {
-          __HELP_API_TOKEN__ = req.headers.authorization || '';
-          res.end();
-          return;
-        }
+        if (req.originalUrl?.startsWith(proxyPath) && req.method === 'OPTIONS' && req.headers.authorization) {  
+          __HELP_API_TOKEN__ = req.headers.authorization || '';  
+          res.end();  
+          return;  
+        }  
         next();
       });
     },


### PR DESCRIPTION
Limit token interception to OPTIONS requests on help-proxy path

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

