### PR TITLE
fix(framework): queueOperator

### DIFF
--- a/.changeset/silent-apes-type.md
+++ b/.changeset/silent-apes-type.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+Added `queueOperator: "merge"` to manifest and config in AppClient

--- a/packages/modules/app/src/AppClient.ts
+++ b/packages/modules/app/src/AppClient.ts
@@ -95,7 +95,7 @@ export class AppClient implements IAppClient {
           });
         },
       },
-      queueOperator: "merge",
+      queueOperator: 'merge',
       key: ({ appKey }) => appKey,
       expire,
     });
@@ -132,7 +132,7 @@ export class AppClient implements IAppClient {
           });
         },
       },
-      queueOperator: "merge",
+      queueOperator: 'merge',
       key: (args) => JSON.stringify(args),
       expire,
     });

--- a/packages/modules/app/src/AppClient.ts
+++ b/packages/modules/app/src/AppClient.ts
@@ -95,6 +95,7 @@ export class AppClient implements IAppClient {
           });
         },
       },
+      queueOperator: "merge",
       key: ({ appKey }) => appKey,
       expire,
     });
@@ -131,6 +132,7 @@ export class AppClient implements IAppClient {
           });
         },
       },
+      queueOperator: "merge",
       key: (args) => JSON.stringify(args),
       expire,
     });


### PR DESCRIPTION
## Why
Added `queueOperator: "merge"` to manifest and config in AppClient

closes: [AB#61485](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/61485)


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

