### PR TITLE
feat(context): add support for custom context path extraction and generation

### DIFF
--- a/.changeset/sad-trains-fix.md
+++ b/.changeset/sad-trains-fix.md
@@ -1,0 +1,52 @@
+---
+"@equinor/fusion-framework-module-context": minor
+"@equinor/fusion-framework-cli": minor
+---
+
+**@equinor/fusion-framework-react:**
+
+- Enhanced `useAppContextNavigation` to support custom context path extraction and generation. This allows for more flexible navigation handling based on application-specific requirements.
+
+**@equinor/fusion-framework-module-context:**
+
+- Added support for custom context path extraction and generation in `ContextConfigBuilder`, `ContextProvider`, and `ContextModuleConfigurator`.
+- Introduced `setContextPathExtractor` and `setContextPathGenerator` methods in `ContextConfigBuilder` to allow developers to define custom logic for extracting and generating context paths.
+- Updated `ContextProvider` to utilize `extractContextIdFromPath` and `generatePathFromContext` from the configuration, enabling dynamic path handling.
+- Enhanced `ContextModuleConfigurator` to include `extractContextIdFromPath` and `generatePathFromContext` in the module configuration.
+
+If you are using `@equinor/fusion-framework-module-context` and need custom logic for context path handling:
+
+1. Use `setContextPathExtractor` to define how to extract context IDs from paths.
+2. Use `setContextPathGenerator` to define how to generate paths based on context items.
+
+Example:
+
+```typescript
+builder.setContextPathExtractor((path) => {
+  // Custom logic to extract context ID from path
+  return path.match(/\/custom\/(.+)/)?.[1];
+});
+
+builder.setContextPathGenerator((context, path) => {
+  // Custom logic to generate path from context
+  return path.replace(/^(\/)?custom\/[^/]+(.*)$/, `/app/${item.id}$2`);
+});
+```
+
+If your portal is generating context paths based on context items, you can now define custom logic for context path handling:
+
+```typescript
+contextProvider.currentContext$
+  .pipe(
+    map((context) => {
+      // Custom logic to generate path from context
+      const path = contextProvider.generatePathFromContext?.(
+        context,
+        location.pathname
+      );
+      return path ?? fallbackPathGenerator(context, location.pathname);
+    }),
+    filter(Boolean)
+  )
+  .subscribe((path) => history.push(path));
+```

--- a/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
+++ b/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
@@ -2,7 +2,11 @@ import { useCallback } from 'react';
 
 import { useCurrentAppModules } from '@equinor/fusion-framework-react/app';
 
-import type { ContextItem, ContextModule, IContextProvider } from '@equinor/fusion-framework-module-context';
+import type {
+  ContextItem,
+  ContextModule,
+  IContextProvider,
+} from '@equinor/fusion-framework-module-context';
 import { extractContextIdFromPath } from '@equinor/fusion-framework-module-context/utils';
 
 import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
@@ -13,22 +17,27 @@ import { useFrameworkModule } from '@equinor/fusion-framework-react';
 
 type CurrentAppModules = [ContextModule, NavigationModule];
 
-const generatePathname = (currentPathname: string, item: ContextItem, context?: IContextProvider, pathContextId?: string) => {
+const generatePathname = (
+  currentPathname: string,
+  item: ContextItem,
+  context?: IContextProvider,
+  pathContextId?: string,
+) => {
   if (pathContextId) {
     // context id exists in the url, replace it with the new context id
-    const pathname = (context?.generatePathFromContext?.(item, currentPathname) ??
-      currentPathname.replace(pathContextId, item.id))
+    const pathname =
+      context?.generatePathFromContext?.(item, currentPathname) ??
+      currentPathname.replace(pathContextId, item.id);
 
     console.debug(
       `🌍 Portal: context changed, navigating to app's context url:`,
-        `found context id [${pathContextId}] in url, replacing with [${pathname}]`
+      `found context id [${pathContextId}] in url, replacing with [${pathname}]`,
     );
 
     return pathname;
   }
   // could not find context id in the url, set the path to the new context id
-  const pathname = context?.generatePathFromContext?.(item, currentPathname) ??
-    `/${item?.id}`;
+  const pathname = context?.generatePathFromContext?.(item, currentPathname) ?? `/${item?.id}`;
 
   console.debug(
     `🌍 Portal: context changed, navigating to app's context url:`,
@@ -97,7 +106,8 @@ export const useAppContextNavigation = () => {
           currentPathname,
           item,
           context,
-          context?.extractContextIdFromPath?.(currentPathname) ?? extractContextIdFromPath(currentPathname),
+          context?.extractContextIdFromPath?.(currentPathname) ??
+            extractContextIdFromPath(currentPathname),
         );
 
         // if app has its own navigation, use it to navigate

--- a/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
+++ b/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { useCurrentAppModules } from '@equinor/fusion-framework-react/app';
 
-import type { ContextItem, ContextModule } from '@equinor/fusion-framework-module-context';
+import type { ContextItem, ContextModule, IContextProvider } from '@equinor/fusion-framework-module-context';
 import { extractContextIdFromPath } from '@equinor/fusion-framework-module-context/utils';
 
 import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
@@ -12,6 +12,31 @@ import { EMPTY } from 'rxjs';
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
 
 type CurrentAppModules = [ContextModule, NavigationModule];
+
+const generatePathname = (currentPathname: string, item: ContextItem, context?: IContextProvider, pathContextId?: string) => {
+  if (pathContextId) {
+    // context id exists in the url, replace it with the new context id
+    const pathname = (context?.generatePathFromContext?.(item, currentPathname) ??
+      currentPathname.replace(pathContextId, item.id))
+
+    console.debug(
+      `🌍 Portal: context changed, navigating to app's context url:`,
+        `found context id [${pathContextId}] in url, replacing with [${pathname}]`
+    );
+
+    return pathname;
+  }
+  // could not find context id in the url, set the path to the new context id
+  const pathname = context?.generatePathFromContext?.(item, currentPathname) ??
+    `/${item?.id}`;
+
+  console.debug(
+    `🌍 Portal: context changed, navigating to app's context url:`,
+    `could not find context id in url, navigating to path [${pathname}]`,
+  );
+
+  return pathname;
+};
 
 /**
  * when current application changes, this hook will observe the application module instances.
@@ -63,28 +88,16 @@ export const useAppContextNavigation = () => {
           return;
         }
 
-        // extract the context id from the current path
-        const pathContextId =
-          context?.extractContextIdFromPath?.(currentPathname) ??
-          extractContextIdFromPath(currentPathname);
+        if (item === undefined) {
+          // no-op
+          return;
+        }
 
-        // generate path to the selected context
-        const pathname = pathContextId
-          ? item
-            ? // context id exists in the url, replace it with the new context id
-              (context?.generatePathFromContext?.(item, currentPathname) ??
-              currentPathname.replace(pathContextId, item.id))
-            : // context was cleared, set the path to the root
-              '/'
-          : // could not find context id in the url, set the path to the new context id
-            `/${item?.id}`;
-
-        console.debug(
-          '🌍 Portal:',
-          "context changed, navigating to app's context url:",
-          pathContextId
-            ? `found context id [${pathContextId}] in url, ${item ? `replacing with [${item.id}]` : 'context was cleared, navigating to root'}`
-            : `could not find context id in url, navigating to context id [${item ? item.id : 'root'}]`,
+        const pathname = generatePathname(
+          currentPathname,
+          item,
+          context,
+          context?.extractContextIdFromPath?.(currentPathname) ?? extractContextIdFromPath(currentPathname),
         );
 
         // if app has its own navigation, use it to navigate
@@ -104,6 +117,7 @@ export const useAppContextNavigation = () => {
         navigation,
         // application navigation instance, may change when the application changes
         appNavigation,
+        context,
       ],
     ),
   );

--- a/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
+++ b/packages/cli/src/bin/dev-portal/useAppContextNavigation.ts
@@ -64,13 +64,16 @@ export const useAppContextNavigation = () => {
         }
 
         // extract the context id from the current path
-        const pathContextId = extractContextIdFromPath(currentPathname);
+        const pathContextId =
+          context?.extractContextIdFromPath?.(currentPathname) ??
+          extractContextIdFromPath(currentPathname);
 
         // generate path to the selected context
         const pathname = pathContextId
           ? item
             ? // context id exists in the url, replace it with the new context id
-              currentPathname.replace(pathContextId, item.id)
+              (context?.generatePathFromContext?.(item, currentPathname) ??
+              currentPathname.replace(pathContextId, item.id))
             : // context was cleared, set the path to the root
               '/'
           : // could not find context id in the url, set the path to the new context id
@@ -87,7 +90,10 @@ export const useAppContextNavigation = () => {
         // if app has its own navigation, use it to navigate
         if (appNavigation) {
           // update the path of the app navigation, preserving search and hash
-          appNavigation.replace({ ...appNavigation.path, pathname });
+          appNavigation.replace({
+            ...appNavigation.path,
+            pathname,
+          });
         } else {
           // update the path of the portal navigation, preserving search and hash
           navigation.replace({ ...navigation.path, pathname });

--- a/packages/modules/context/src/ContextConfigBuilder.ts
+++ b/packages/modules/context/src/ContextConfigBuilder.ts
@@ -74,6 +74,25 @@ export class ContextConfigBuilder<
     this.config.resolveContext = fn;
   }
 
+  /**
+   * Sets the function responsible for extracting the context ID from a given path.
+   *
+   * @param fn - A function that defines how to extract the context ID from a path.
+   *             This function should match the type defined in `ContextModuleConfig['extractContextIdFromPath']`.
+   */
+  setContextPathExtractor(fn: ContextModuleConfig['extractContextIdFromPath']) {
+    this.config.extractContextIdFromPath = fn;
+  }
+
+  /**
+   * Sets the function responsible for generating a path from the context.
+   *
+   * @param fn - A function that takes a context and generates a corresponding path.
+   */
+  setContextPathGenerator(fn: ContextModuleConfig['generatePathFromContext']) {
+    this.config.generatePathFromContext = fn;
+  }
+
   setResolveInitialContext(fn: ContextModuleConfig['resolveInitialContext']) {
     this.config.resolveInitialContext = fn;
   }

--- a/packages/modules/context/src/ContextProvider.ts
+++ b/packages/modules/context/src/ContextProvider.ts
@@ -138,6 +138,23 @@ export interface IContextProvider {
     context: ContextItem<Record<string, unknown>> | null,
     opt?: { validate?: boolean; resolve?: boolean },
   ): Promise<ContextItem<Record<string, unknown>> | null>;
+
+  /**
+   * Method for extracting context id from a path.
+   *
+   * @param path path to resolve context from
+   * @returns the resolved context item id
+   */
+  extractContextIdFromPath?: (path: string) => string | undefined;
+
+  /**
+   * Method for generating path from a context item.
+   *
+   * @param context context item to generate path from
+   * @param path current path
+   * @returns path for the context item
+   */
+  generatePathFromContext?: (context: ContextItem, path: string) => string | undefined;
 }
 
 export class ContextProvider implements IContextProvider {
@@ -204,6 +221,15 @@ export class ContextProvider implements IContextProvider {
     // set the resolve and validate context functions
     config.resolveContext && (this.resolveContext = config.resolveContext?.bind(this));
     config.validateContext && (this.validateContext = config.validateContext?.bind(this));
+
+    if (config.extractContextIdFromPath) {
+      // @ts-ignore
+      this.extractContextIdFromPath = config.extractContextIdFromPath;
+    }
+    if (config.generatePathFromContext) {
+      // @ts-ignore
+      this.generatePathFromContext = config.generatePathFromContext;
+    }
 
     this.#contextType = config.contextType;
     this.#contextFilter = config.contextFilter;

--- a/packages/modules/context/src/configurator.ts
+++ b/packages/modules/context/src/configurator.ts
@@ -40,6 +40,9 @@ export interface ContextModuleConfig {
   /** set initial context from parent, will await resolve */
   skipInitialContext?: boolean;
 
+  extractContextIdFromPath?: (path: string) => string | undefined;
+  generatePathFromContext?: (context: ContextItem, path: string) => string | undefined;
+
   /**
    * Method for generating context query parameters.
    */
@@ -105,7 +108,14 @@ export class ContextModuleConfigurator implements IContextModuleConfigurator {
       Promise.resolve({} as Partial<ContextModuleConfig>),
     );
 
-    config.resolveInitialContext ??= resolveInitialContext();
+    console.log(999, 'createConfig', config);
+
+    config.resolveInitialContext ??= resolveInitialContext({
+      path: {
+        extract: config.extractContextIdFromPath,
+        validate: config.extractContextIdFromPath ? () => true : undefined,
+      },
+    });
 
     // TODO - make less lazy
     config.client ??= await (async (): Promise<ContextModuleConfig['client']> => {

--- a/packages/modules/context/src/configurator.ts
+++ b/packages/modules/context/src/configurator.ts
@@ -108,8 +108,6 @@ export class ContextModuleConfigurator implements IContextModuleConfigurator {
       Promise.resolve({} as Partial<ContextModuleConfig>),
     );
 
-    console.log(999, 'createConfig', config);
-
     config.resolveInitialContext ??= resolveInitialContext({
       path: {
         extract: config.extractContextIdFromPath,

--- a/packages/modules/services/tests/mocks/get-context-item.ts
+++ b/packages/modules/services/tests/mocks/get-context-item.ts
@@ -17,10 +17,10 @@ function stringToSeed(uuid: string): number {
 /**
  * Since generation of dates might have a slight difference in milliseconds
  * we normalize the date to the nearest minute, so we can compare them.
- * 
+ *
  * @note
  * This might fail at exactly midnight, but the odds for that are slim. Rerun the test if it fails.
- * 
+ *
  * @param date date to normalize
  * @returns string
  */


### PR DESCRIPTION
**@equinor/fusion-framework-react:**

- Enhanced `useAppContextNavigation` to support custom context path extraction and generation. This allows for more flexible navigation handling based on application-specific requirements.

**@equinor/fusion-framework-module-context:**

- Added support for custom context path extraction and generation in `ContextConfigBuilder`, `ContextProvider`, and `ContextModuleConfigurator`.
- Introduced `setContextPathExtractor` and `setContextPathGenerator` methods in `ContextConfigBuilder` to allow developers to define custom logic for extracting and generating context paths.
- Updated `ContextProvider` to utilize `extractContextIdFromPath` and `generatePathFromContext` from the configuration, enabling dynamic path handling.
- Enhanced `ContextModuleConfigurator` to include `extractContextIdFromPath` and `generatePathFromContext` in the module configuration.

If you are using `@equinor/fusion-framework-module-context` and need custom logic for context path handling:

1. Use `setContextPathExtractor` to define how to extract context IDs from paths.
2. Use `setContextPathGenerator` to define how to generate paths based on context items.

Example:

```typescript
builder.setContextPathExtractor((path) => {
  // Custom logic to extract context ID from path
  return path.match(/\/custom\/(.+)/)?.[1];
});

builder.setContextPathGenerator((context, path) => {
  // Custom logic to generate path from context
  return path.replace(/^(\/)?custom\/[^/]+(.*)$/, `/app/${item.id}$2`);
});
```

If your portal is generating context paths based on context items, you can now define custom logic for context path handling:

```typescript
contextProvider.currentContext$
  .pipe(
    map((context) => {
      // Custom logic to generate path from context
      const path = contextProvider.generatePathFromContext?.(
        context,
        location.pathname
      );
      return path ?? fallbackPathGenerator(context, location.pathname);
    }),
    filter(Boolean)
  )
  .subscribe((path) => history.push(path));
```



### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

