### PR TITLE
Add optional parent ModulesInstance to Framework component

### DIFF
--- a/.changeset/deep-spiders-warn.md
+++ b/.changeset/deep-spiders-warn.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react": patch
+---
+
+Added optional parent `ModulesInstance` when creating `Framework` component

--- a/packages/react/framework/src/Framework.tsx
+++ b/packages/react/framework/src/Framework.tsx
@@ -2,6 +2,7 @@ import type { FrameworkConfigurator } from '@equinor/fusion-framework';
 import { createFrameworkProvider } from './create-framework-provider';
 import { type PropsWithChildren, type ReactNode, Suspense, useMemo } from 'react';
 import { useModules } from '@equinor/fusion-framework-react-module';
+import type { ModulesInstance } from '@equinor/fusion-framework-module';
 
 type ConfigureCallback = (configurator: FrameworkConfigurator) => void;
 
@@ -9,12 +10,17 @@ export const Framework = (
   props: PropsWithChildren<{
     readonly configure: ConfigureCallback;
     readonly fallback: NonNullable<ReactNode> | null;
+    // biome-ignore lint/suspicious/noExplicitAny: should alow any
+    readonly parent?: ModulesInstance<any>;
   }>,
 ) => {
-  const { configure, fallback, children } = props;
+  const { configure, fallback, parent, children } = props;
   //import modules from parent context
   const ref = useModules<[]>();
-  const Component = useMemo(() => createFrameworkProvider(configure, ref), [configure, ref]);
+  const Component = useMemo(
+    () => createFrameworkProvider(configure, parent ?? ref),
+    [configure, ref, parent],
+  );
   return (
     <Suspense fallback={fallback}>
       <Component>{children}</Component>

--- a/packages/react/framework/src/Framework.tsx
+++ b/packages/react/framework/src/Framework.tsx
@@ -10,7 +10,7 @@ export const Framework = (
   props: PropsWithChildren<{
     readonly configure: ConfigureCallback;
     readonly fallback: NonNullable<ReactNode> | null;
-    // biome-ignore lint/suspicious/noExplicitAny: should alow any
+    // biome-ignore lint/suspicious/noExplicitAny: should allow any
     readonly parent?: ModulesInstance<any>;
   }>,
 ) => {


### PR DESCRIPTION
Introduce an optional parent `ModulesInstance` prop to the `Framework` component, allowing for enhanced module context management.