### PR TITLE
fix(cli): prevent context provider change if app is not current

### DIFF
--- a/.changeset/whole-rice-jog.md
+++ b/.changeset/whole-rice-jog.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-react-app": patch
+"@equinor/fusion-framework-cli": patch
+---
+
+- Add env to 'onReactAppLoaded' event
+- Prevent context provider change if app key is not current app for 'onReactAppLoaded'

--- a/packages/cli/src/bin/dev-portal/ContextSelector/useContextResolver.ts
+++ b/packages/cli/src/bin/dev-portal/ContextSelector/useContextResolver.ts
@@ -131,7 +131,10 @@ export const useContextResolver = (): {
       framework.modules.event.addEventListener('onReactAppLoaded', (e) => {
         // Only change provider if event is for current app
         if (e.detail.env.manifest.appKey === framework.modules.app.current?.appKey) {
-          console.debug('useContextResolver::onReactAppLoaded', 'using legacy register hack method');
+          console.debug(
+            'useContextResolver::onReactAppLoaded',
+            'using legacy register hack method',
+          );
           return onContextProviderChange(e.detail.modules);
         }
       }),

--- a/packages/cli/src/bin/dev-portal/ContextSelector/useContextResolver.ts
+++ b/packages/cli/src/bin/dev-portal/ContextSelector/useContextResolver.ts
@@ -129,8 +129,11 @@ export const useContextResolver = (): {
   useEffect(
     () =>
       framework.modules.event.addEventListener('onReactAppLoaded', (e) => {
-        console.debug('useContextResolver::onReactAppLoaded', 'using legacy register hack method');
-        return onContextProviderChange(e.detail.modules);
+        // Only change provider if event is for current app
+        if (e.detail.env.manifest.appKey === framework.modules.app.current?.appKey) {
+          console.debug('useContextResolver::onReactAppLoaded', 'using legacy register hack method');
+          return onContextProviderChange(e.detail.modules);
+        }
       }),
     [framework, onContextProviderChange],
   );

--- a/packages/react/app/src/create-component.tsx
+++ b/packages/react/app/src/create-component.tsx
@@ -87,7 +87,7 @@ export const createComponent =
       })) as unknown as AppModulesInstance;
 
       modules.event.dispatchEvent('onReactAppLoaded', {
-        detail: { modules, fusion },
+        detail: { modules, fusion, env: env },
         source: Component,
       });
       return {
@@ -107,7 +107,7 @@ export const createComponent =
 declare module '@equinor/fusion-framework-module-event' {
   interface FrameworkEventMap {
     onReactAppLoaded: FrameworkEvent<
-      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion }, React.ComponentType>
+      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion, env: AppEnv }, React.ComponentType>
     >;
   }
 }

--- a/packages/react/app/src/create-component.tsx
+++ b/packages/react/app/src/create-component.tsx
@@ -107,7 +107,10 @@ export const createComponent =
 declare module '@equinor/fusion-framework-module-event' {
   interface FrameworkEventMap {
     onReactAppLoaded: FrameworkEvent<
-      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion, env: AppEnv }, React.ComponentType>
+      FrameworkEventInit<
+        { modules: AppModulesInstance; fusion: Fusion; env: AppEnv },
+        React.ComponentType
+      >
     >;
   }
 }

--- a/packages/react/app/src/make-component.tsx
+++ b/packages/react/app/src/make-component.tsx
@@ -60,7 +60,7 @@ export const makeComponent = <
     const { fusion } = args;
 
     modules.event.dispatchEvent('onReactAppLoaded', {
-      detail: { modules, fusion },
+      detail: { modules, fusion, env: args.env },
       source: Component,
     });
 
@@ -76,7 +76,7 @@ export const makeComponent = <
 declare module '@equinor/fusion-framework-module-event' {
   interface FrameworkEventMap {
     onReactAppLoaded: FrameworkEvent<
-      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion }, React.ComponentType>
+      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion, env: AppEnv }, React.ComponentType>
     >;
   }
 }

--- a/packages/react/app/src/make-component.tsx
+++ b/packages/react/app/src/make-component.tsx
@@ -76,7 +76,10 @@ export const makeComponent = <
 declare module '@equinor/fusion-framework-module-event' {
   interface FrameworkEventMap {
     onReactAppLoaded: FrameworkEvent<
-      FrameworkEventInit<{ modules: AppModulesInstance; fusion: Fusion, env: AppEnv }, React.ComponentType>
+      FrameworkEventInit<
+        { modules: AppModulesInstance; fusion: Fusion; env: AppEnv },
+        React.ComponentType
+      >
     >;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,6 @@
       "@equinor/fusion-query": ["./utils/query/src"]
     }
   },
-  "include": [
-    "packages/**/src/**/*.ts",
-    "packages/**/src/**/*.tsx"
-  ],
+  "include": ["packages/**/src/**/*.ts", "packages/**/src/**/*.tsx"],
   "exclude": ["node_modules", "dist", "lib", "*.spec.ts"]
 }


### PR DESCRIPTION
Also add env to 'onReactAppLoaded' event

Ref [AB#61787](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/61787)

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

