### PR TITLE
refactor: remove unused typesVersions from package.json files

### DIFF
--- a/.changeset/four-carrots-shine.md
+++ b/.changeset/four-carrots-shine.md
@@ -1,0 +1,25 @@
+---
+"@equinor/fusion-framework-react-module-bookmark": patch
+"@equinor/fusion-framework-legacy-interopt": patch
+"@equinor/fusion-framework-react-module-signalr": patch
+"@equinor/fusion-framework-module-feature-flag": patch
+"@equinor/fusion-framework-module-navigation": patch
+"@equinor/fusion-framework-module-bookmark": patch
+"@equinor/fusion-framework-module-services": patch
+"@equinor/fusion-observable": patch
+"@equinor/fusion-framework-module-ag-grid": patch
+"@equinor/fusion-framework-module-signalr": patch
+"@equinor/fusion-framework-react": patch
+"@equinor/fusion-framework-module": patch
+"@equinor/fusion-framework-module-widget": patch
+"@equinor/fusion-framework-module-event": patch
+"@equinor/fusion-framework-react-ag-grid": patch
+"@equinor/fusion-framework-module-http": patch
+"@equinor/fusion-framework-module-msal": patch
+"@equinor/fusion-framework-module-app": patch
+"@equinor/fusion-query": patch
+"@equinor/fusion-framework-react-app": patch
+"@equinor/fusion-framework-app": patch
+---
+
+removed `typesVersions` from packages, since we no longer support TS < 4.7, also corrected `types` path in package.json

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,11 +14,6 @@
       "import": "./dist/esm/enable-bookmark.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "enable-bookmark": ["dist/types/enable-bookmark.d.ts"]
-    }
-  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/modules/ag-grid/package.json
+++ b/packages/modules/ag-grid/package.json
@@ -16,11 +16,6 @@
     "./package.json": "./package.json",
     "./README.md": "./README.md"
   },
-  "typesVersions": {
-    "*": {
-      "themes": ["dist/types/themes.d.ts"]
-    }
-  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/modules/app/package.json
+++ b/packages/modules/app/package.json
@@ -25,14 +25,6 @@
     }
   },
   "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "errors.js": ["dist/types/errors.d.ts"],
-      "schemas.js": ["dist/types/schemas.d.ts"],
-      "app": ["dist/types/app/index.d.ts"],
-      "app/*.js": ["dist/types/app/*.d.ts"]
-    }
-  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/modules/bookmark/package.json
+++ b/packages/modules/bookmark/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.5",
   "description": "",
   "main": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -12,12 +13,6 @@
     "./utils": {
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/types/utils/index.d.ts"
-    }
-  },
-  "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "utils": ["dist/types/utils/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/modules/event/package.json
+++ b/packages/modules/event/package.json
@@ -4,6 +4,7 @@
   "description": "Fusion module for events",
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -33,11 +34,5 @@
     "@types/lodash.clonedeep": "^4.5.9",
     "rxjs": "^7.8.1",
     "typescript": "^5.8.2"
-  },
-  "types": "index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"]
-    }
   }
 }

--- a/packages/modules/feature-flag/package.json
+++ b/packages/modules/feature-flag/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.14",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -18,14 +19,6 @@
     },
     "./package.json": "./package.json",
     "./README.md": "./README.md"
-  },
-  "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/index.d.ts"],
-      "plugins": ["dist/types/plugins/index.d.ts"],
-      "selectors": ["dist/types/utils/selectors.d.ts"]
-    }
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/modules/http/package.json
+++ b/packages/modules/http/package.json
@@ -3,7 +3,7 @@
   "version": "6.2.4",
   "description": "",
   "main": "dist/esm/index.js",
-  "types": "index.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -24,14 +24,6 @@
     "./errors": {
       "import": "./dist/esm/errors.js",
       "types": "./dist/types/errors.d.ts"
-    }
-  },
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"],
-      "client": ["dist/types/lib/client/index.d.ts"],
-      "operators": ["dist/types/lib/operators/index.d.ts"],
-      "selectors": ["dist/types/lib/selectors/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/modules/module/package.json
+++ b/packages/modules/module/package.json
@@ -3,6 +3,7 @@
   "version": "4.3.7",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -11,13 +12,6 @@
     "./provider": {
       "import": "./dist/esm/lib/provider/index.js",
       "types": "./dist/types/lib/provider/index.d.ts"
-    }
-  },
-  "types": "index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"],
-      "provider": ["dist/types/lib/provider/index"]
     }
   },
   "scripts": {

--- a/packages/modules/msal/package.json
+++ b/packages/modules/msal/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.2",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -11,12 +12,6 @@
     "./v2": {
       "import": "./dist/esm/v2/index.js",
       "types": "./dist/types/v2/index.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "v2": ["dist/types/v2/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/modules/navigation/package.json
+++ b/packages/modules/navigation/package.json
@@ -4,12 +4,7 @@
   "description": "",
   "sideEffects": false,
   "main": "dist/esm/index.js",
-  "types": "index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"]
-    }
-  },
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/modules/services/package.json
+++ b/packages/modules/services/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "sideEffects": false,
   "main": "dist/esm/index.js",
-  "types": "index.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/modules/signalr/package.json
+++ b/packages/modules/signalr/package.json
@@ -5,11 +5,6 @@
   "sideEffects": false,
   "main": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["./dist/types/index.d.ts", "dist/types/*"]
-    }
-  },
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/modules/widget/package.json
+++ b/packages/modules/widget/package.json
@@ -3,6 +3,7 @@
   "version": "9.0.7",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -11,12 +12,6 @@
     "./errors.js": {
       "import": "./dist/esm/errors.js",
       "types": "./dist/types/errors.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "errors.js": ["dist/types/errors.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/ag-grid/package.json
+++ b/packages/react/ag-grid/package.json
@@ -24,11 +24,6 @@
     "./package.json": "./package.json",
     "./README.md": "./README.md"
   },
-  "typesVersions": {
-    "*": {
-      "themes": ["dist/types/themes.d.ts"]
-    }
-  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -46,19 +46,6 @@
       "import": "./dist/esm/widget/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "bookmark": ["dist/types/bookmark/index.d.ts"],
-      "context": ["dist/types/context/index.d.ts"],
-      "feature-flag": ["dist/types/feature-flag/index.d.ts"],
-      "framework": ["dist/types/framework/index.d.ts"],
-      "http": ["dist/types/http/index.d.ts"],
-      "msal": ["dist/types/msal/index.d.ts"],
-      "navigation": ["dist/types/navigation/index.d.ts"],
-      "settings": ["dist/types/settings/index.d.ts"],
-      "widget": ["dist/types/widget/index.d.ts"]
-    }
-  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/react/framework/package.json
+++ b/packages/react/framework/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.7",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -31,17 +32,6 @@
     "./signalr": {
       "import": "./dist/esm/signalr/index.js",
       "types": "./dist/types/signalr/index.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "app": ["dist/types/app/index.d.ts"],
-      "feature-flag": ["dist/types/feature-flag/index.d.ts"],
-      "context": ["dist/types/context/index.d.ts"],
-      "hooks": ["dist/types/hooks/index.d.ts"],
-      "http": ["dist/types/http/index.d.ts"],
-      "signalr": ["dist/types/signalr/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/legacy-interopt/package.json
+++ b/packages/react/legacy-interopt/package.json
@@ -3,6 +3,7 @@
   "version": "21.0.9",
   "description": "Library for interopt legacy fusion applications",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -11,12 +12,6 @@
     "./components": {
       "import": "./dist/esm/components/index.js",
       "types": "./dist/types/components/index.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "components": ["dist/types/components/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/modules/bookmark/package.json
+++ b/packages/react/modules/bookmark/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.7",
   "description": "",
   "main": "dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -11,12 +12,6 @@
     "./portal": {
       "import": "./dist/esm/portal/index.js",
       "types": "./dist/types/portal/index.d.ts"
-    }
-  },
-  "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "portal": ["dist/types/portal/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/react/modules/signalr/package.json
+++ b/packages/react/modules/signalr/package.json
@@ -4,12 +4,7 @@
   "description": "",
   "sideEffects": false,
   "main": "dist/esm/index.js",
-  "types": "index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"]
-    }
-  },
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/utils/observable/package.json
+++ b/packages/utils/observable/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://equinor.github.io/fusion-framework/",
   "license": "ISC",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -18,13 +19,6 @@
     "./react": {
       "import": "./dist/esm/react/index.js",
       "types": "./dist/types/react/index.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operators": ["dist/types/operators/index.d.ts"],
-      "react": ["dist/types/react/index.d.ts"]
     }
   },
   "directories": {

--- a/packages/utils/query/package.json
+++ b/packages/utils/query/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/equinor/fusion-framework/tree/master/packages/observable#readme",
   "license": "ISC",
   "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -26,15 +27,6 @@
     "./operators": {
       "import": "./dist/esm/operators.js",
       "types": "./dist/types/operators.d.ts"
-    }
-  },
-  "types": "dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "cache": ["dist/types/cache/index.d.ts"],
-      "client": ["dist/types/client/index.d.ts"],
-      "operators": ["dist/types/operators.d.ts"],
-      "react": ["dist/types/react/index.d.ts"]
     }
   },
   "directories": {


### PR DESCRIPTION
Removes unused typesVersions from package.json files

Cleans up package.json files by removing unnecessary
typesVersions entries that are no longer in use.

This refactor helps streamline the package configuration
and reduces potential confusion regarding type definitions.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

