### PR TITLE
Improve import resolution and support for multiple configuration files

### DIFF
--- a/.changeset/all-rice-repair.md
+++ b/.changeset/all-rice-repair.md
@@ -1,0 +1,33 @@
+---
+"@equinor/fusion-imports": minor
+---
+
+This update to `@equinor/fusion-imports` improves error handling, enhances support for resolving multiple configuration file base names, and delivers structured results for import operations. Key enhancements include:
+
+- Dedicated error classes for file-related issues
+- Improved handling of script imports
+- Robust file resolution mechanisms
+  
+Import handling now supports resolving scripts with imports from other modules, correctly resolving from the source directory or node_modules. Previously, imports were resolved only from memory, excluding the current working directory (cwd).
+
+Note: This release includes breaking changes, requiring updates to dependent codebases.
+
+**Added:**
+- Introduced `FileNotFoundError` and `FileNotAccessibleError` classes to handle specific file-related errors.
+- Added `processAccessError` utility to process file access errors and throw appropriate error types.
+- Added support for resolving multiple base names in `resolveConfigFile`.
+- Added `ImportConfigResult` type to provide structured results from `importConfig`.
+
+**Changed:**
+- Updated `importConfig` to return a structured result containing `path`, `extension`, and `config` instead of just the configuration object.
+- Modified `importScript` to support custom output paths and handle memory-based builds when `write` is set to `false`.
+- Enhanced `resolveConfigFile` to handle arrays of base names and throw `FileNotFoundError` for missing files.
+
+**Fixed:**
+- Fixed issues with `importScript` where missing files were not properly handled.
+- Improved error handling for file access in `resolveConfigFile`.
+
+**BREAKING CHANGES:**
+- `importConfig` now returns an object of type `ImportConfigResult` instead of the raw configuration content. This change requires updates to all consumers of this function.
+- `resolveConfigFile` now throws `FileNotFoundError` instead of a generic `Error` when no configuration file is found.
+- `importScript` now uses `read-package-up` to determine the package-local path, which may affect the output location of bundled files.

--- a/packages/utils/imports/package.json
+++ b/packages/utils/imports/package.json
@@ -33,6 +33,9 @@
   "bugs": {
     "url": "https://github.com/equinor/fusion-framework/issues"
   },
+  "dependencies": {
+    "read-package-up": "^11.0.0"
+  },
   "devDependencies": {
     "@types/node": "^20.11.14",
     "esbuild": "^0.25.1",

--- a/packages/utils/imports/src/error.ts
+++ b/packages/utils/imports/src/error.ts
@@ -1,0 +1,51 @@
+/**
+ * Represents an error that is thrown when a specified file cannot be found.
+ *
+ * @extends {Error}
+ *
+ * @param message - A descriptive message providing details about the missing file.
+ * @param options - Optional error options that can be used to provide additional context.
+ */
+export class FileNotFoundError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'FileNotFoundError';
+  }
+}
+
+/**
+ * Represents an error that occurs when a file is not accessible.
+ *
+ * @extends Error
+ * @param message - A descriptive message providing details about the error.
+ * @param options - Optional error options that can include additional metadata or cause information.
+ */
+export class FileNotAccessibleError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'FileNotAccessibleError';
+  }
+}
+
+/**
+ * Processes an access error and throws a specific error based on the error code.
+ *
+ * @param error - The error object to process, typically of type `unknown`.
+ * @param path - The file path associated with the error.
+ *
+ * @throws FileNotFoundError - If the error code is `ENOENT`, indicating the file was not found.
+ * @throws FileNotAccessibleError - If the error code is `EACCES`, indicating the file is not accessible.
+ * @throws Error - For any other error codes, indicating an unknown error occurred.
+ */
+export const processAccessError = (error: unknown, path: string): Error => {
+  switch ((error as NodeJS.ErrnoException).code) {
+    case 'ENOENT':
+      return new FileNotFoundError(`File not found: ${path}`, { cause: error });
+    case 'EISDIR':
+      return new FileNotAccessibleError(`Path is a directory: ${path}`, { cause: error });
+    case 'EACCES':
+      return new FileNotAccessibleError(`File not accessible: ${path}`, { cause: error });
+    default:
+      return new Error(`Unknown error accessing: ${path}`, { cause: error });
+  }
+};

--- a/packages/utils/imports/src/import-script.ts
+++ b/packages/utils/imports/src/import-script.ts
@@ -1,6 +1,9 @@
 import { build, type BuildOptions } from 'esbuild';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
+import { processAccessError } from './error.js';
+
+import { readPackageUp } from 'read-package-up';
 
 /**
  * Represents a Node.js module with an optional default export.
@@ -16,13 +19,14 @@ export type EsmModule = Record<string, unknown> & {
 /**
  * Options for importing a script, excluding certain build options.
  *
+ * @note when `write` is set to `false`, the output will be loaded from memory.
+ *
  * This type is derived from `BuildOptions` but omits the following properties:
  * - `entryPoints`
- * - `write`
  * - `bundle`
  * - `format`
  */
-export type ImportScriptOptions = Omit<BuildOptions, 'entryPoints' | 'write' | 'bundle' | 'format'>;
+export type ImportScriptOptions = Omit<BuildOptions, 'entryPoints' | 'bundle' | 'format'>;
 
 /**
  * Asynchronously imports a script file using esbuild to bundle it.
@@ -52,39 +56,56 @@ export const importScript = async <M extends EsmModule>(
   try {
     await access(sourceFile);
   } catch (error) {
-    throw new Error(`The file '${entryPoint}' does not exist or cannot be accessed`, {
-      cause: error,
-    });
+    throw processAccessError(error, sourceFile);
   }
+
+  const packageLocalPath = await readPackageUp().then((pkg) =>
+    pkg ? path.dirname(pkg?.path) : process.cwd(),
+  );
+
+  const outfile =
+    options?.outfile ??
+    path.join(
+      packageLocalPath,
+      'node_modules/.cache/esbuild',
+      `${path.basename(sourceFile)}.esbuild.js`,
+    );
 
   try {
     const buildOptions = Object.assign(
       {
         // default options
+        outfile,
         platform: 'node',
+        write: true,
       },
       options, // provided options
       {
         // non-overridable options
+        outdir: undefined,
         entryPoints: [sourceFile],
-        write: false,
         bundle: true,
+        packages: 'external',
         format: 'esm',
       },
     ) as BuildOptions;
 
     const result = await build(buildOptions);
 
-    // Ensure that at least one output file was generated
-    const [output] = result.outputFiles ?? [];
-    if (!output) {
-      throw new Error(`No output files generated for '${entryPoint}'`);
+    if (!buildOptions.write) {
+      // If write is false, we need to write the output files manually
+      // Ensure that at least one output file was generated
+      const [output] = result.outputFiles ?? [];
+      if (!output) {
+        throw new Error(`No output files generated for '${entryPoint}'`);
+      }
+
+      // Create a data URL from the bundled script
+      const dataUrl = `data:text/javascript;base64,${Buffer.from(output.text).toString('base64')}`;
+      return import(dataUrl);
     }
 
-    // Create a data URL from the bundled script
-    const dataUrl = `data:text/javascript;base64,${Buffer.from(output.text).toString('base64')}`;
-
-    return import(dataUrl);
+    return import(outfile);
   } catch (error) {
     throw new Error(
       `Failed to bundle '${entryPoint}' with esbuild. Check for syntax errors or unresolved imports.`,

--- a/packages/utils/imports/src/index.ts
+++ b/packages/utils/imports/src/index.ts
@@ -1,4 +1,11 @@
-export { importScript } from './import-script';
-export { importJSON } from './import-json';
-export { default, importConfig, type ConfigContent } from './import-config';
-export { resolveConfigFile } from './resolve-config-file';
+export { importScript } from './import-script.js';
+export { importJSON } from './import-json.js';
+export {
+  default,
+  importConfig,
+  type ConfigContent,
+  type ImportConfigResult,
+} from './import-config.js';
+export { resolveConfigFile } from './resolve-config-file.js';
+
+export { FileNotFoundError, FileNotAccessibleError } from './error.js';

--- a/packages/utils/imports/src/resolve-config-file.ts
+++ b/packages/utils/imports/src/resolve-config-file.ts
@@ -1,6 +1,8 @@
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+import { FileNotFoundError, processAccessError } from './error.js';
+
 const defaultExtensions = ['.ts', '.mjs', '.js', '.json'];
 
 /**
@@ -24,25 +26,40 @@ export type ResolveConfigFileOptions = {
  * @throws Will throw an error if no configuration file is found with the given base name and extensions.
  */
 export async function resolveConfigFile(
-  baseName: string,
+  baseName: string | string[],
   options: ResolveConfigFileOptions = {},
 ): Promise<string> {
-  if (!baseName || typeof baseName !== 'string') {
-    throw new Error('baseName must be a non-empty string');
-  }
-
   const { baseDir = process.cwd(), extensions = defaultExtensions } = options;
 
-  for (const ext of extensions) {
-    const filePath = resolve(baseDir, `${baseName}${ext}`);
-    try {
-      await access(filePath);
-      return filePath;
-    } catch {
-      // Continue to the next extension
+  const suggestions = Array.isArray(baseName) ? baseName : [baseName];
+
+  for (const suggestion of suggestions) {
+    if (typeof suggestion !== 'string' || suggestion.length === 0) {
+      throw new Error('baseName must be a non-empty string');
     }
+    try {
+      await access(suggestion);
+      return suggestion;
+    } catch (err) {
+      const error = processAccessError(err, suggestion);
+      if (error instanceof FileNotFoundError === false) {
+        // unless the error is a FileNotFoundError, rethrow the error
+        throw error;
+      }
+    }
+    for (const ext of extensions) {
+      const filePath = resolve(baseDir, `${suggestion}${ext}`);
+      try {
+        await access(filePath);
+        return filePath;
+      } catch {
+        // Continue to the next extension
+      }
+    }
+    // continue to the next suggestion
   }
-  throw new Error(`No configuration file found for basename '${baseName}'`);
+  // no suggestion found
+  throw new FileNotFoundError(`No configuration file found for basename '${baseName}'`);
 }
 
 export default resolveConfigFile;

--- a/packages/utils/imports/tests/import-config.test.ts
+++ b/packages/utils/imports/tests/import-config.test.ts
@@ -19,7 +19,7 @@ describe('import-config', () => {
   it('should load config from a json file', async () => {
     vol.writeFileSync('config.json', JSON.stringify(mockConfig));
     const result = await importConfig('config');
-    expect(result).toMatchObject(mockConfig);
+    expect(result.config).toMatchObject(mockConfig);
   });
 
   it('should load config from a javascript file', async () => {
@@ -31,7 +31,7 @@ describe('import-config', () => {
       ),
     );
     const result = await importConfig('config');
-    expect(result).toMatchObject(mockConfig);
+    expect(result.config).toMatchObject(mockConfig);
   });
 
   it('should prefer typescript over javascript', async () => {
@@ -47,7 +47,8 @@ describe('import-config', () => {
       ),
     );
     const result = await importConfig('config');
-    expect(result).toMatchObject(mockConfig);
+    expect(result.config).toMatchObject(mockConfig);
+    expect(result.extension).toBe('.ts');
     expect(vol.existsSync('config.js')).toBe(true);
   });
 
@@ -62,7 +63,21 @@ describe('import-config', () => {
         resolve: (module: Module) => module.foo(1),
       },
     });
-    expect(result).toBe(2);
+    expect(result.config).toBe(2);
+  });
+
+  it('should load a config with a custom async resolver', async () => {
+    type Module = { foo: (value: number) => Promise<number> };
+    vol.writeFileSync(
+      'config.ts',
+      generateFileContent('export const foo = async (value: number) => value + 1;'),
+    );
+    const result = await importConfig('config', {
+      script: {
+        resolve: async (module: Module) => module.foo(1),
+      },
+    });
+    expect(result.config).toBe(2);
   });
 
   it('should throw an error if the config file does not exist', async () => {

--- a/packages/utils/imports/tests/setup.ts
+++ b/packages/utils/imports/tests/setup.ts
@@ -31,6 +31,14 @@ export const memfsPlugin: EsBuildPlugin = {
       const contents = String(vol.readFileSync(args.path, 'utf-8'));
       return { contents, loader: extname(args.path).slice(1) as 'js' | 'ts' };
     });
+
+    build.onEnd((result) => {
+      for (const file of result.outputFiles ?? []) {
+        const { path, contents } = file;
+        vol.mkdirSync(dirname(path), { recursive: true });
+        vol.writeFileSync(path, contents);
+      }
+    });
   },
 };
 
@@ -47,6 +55,7 @@ beforeAll(() => {
       original.importScript(path, {
         ...options,
         plugins: (options?.plugins ?? []).concat(memfsPlugin),
+        write: false,
       });
     return {
       importScript,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1670,6 +1670,10 @@ importers:
         version: 5.8.3
 
   packages/utils/imports:
+    dependencies:
+      read-package-up:
+        specifier: ^11.0.0
+        version: 11.0.0
     devDependencies:
       '@types/node':
         specifier: ^20.11.14
@@ -17451,16 +17455,16 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       index-to-position: 1.1.0
-      type-fest: 4.39.1
+      type-fest: 4.40.1
 
   parse-ms@4.0.0: {}
 
@@ -18897,8 +18901,7 @@ snapshots:
 
   type-fest@4.39.1: {}
 
-  type-fest@4.40.1:
-    optional: true
+  type-fest@4.40.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION

This update to `@equinor/fusion-imports` improves error handling, enhances support for resolving multiple configuration file base names, and delivers structured results for import operations. Key enhancements include:

- Dedicated error classes for file-related issues
- Improved handling of script imports
- Robust file resolution mechanisms
  
Import handling now supports resolving scripts with imports from other modules, correctly resolving from the source directory or node_modules. Previously, imports were resolved only from memory, excluding the current working directory (cwd).

Note: This release includes breaking changes, requiring updates to dependent codebases.

**Added:**
- Introduced `FileNotFoundError` and `FileNotAccessibleError` classes to handle specific file-related errors.
- Added `processAccessError` utility to process file access errors and throw appropriate error types.
- Added support for resolving multiple base names in `resolveConfigFile`.
- Added `ImportConfigResult` type to provide structured results from `importConfig`.

**Changed:**
- Updated `importConfig` to return a structured result containing `path`, `extension`, and `config` instead of just the configuration object.
- Modified `importScript` to support custom output paths and handle memory-based builds when `write` is set to `false`.
- Enhanced `resolveConfigFile` to handle arrays of base names and throw `FileNotFoundError` for missing files.

**Fixed:**
- Fixed issues with `importScript` where missing files were not properly handled.
- Improved error handling for file access in `resolveConfigFile`.

**BREAKING CHANGES:**
- `importConfig` now returns an object of type `ImportConfigResult` instead of the raw configuration content. This change requires updates to all consumers of this function.
- `resolveConfigFile` now throws `FileNotFoundError` instead of a generic `Error` when no configuration file is found.
- `importScript` now uses `read-package-up` to determine the package-local path, which may affect the output location of bundled files.
