### PR TITLE
Add support for Server-Sent Events (SSE) in HTTP module

### DIFF
--- a/.changeset/sse-support-added.md
+++ b/.changeset/sse-support-added.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-module-http": minor
+---
+
+### Added
+
+- Introduced support for Server-Sent Events (SSE) in the HTTP module.
+  - Added `sse$` method to `HttpClient` for subscribing to SSE streams.
+  - Added `sseMap` operator for handling SSE in RxJS pipelines.
+  - Added `createSseSelector` for transforming SSE responses into observables.
+  - Enhanced error handling with `ServerSentEventResponseError`.
+
+### Documentation
+
+- Updated README with examples and usage details for SSE support.

--- a/packages/modules/http/README.md
+++ b/packages/modules/http/README.md
@@ -18,13 +18,13 @@ Whether you're building a simple application or a complex portal, the Fusion Fra
 
 ## Package
 
-| Namespace | Description |
-|-----------|-------------|
-| `@equinor/fusion-framework-module-http` | http module
-| `@equinor/fusion-framework-module-http/client` | http clients
-| `@equinor/fusion-framework-module-http/selectors` | http selectors
-| `@equinor/fusion-framework-module-http/operators` | http client operators
-| `@equinor/fusion-framework-module-http/errors` | http client errors
+| Namespace                                         | Description           |
+| ------------------------------------------------- | --------------------- |
+| `@equinor/fusion-framework-module-http`           | http module           |
+| `@equinor/fusion-framework-module-http/client`    | http clients          |
+| `@equinor/fusion-framework-module-http/selectors` | http selectors        |
+| `@equinor/fusion-framework-module-http/operators` | http client operators |
+| `@equinor/fusion-framework-module-http/errors`    | http client errors    |
 
 ## Usage
 Working with Fusion Framework, HTTP clients are defined during the configuration phase. The configuration is called by the Framework during initialization, ensuring that the HTTP clients are ready to be used. This approach allows for centralized and optimized client configuration, promoting consistency, performance, and security in HTTP communication within the Fusion Framework ecosystem.
@@ -179,15 +179,15 @@ By following this approach, you can enhance the efficiency, consistency, securit
 
 When configuring an HTTP client in the Fusion Framework, you can specify various settings to customize its behavior. The following options are available for configuring an HTTP client:
 
-| Property | Description |
-|----------|-------------|
-| `baseUri` | The base URI for the API endpoint. |
-| `defaultScopes` | The default scopes for MSAL authentication. |
-| `selector` | The response selector for processing the response. |
-| `onCreate` | A callback function to execute when the client is created. |
-| `requestHandler` | The request operators for processing outgoing requests. |
-| `responseHandler` | The response operators for processing incoming responses. |
-| `ctor` | The constructor function for a custom client. |
+| Property          | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `baseUri`         | The base URI for the API endpoint.                         |
+| `defaultScopes`   | The default scopes for MSAL authentication.                |
+| `selector`        | The response selector for processing the response.         |
+| `onCreate`        | A callback function to execute when the client is created. |
+| `requestHandler`  | The request operators for processing outgoing requests.    |
+| `responseHandler` | The response operators for processing incoming responses.  |
+| `ctor`            | The constructor function for a custom client.              |
 
 
 ### Basic configuration
@@ -807,6 +807,12 @@ client.blob('/image.jpg').then(
   }
 );
 
+/** example of Server Sent Events */
+client.sse$('/chatbot', {
+  method: 'POST',
+  body: { prompt: 'Tell me a joke' }
+})
+
 /** Example of executing named function */
 client.execute<Users>('json', '/users'); // same as client.json<Users>('/users');
 
@@ -827,3 +833,162 @@ client.response$.subscribe(response => {
   console.log('Incoming response:', response);
 });
 ```
+
+### Server-Sent Events (SSE)
+
+The HTTP client supports Server-Sent Events (SSE) through the `sse$` method. While this feature is versatile and can be used for various real-time communication scenarios, such as notifications, dashboards, or collaborative tools, it was primarily developed to facilitate streaming responses from chatbots. 
+
+Key benefits of SSE:
+- Ideal for live updates, such as chatbot interactions, notifications, or collaborative tools.
+- Provides an efficient way to handle server-driven data updates.
+- Simplifies real-time communication with minimal setup.
+
+The `sse$` method enables you to subscribe to a continuous stream of events sent by the server, making it particularly useful for applications requiring dynamic, real-time interactions, such as conversational AI or chatbot systems. This functionality ensures seamless and efficient communication between the client and server, enhancing the user experience in scenarios where immediate feedback or updates are critical.
+
+#### Usage
+
+The `sse$` method returns an observable that emits events as they are received from the server. It uses `client.fetch$` under the hood, abstracting common boilerplate code such as setting headers, configuring the request, and handling the response stream.
+
+```typescript
+/** Example of using the sse$ method to subscribe to server-sent events */
+const eventStream$ = client.sse$<{ message: string }>('/events');
+
+const subscription = eventStream$.subscribe({
+  next: (event) => console.log('Received event:', event),
+  error: (error) => console.error('An error occurred:', error),
+  complete: () => console.log('Event stream completed'),
+});
+
+// To stop listening to events, unsubscribe from the observable
+subscription.unsubscribe();
+```
+
+#### Options
+
+| Option           | Description                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `dataParser`     | A function to parse the raw event data into a desired format.                        |
+| `skipHeartbeats` | A boolean indicating whether to skip heartbeat events (default: `false`).            |
+| `eventFilter`    | An array of event types to filter. Only events matching these types will be emitted. |
+
+#### Customizing SSE Behavior
+
+You can customize the behavior of the SSE stream by providing options to the `sse$` method. For example, you can specify a custom data parser or handle reconnection logic.
+
+```typescript
+/** Example of customizing SSE behavior with options */
+const customEventStream$ = client.sse$<MyEventData & { timestamp: Date }>(
+  '/custom-events', 
+  null, 
+  {
+    dataParser: (data) => {
+      const parsedData = JSON.parse(data) as MyEventData;
+      return { ...parsedData, timestamp: new Date() };
+    },
+  }
+);
+
+customEventStream$.subscribe({
+  next: (event) => console.log('Custom event received:', event),
+  error: (error) => console.error('An error occurred:', error),
+  complete: () => console.log('Custom event stream completed'),
+});
+```
+
+#### Aborting SSE Requests
+
+You can abort an SSE request by using the `abort` method of the HTTP client or by unsubscribing from the observable.
+
+```typescript
+/** Example of aborting an SSE request */
+const abortController = new AbortController();
+
+const abortableEventStream$ = client.sse$<{ message: string }>('/abortable-events', {
+  signal: abortController.signal,
+});
+
+const subscription = abortableEventStream$.subscribe({
+  next: (event) => console.log('Received event:', event),
+  error: (error) => console.error('An error occurred:', error),
+  complete: () => console.log('Event stream completed'),
+});
+
+// Abort the request
+abortController.abort();
+```
+
+> [!NOTE]
+> Unsubscribing from the observable will also abort the SSE request automatically.
+
+#### Using `sseSelector` with `httpClient.fetch`
+
+If you need to create an SSE call from scratch without using the `sse$` method, you can use the `sseSelector` directly with the `httpClient.fetch` method. Here's an example:
+
+```typescript
+import { createSseSelector } from '@equinor/fusion-framework-module-http/selectors';
+
+/** Example of using sseSelector with httpClient.fetch */
+const sseSelector = createSseSelector<{ message: string }>({
+  dataParser: (data) => JSON.parse(data),
+  skipHeartbeats: true,
+  eventFilter: ['message', 'update'],
+});
+
+const headers = new Headers({
+  'Accept': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  'Connection': 'keep-alive',
+});
+
+const sseStream$ = client.fetch('/events', {
+  selector: sseSelector,
+  headers,
+  method: 'GET', // SSE calls typically use GET
+});
+
+const subscription = sseStream$.subscribe({
+  next: (event) => console.log('Received event:', event),
+  error: (error) => console.error('An error occurred:', error),
+  complete: () => console.log('Event stream completed'),
+});
+
+// To stop listening to events, unsubscribe from the observable
+subscription.unsubscribe();
+```
+
+#### Using `sseMap` with `client.fetch$`
+
+The `sseMap` operator can be used with `client.fetch$` to process Server-Sent Events (SSE) in a declarative manner. This approach allows you to handle SSE streams while leveraging the flexibility of RxJS.
+
+```typescript
+import { sseMap } from '@equinor/fusion-framework-module-http/operators';
+
+/** Example of using sseMap with client.fetch$ */
+const sseStream$ = client.fetch$('/events', {
+  method: 'GET',
+  headers: {
+    'Accept': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  },
+}).pipe(
+  sseMap<{ message: string }>({
+    dataParser: (data) => JSON.parse(data),
+    skipHeartbeats: true,
+    eventFilter: ['message', 'update'],
+  }),
+);
+
+const subscription = sseStream$.subscribe({
+  next: (event) => console.log('Received event:', event),
+  error: (error) => console.error('An error occurred:', error),
+  complete: () => console.log('SSE stream completed'),
+});
+
+// To stop listening to events, unsubscribe from the observable
+subscription.unsubscribe();
+```
+
+This example demonstrates how to use `sseMap` with `client.fetch$` to process SSE data efficiently.
+
+This approach provides more flexibility for customizing the SSE behavior while still leveraging the `httpClient.fetch` method. However, for most use cases, `client.sse$` is recommended as it simplifies the process by abstracting common boilerplate code.

--- a/packages/modules/http/README.md
+++ b/packages/modules/http/README.md
@@ -879,7 +879,7 @@ You can customize the behavior of the SSE stream by providing options to the `ss
 /** Example of customizing SSE behavior with options */
 const customEventStream$ = client.sse$<MyEventData & { timestamp: Date }>(
   '/custom-events', 
-  null, 
+  { method: 'POST', body: 'tell me a joke' }, 
   {
     dataParser: (data) => {
       const parsedData = JSON.parse(data) as MyEventData;

--- a/packages/modules/http/src/errors.ts
+++ b/packages/modules/http/src/errors.ts
@@ -40,3 +40,27 @@ export class HttpJsonResponseError<
     this.data = options?.data;
   }
 }
+
+export class HttpStreamResponseError<
+  TType = unknown,
+  TResponse = Response,
+> extends HttpResponseError<TResponse> {
+  static Name = 'HttpStreamResponseError';
+  public readonly data?: TType;
+
+  constructor(message: string, response: TResponse, options?: ErrorOptions & { data?: TType }) {
+    super(message, response, options);
+    this.name = HttpStreamResponseError.Name;
+    this.data = options?.data;
+  }
+}
+
+export class ServerSentEventResponseError<
+  TType = unknown,
+  TResponse = Response,
+> extends HttpResponseError<TResponse> {
+  constructor(message: string, response: TResponse, options?: ErrorOptions & { data?: TType }) {
+    super(message, response, options);
+    this.name = 'ServerSentEventResponseError';
+  }
+}

--- a/packages/modules/http/src/errors.ts
+++ b/packages/modules/http/src/errors.ts
@@ -41,26 +41,29 @@ export class HttpJsonResponseError<
   }
 }
 
-export class HttpStreamResponseError<
-  TType = unknown,
-  TResponse = Response,
-> extends HttpResponseError<TResponse> {
-  static Name = 'HttpStreamResponseError';
-  public readonly data?: TType;
-
-  constructor(message: string, response: TResponse, options?: ErrorOptions & { data?: TType }) {
-    super(message, response, options);
-    this.name = HttpStreamResponseError.Name;
-    this.data = options?.data;
-  }
-}
-
+/**
+ * Represents an error that occurs when handling a server-sent event (SSE) HTTP response.
+ *
+ * @template TType - The type of additional data associated with the error.
+ * @template TResponse - The type of the HTTP response object.
+ *
+ * @extends HttpResponseError<TResponse>
+ */
 export class ServerSentEventResponseError<
   TType = unknown,
   TResponse = Response,
 > extends HttpResponseError<TResponse> {
+  static Name = 'ServerSentEventResponseError';
+
+  /**
+   * Creates a new instance of the error.
+   *
+   * @param message - The error message describing the cause of the error.
+   * @param response - The HTTP response associated with the error.
+   * @param options - Optional error options, which may include additional data of type `TType`.
+   */
   constructor(message: string, response: TResponse, options?: ErrorOptions & { data?: TType }) {
     super(message, response, options);
-    this.name = 'ServerSentEventResponseError';
+    this.name = ServerSentEventResponseError.Name;
   }
 }

--- a/packages/modules/http/src/lib/client/client.ts
+++ b/packages/modules/http/src/lib/client/client.ts
@@ -229,18 +229,44 @@ export class HttpClient<
     return firstValueFrom(this.blob$(path, args));
   }
 
+  /**
+   * Initiates a Server-Sent Events (SSE) stream request to the specified path and returns a stream of events.
+   *
+   * @template T - The type of the event data expected from the SSE stream.
+   * @param path - The endpoint path to connect to for the SSE stream.
+   * @param args - Optional fetch request initialization options, including headers and abort signal.
+   * @param options - Optional selector options for customizing the SSE stream, excluding the abort signal.
+   *
+   * @returns A `StreamResponse` that emits `ServerSentEvent<T>` objects as they are received from the server.
+   *
+   * @example
+   * const sse$ = httpClient.sse(
+   *  '/events',
+   *  { method: 'POST', body: JSON.stringify({ prompt: 'tell me a joke' }) },
+   *  { eventFilter: ['message'] }
+   * );
+   * sse$.subscribe({
+   *  next: (event) => console.log(event),
+   *  error: (err) => console.error(err),
+   *  complete: () => console.log('Completed'),
+   * });
+   */
   public sse$<T = unknown>(
     path: string,
     args?: FetchRequestInit<ServerSentEvent<T>, TRequest, TResponse> | null,
     options?: Omit<SseSelectorOptions<T>, 'abortSignal'>,
   ): StreamResponse<ServerSentEvent<T>> {
+    // Setup default common headers for SSE
     const headers = new Headers(args?.headers);
     headers.append('Accept', 'text/event-stream');
     headers.append('Content-Type', 'text/event-stream');
     headers.append('Cache-Control', 'no-cache');
     headers.append('Connection', 'keep-alive');
 
+    // Create the selector using the provided options and the abort signal from args
     const selector = createSseSelector<T>({ ...options, abortSignal: args?.signal });
+
+    // Call the fetch$ method with the provided path and the constructed init object
     return this._fetch$(path, { selector, ...args, headers } as FetchRequestInit<
       ServerSentEvent<T>,
       TRequest,

--- a/packages/modules/http/src/lib/operators/sse.operator.ts
+++ b/packages/modules/http/src/lib/operators/sse.operator.ts
@@ -1,0 +1,44 @@
+import type { OperatorFunction } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import {
+  createSseSelector,
+  type ServerSentEvent,
+  type SseSelectorOptions,
+} from '../selectors/sse-selector';
+
+/**
+ * An operator function for handling Server-Sent Events (SSE) in an RxJS pipeline.
+ *
+ * @template R - The type of the parsed data from the SSE.
+ * @template T - The type of the input `Response` object, defaults to `Response`.
+ *
+ * @param options - Configuration options for the SSE selector.
+ *
+ * @returns An `OperatorFunction` that transforms a stream of `Response` objects
+ * into a stream of `ServerSentEvent` objects containing parsed data of type `R`.
+ *
+ * @example
+ * ```typescript
+ * import { sseMap } from '@equinor/fusion-framework-module-http/operators';
+ * import { fromFetch } from 'rxjs/fetch';
+ *
+ * const response$ = fromFetch('https://example.com/sse', {
+ *   method: 'GET',
+ *   headers: {
+ *     'Accept': 'text/event-stream',
+ *   },
+ * }).pipe(
+ *   sseMap( { /* SSE selector options *\/ })
+ * ).subscribe((event) => {
+ *   console.log(event.data); // Process the parsed SSE data
+ * });
+ * ```
+ */
+export const sseMap =
+  <R = unknown, T extends Response = Response>(
+    options?: SseSelectorOptions<R>,
+  ): OperatorFunction<T, ServerSentEvent<R>> =>
+  (source) =>
+    source.pipe(switchMap(createSseSelector<R, T>(options)));
+
+export default sseMap;

--- a/packages/modules/http/src/lib/selectors/sse-selector.ts
+++ b/packages/modules/http/src/lib/selectors/sse-selector.ts
@@ -216,7 +216,8 @@ export type SseSelector<TData = unknown, TResponse extends Response = Response> 
  * @param options - Optional configuration for event filtering and heartbeat handling.
  * @param options.eventFilter - Filter events by type (single string or array).
  * @param options.skipHeartbeats - Skip empty/heartbeat events if true.
- * @param options.maxRetries - Maximum number of reconnection attempts (default: 3).
+ * @param options.dataParser - Custom parser for the data field.
+ * @param options.abortSignal - Abort signal to cancel the stream.
  * @returns An Observable emitting parsed ServerSentEvent objects.
  * @throws ServerSentEventResponseError if response is invalid or stream fails.
  */

--- a/packages/modules/http/src/lib/selectors/sse-selector.ts
+++ b/packages/modules/http/src/lib/selectors/sse-selector.ts
@@ -1,0 +1,261 @@
+import { EMPTY, from, fromEvent, type Observable } from 'rxjs';
+import { finalize, takeUntil } from 'rxjs/operators';
+
+import type { ResponseSelector } from '../client/types.js';
+import { ServerSentEventResponseError } from '../../errors.js';
+
+/**
+ * A type representing a function that parses a string into a specific data type.
+ *
+ * @typeParam TData - The type of the parsed data. Defaults to `unknown` if not specified.
+ * @param data - The string input to be parsed.
+ * @returns The parsed data of type `TData`.
+ */
+export type DataParser<TData = unknown> = (data: string) => TData;
+
+const defaultDataParser: DataParser = (data: string) => {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+};
+
+/**
+ * Represents a Server-Sent Event (SSE) with optional fields.
+ */
+export type ServerSentEvent<TData = unknown> = {
+  id?: string;
+  event?: string;
+  data?: TData;
+  retry?: string;
+};
+
+/**
+ * Parses a string containing Server-Sent Events (SSE) data into individual event objects.
+ *
+ * @template TData - The type of the parsed `data` field in the event.
+ * @param text - The raw SSE data as a string, where events are separated by double newlines.
+ * @param options - Optional configuration for parsing the events.
+ * @param options.dataParser - A custom parser function for the `data` field. Defaults to JSON parsing,
+ *                             falling back to returning the raw string if parsing fails.
+ *
+ * @returns A generator that yields `ServerSentEvent` objects parsed from the input string.
+ *
+ * @remarks
+ * - Empty lines and events with no fields are ignored.
+ * - If the `data` field cannot be parsed as JSON, it is returned as a plain string.
+ * - Fields other than `data` are stored as strings in the resulting `ServerSentEvent` object.
+ *
+ * @example
+ * ```typescript
+ * const sseData = `
+ * id: 1
+ * event: message
+ * data: {"key":"value"}
+ *
+ * id: 2
+ * event: update
+ * data: plain text
+ * `;
+ *
+ * for (const event of parseEvents(sseData)) {
+ *   console.log(event);
+ * }
+ * // Output:
+ * // { id: "1", event: "message", data: { key: "value" } }
+ * // { id: "2", event: "update", data: "plain text" }
+ * ```
+ */
+function* parseEvents<TData = unknown>(
+  text: string,
+  options?: { dataParser?: DataParser<TData> },
+): Generator<ServerSentEvent<TData>> {
+  // Split the input string into individual event strings using double newline as separator
+  const eventStrings = text.split('\n\n');
+
+  const dataParser = options?.dataParser || (defaultDataParser as DataParser<TData>);
+
+  // Iterate through each event string
+  for (const eventStr of eventStrings) {
+    // Skip empty event strings (after trimming whitespace)
+    if (!eventStr.trim()) continue;
+
+    // Split the event string into lines (fields) using single newline
+    const lines = eventStr.split('\n');
+
+    // Use reduce to process each line in the event string
+    const event = lines.reduce(
+      (event, line) => {
+        // Skip empty lines
+        if (!line) return event;
+
+        // Find the index of the first colon, which separates field name and value
+        const colonIndex = line.indexOf(':');
+
+        // Skip lines without a colon (invalid format)
+        if (colonIndex === -1) return event;
+
+        // Extract the field name (before colon) and trim whitespace
+        const field = line.slice(0, colonIndex).trim();
+        // Extract the field value (after colon) and trim whitespace
+        const value = line.slice(colonIndex + 1).trim();
+
+        // Handle the 'data' field specially, attempting JSON parsing
+        if (field === 'data') {
+          event.data = dataParser(value);
+        } else {
+          // For non-data fields, assign the value as a string to the event object
+          (event as Record<string, unknown>)[field] = value;
+        }
+
+        return event;
+      },
+      {} as ServerSentEvent<TData>,
+    );
+
+    // Only emit the event to the results if it has at least one field
+    if (Object.keys(event).length) {
+      yield event;
+    }
+  }
+}
+
+async function* readStream<TData>(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  options?: {
+    dataParser?: DataParser<TData>;
+    skipHeartbeats?: boolean;
+    eventFilter?: string | string[];
+  },
+): AsyncGenerator<ServerSentEvent<TData>> {
+  const skipHeartbeats = !!options?.skipHeartbeats;
+
+  const eventFilter = options?.eventFilter
+    ? Array.isArray(options.eventFilter)
+      ? options.eventFilter
+      : [options.eventFilter]
+    : null;
+
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    const text = decoder.decode(value, { stream: true });
+    const events = parseEvents<TData>(text, { dataParser: options?.dataParser });
+    for (const event of events) {
+      if (event.retry) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, Number.parseInt(event.retry ?? '300', 10)),
+        );
+        continue;
+      }
+      if (skipHeartbeats) {
+        // Skip comment-based heartbeats (no event, data, or id)
+        if (!event.event && !event.data && !event.id) {
+          continue;
+        }
+        // Skip named heartbeat events (e.g., event: heartbeat or event: ping)
+        if (event.event && ['heartbeat', 'ping'].includes(event.event)) {
+          continue;
+        }
+      }
+      if (!eventFilter || (event.event && eventFilter.includes(event.event))) {
+        yield event as ServerSentEvent<TData>;
+      }
+    }
+  }
+}
+
+/**
+ * Options for configuring the SSE (Server-Sent Events) selector.
+ */
+export type SseSelectorOptions<TData = unknown> = {
+  dataParser?: DataParser<TData>;
+  /**
+   * A string or an array of strings specifying the events to filter.
+   * Only events matching the filter will be processed. If not provided,
+   * all events will be processed.
+   */
+  eventFilter?: string | string[];
+
+  /**
+   * A boolean indicating whether to skip processing heartbeat events.
+   * Defaults to `false` if not specified.
+   */
+  skipHeartbeats?: boolean;
+
+  /**
+   * An `AbortSignal` that can be used to abort the SSE operation.
+   * Useful for managing the lifecycle of the SSE connection.
+   */
+  abortSignal?: AbortSignal | null;
+};
+
+/**
+ * A type alias for selecting and transforming Server-Sent Events (SSE) from an HTTP response.
+ *
+ * @template TData - The type of the data contained within the Server-Sent Event. Defaults to `unknown`.
+ * @template TResponse - The type of the HTTP response object. Defaults to `Response`.
+ *
+ * This selector is used to process and extract `ServerSentEvent<TData>` objects
+ * from an HTTP `Response` object, enabling custom handling of SSE data streams.
+ */
+export type SseSelector<TData = unknown, TResponse extends Response = Response> = ResponseSelector<
+  ServerSentEvent<TData>,
+  TResponse
+>;
+
+/**
+ * Transforms an SSE response into an Observable stream of parsed events.
+ * @param response - The HTTP response with Content-Type: text/event-stream.
+ * @param options - Optional configuration for event filtering and heartbeat handling.
+ * @param options.eventFilter - Filter events by type (single string or array).
+ * @param options.skipHeartbeats - Skip empty/heartbeat events if true.
+ * @param options.maxRetries - Maximum number of reconnection attempts (default: 3).
+ * @returns An Observable emitting parsed ServerSentEvent objects.
+ * @throws ServerSentEventResponseError if response is invalid or stream fails.
+ */
+export const createSseSelector = <TData = unknown, TResponse extends Response = Response>(
+  options?: SseSelectorOptions<TData>,
+): SseSelector<TData, TResponse> => {
+  return (response: TResponse): Observable<ServerSentEvent<TData>> => {
+    if (!response.ok) {
+      throw new ServerSentEventResponseError(`HTTP error! Status: ${response.status}`, response);
+    }
+
+    if (!response.body) {
+      throw new ServerSentEventResponseError('Response body is not readable', response);
+    }
+
+    if (!response.headers.get('Content-Type')?.includes('text/event-stream')) {
+      throw new ServerSentEventResponseError('Response is not a text/event-stream', response);
+    }
+
+    const reader = response.body.getReader();
+
+    return from(
+      readStream<TData>(reader, {
+        dataParser: options?.dataParser,
+        skipHeartbeats: options?.skipHeartbeats,
+        eventFilter: options?.eventFilter,
+      }),
+    ).pipe(
+      // Stop reading if the abort signal is triggered
+      takeUntil(options?.abortSignal ? fromEvent(options.abortSignal, 'abort') : EMPTY),
+      finalize(async () => {
+        // cancel just in case of a pre-mature exit
+        await reader.cancel().catch(() => {
+          /** ignore cancellation errors */
+        });
+        reader.releaseLock();
+      }),
+    );
+  };
+};
+
+export default createSseSelector;

--- a/packages/modules/http/tests/sse.selector.test.ts
+++ b/packages/modules/http/tests/sse.selector.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { ServerSentEventResponseError } from '../src/errors.js';
+import { createSseSelector } from '../src/lib/selectors/sse-selector.js'; // Adjust the import path as needed
+import { of, lastValueFrom } from 'rxjs';
+import { concatMap, scan } from 'rxjs/operators';
+import { set } from 'zod';
+
+// Helper to create a mock Response
+function createMockResponse(
+  bodyChunks: (Uint8Array | null)[],
+  headers: Record<string, string> = { 'Content-Type': 'text/event-stream' },
+  status = 200,
+): Response {
+  const body = new ReadableStream({
+    start(controller) {
+      for (const chunk of bodyChunks) {
+        if (chunk === null) {
+          controller.close();
+          break;
+        }
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status, headers });
+}
+
+describe('createSseSelector', () => {
+  it('emits parsed events from a valid SSE response', async () => {
+    const chunks = [new Uint8Array(new TextEncoder().encode('data: {"key": "value"}\n\n'))];
+    const response = createMockResponse(chunks);
+    const selector = createSseSelector();
+    const events = await lastValueFrom(
+      of(response).pipe(
+        concatMap(selector),
+        scan((acc, event) => [...acc, event], [] as any[]),
+      ),
+    );
+    expect(events).toEqual([{ data: { key: 'value' } }]);
+  });
+
+  it('throws on non-200 response', () => {
+    const response = createMockResponse([], {}, 500);
+    const selector = createSseSelector();
+
+    expect(() => selector(response)).toThrowError(
+      new ServerSentEventResponseError('HTTP error! Status: 500', response),
+    );
+  });
+
+  it('throws on missing body', () => {
+    const response = new Response(null, {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    const selector = createSseSelector();
+
+    expect(() => selector(response)).toThrowError(
+      new ServerSentEventResponseError('Response body is not readable', response),
+    );
+  });
+
+  it('throws on invalid Content-Type', () => {
+    const response = createMockResponse([], { 'Content-Type': 'application/json' });
+    const selector = createSseSelector();
+
+    expect(() => selector(response)).toThrowError(
+      new ServerSentEventResponseError('Response is not a text/event-stream', response),
+    );
+  });
+
+  it('filters events by event type', async () => {
+    const chunks = [
+      new Uint8Array(new TextEncoder().encode('event: message\ndata: {"key": "value"}\n\n')),
+      new Uint8Array(new TextEncoder().encode('event: other\ndata: {"other": "data"}\n\n')),
+    ];
+    const response = createMockResponse(chunks);
+    const selector = createSseSelector({ eventFilter: 'message' });
+    const events = await lastValueFrom(
+      of(response).pipe(
+        concatMap(selector),
+        scan((acc, event) => [...acc, event], [] as any[]),
+      ),
+    );
+
+    expect(events).toEqual([{ event: 'message', data: { key: 'value' } }]);
+  });
+
+  it('skips heartbeat events when skipHeartbeats is true', async () => {
+    const chunks = [
+      new Uint8Array(new TextEncoder().encode(':heartbeat\n\n')), // Heartbeat
+      new Uint8Array(new TextEncoder().encode('event: heartbeat\n\n')), // Heartbeat
+      new Uint8Array(new TextEncoder().encode('event: ping\n\n')), // Heartbeat
+      new Uint8Array(new TextEncoder().encode('data: {"key": "value"}\n\n')),
+    ];
+    const response = createMockResponse(chunks);
+    const selector = createSseSelector({ skipHeartbeats: true });
+    const events = await lastValueFrom(
+      of(response).pipe(
+        concatMap(selector),
+        scan((acc, event) => [...acc, event], [] as any[]),
+      ),
+    );
+
+    expect(events).toEqual([{ data: { key: 'value' } }]);
+  });
+
+  it('retries on retry event with specified delay', async () => {
+    const chunks = [
+      new Uint8Array(new TextEncoder().encode('data: {"foo": "value1"}\n\n')),
+      new Uint8Array(new TextEncoder().encode('retry: 100\n\n')),
+      new Uint8Array(new TextEncoder().encode('data: {"bar": "value2"}\n\n')),
+    ];
+    const response = createMockResponse(chunks);
+    const selector = createSseSelector();
+
+    const events = await lastValueFrom(
+      of(response).pipe(
+        concatMap(selector),
+        scan((acc, event) => [...acc, event], [] as any[]),
+      ),
+    );
+
+    expect(events).toEqual([{ data: { foo: 'value1' } }, { data: { bar: 'value2' } }]);
+  });
+
+  it('stops on abort signal', async () => {
+    const abortController = new AbortController();
+    const chunks = [
+      new Uint8Array(new TextEncoder().encode('data: {"key": "value"}\n\n')),
+      new Uint8Array(new TextEncoder().encode('retry: 100\n\n')),
+      new Uint8Array(new TextEncoder().encode('data: {"next": "event"}\n\n')),
+    ];
+    const response = createMockResponse(chunks);
+    const selector = createSseSelector({ abortSignal: abortController.signal });
+    const eventsPromise = lastValueFrom(
+      of(response).pipe(
+        concatMap(selector),
+        scan((acc, event) => [...acc, event], [] as any[]),
+      ),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    abortController.abort();
+
+    const events = await eventsPromise;
+
+    expect(events).toEqual([{ data: { key: 'value' } }]);
+  });
+});


### PR DESCRIPTION
Introduce a new `sse$` method for subscribing to SSE streams, along with an `sseMap` operator for RxJS pipelines. Enhance error handling with a dedicated error class for SSE responses. Update documentation with examples for the new features.