### PR TITLE
feat(framework): enhance DotPath utility and config builder flexibility

### DIFF
--- a/.changeset/enhance-dotpath-utility.md
+++ b/.changeset/enhance-dotpath-utility.md
@@ -1,0 +1,13 @@
+---
+"fusion-framework": minor
+---
+
+### Enhance DotPath Utility and Config Builder Flexibility
+
+- Improved the `DotPath` utility to support deeper type resolution, including arrays and nominal class types.
+- Updated `BaseConfigBuilder` to use the new `DotPathUnion` and `DotPathType` types for better type safety and flexibility.
+- Enhanced `_set` in `BaseConfigBuilder` to accept both direct values and callbacks, improving usability.
+- Introduced and exported `ModuleConfiguratorConfigCallback` type for better type safety in module configuration.
+- Re-exported `ModuleConfiguratorConfigCallback` in the public API for accessibility.
+
+These changes improve type safety, developer experience, and flexibility when working with nested configurations and module builders.

--- a/packages/modules/module/src/configurator.ts
+++ b/packages/modules/module/src/configurator.ts
@@ -101,6 +101,21 @@ class RequiredModuleTimeoutError extends Error {
 }
 
 /**
+ * A callback type used to configure a module's configuration.
+ *
+ * @template TModule - The type of the module being configured. Must extend `AnyModule`.
+ * @template TRef - An optional reference type that can be used during configuration. Defaults to `unknown`.
+ *
+ * @param config - The configuration object for the specified module type.
+ * @param ref - An optional reference object that can be used to assist in the configuration process.
+ * @returns A `void` or a `Promise<void>` indicating that the configuration process may be asynchronous.
+ */
+export type ModuleConfiguratorConfigCallback<TModule extends AnyModule, TRef = unknown> = (
+  config: ModuleConfigType<TModule>,
+  ref?: TRef,
+) => void | Promise<void>;
+
+/**
  * Callback function type for configuring modules.
  * @template TRef The reference type.
  * @param config The modules configuration.

--- a/packages/modules/module/src/index.ts
+++ b/packages/modules/module/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './BaseConfigBuilder';
 
 export {
+  type ModuleConfiguratorConfigCallback,
   type IModuleConfigurator,
   type IModulesConfigurator,
   ModulesConfigurator,

--- a/packages/modules/module/src/utils/dot-path.ts
+++ b/packages/modules/module/src/utils/dot-path.ts
@@ -20,7 +20,12 @@ export type DotPath<TObject, Depth extends number = 5> = Depth extends 0
         }[keyof Required<TObject> & string]
     : never;
 
-type Decrement = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+// The Decrement type array is used to control recursion depth in the DotPath utility.
+// Each index represents the current depth, and the value at that index is the next depth.
+// For example, at depth 5, the next depth is 4. This allows the utility to "count down"
+// recursion levels until it reaches 0, at which point recursion stops.
+// Extend this array if deeper recursion levels are needed in the future.
+type Decrement = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
 
 // DotPathUnion for unions
 // biome-ignore lint/suspicious/noExplicitAny: necessary

--- a/packages/modules/module/src/utils/dot-path.ts
+++ b/packages/modules/module/src/utils/dot-path.ts
@@ -1,13 +1,41 @@
-export type DotPath<TObject extends object> = {
-  [Key in keyof TObject & string]: TObject[Key] extends object
-    ? `${Key}` | `${Key}.${DotPath<TObject[Key]>}`
-    : `${Key}`;
-}[keyof TObject & string];
+// Nominal type tag for classes
+// biome-ignore lint/suspicious/noExplicitAny: necessary
+type OpaqueClass = new (...args: any[]) => any;
 
-export type DotPathType<TType, TPath extends string> = TPath extends keyof TType
-  ? TType[TPath]
-  : TPath extends `${infer K}.${infer R}`
-    ? K extends keyof TType
-      ? DotPathType<TType[K], R>
-      : never
+// Modify DotPath to stop at OpaqueClass
+export type DotPath<TObject, Depth extends number = 5> = Depth extends 0
+  ? never
+  : TObject extends object
+    ? // biome-ignore lint/suspicious/noExplicitAny: necessary
+      TObject extends any[]
+      ? `${number}` | `${number}.${DotPath<TObject[number], Decrement[Depth]>}`
+      : {
+          [Key in keyof Required<TObject> & string]: TObject[Key] extends object
+            ?
+                | `${Key}`
+                | (TObject[Key] extends null | undefined
+                    ? never
+                    : `${Key}.${DotPath<NonNullable<TObject[Key]>, Decrement[Depth]>}`)
+            : `${Key}`;
+        }[keyof Required<TObject> & string]
     : never;
+
+type Decrement = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+// DotPathUnion for unions
+// biome-ignore lint/suspicious/noExplicitAny: necessary
+export type DotPathUnion<T> = T extends any ? DotPath<T> : never;
+
+// Type resolution for paths
+// biome-ignore lint/suspicious/noExplicitAny: necessary
+export type DotPathType<TType extends object, TPath extends DotPathUnion<TType>> = TType extends any
+  ? TPath extends keyof TType
+    ? TType[TPath]
+    : TPath extends `${infer K}.${infer R}`
+      ? K extends keyof TType
+        ? R extends DotPathUnion<NonNullable<TType[K]>>
+          ? DotPathType<NonNullable<TType[K]>, R>
+          : never
+        : never
+      : never
+  : never;


### PR DESCRIPTION
- Improved the  utility to support deeper type resolution, including arrays and nominal class types.
- Updated  to use the new  and  types for better type safety and flexibility.
- Enhanced  in  to accept both direct values and callbacks, improving usability.
- Introduced and exported  type for better type safety in module configuration.
- Re-exported  in the public API for accessibility.

These changes improve type safety, developer experience, and flexibility when working with nested configurations and module builders.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

