### PR TITLE
Update typesVersions in package.json for better type resolution

### DIFF
--- a/.changeset/clear-keys-begin.md
+++ b/.changeset/clear-keys-begin.md
@@ -1,0 +1,10 @@
+---
+"@equinor/fusion-framework-module-navigation": patch
+"@equinor/fusion-observable": patch
+"@equinor/fusion-framework-module-ag-grid": patch
+"@equinor/fusion-framework-module-context": patch
+"@equinor/fusion-framework-module": patch
+"@equinor/fusion-framework-module-event": patch
+---
+
+fixed `typeVersions`

--- a/packages/modules/ag-grid/package.json
+++ b/packages/modules/ag-grid/package.json
@@ -18,6 +18,7 @@
   },
   "typesVersions": {
     "*": {
+      ".": ["dist/types/index.d.ts"],
       "themes": ["dist/types/themes.d.ts"]
     }
   },

--- a/packages/modules/context/package.json
+++ b/packages/modules/context/package.json
@@ -19,6 +19,13 @@
     "./package.json": "./package.json"
   },
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": ["dist/types/index.d.ts"],
+      "errors.js": ["dist/types/errors.d.ts"],
+      "utils": ["dist/types/utils/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"

--- a/packages/modules/event/package.json
+++ b/packages/modules/event/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/types/index.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      ".": ["dist/types/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "tsc -b",
     "prepack": "pnpm build"
@@ -34,10 +39,5 @@
     "@types/lodash.clonedeep": "^4.5.9",
     "rxjs": "^7.8.1",
     "typescript": "^5.8.2"
-  },
-  "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"]
-    }
   }
 }

--- a/packages/modules/module/package.json
+++ b/packages/modules/module/package.json
@@ -15,9 +15,9 @@
     }
   },
   "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"],
-      "provider": ["dist/types/lib/provider/index"]
+    "*": {
+      ".": ["dist/types/index.d.ts"],
+      "provider": ["dist/types/lib/provider/index.d.ts"]
     }
   },
   "scripts": {

--- a/packages/modules/navigation/package.json
+++ b/packages/modules/navigation/package.json
@@ -12,8 +12,8 @@
     }
   },
   "typesVersions": {
-    ">=4.2": {
-      "*": ["dist/types/*"]
+    "*": {
+      ".": ["dist/types/*"]
     }
   },
   "scripts": {

--- a/packages/utils/observable/package.json
+++ b/packages/utils/observable/package.json
@@ -21,6 +21,13 @@
       "types": "./dist/types/react/index.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      ".": ["dist/types/index.d.ts"],
+      "operators": ["dist/types/operators/index.d.ts"],
+      "react": ["dist/types/react/index.d.ts"]
+    }
+  },
   "directories": {
     "dist": "dist"
   },
@@ -32,12 +39,6 @@
     "type": "git",
     "url": "git+https://github.com/equinor/fusion-framework.git",
     "directory": "packages/utils/observable"
-  },
-  "typesVersions": {
-    "*": {
-      "operators": ["dist/types/operators/index.d.ts"],
-      "react": ["dist/types/react/index.d.ts"]
-    }
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
Enhance type resolution across multiple packages by updating the `typesVersions` field in the package.json files. This change improves the clarity and accessibility of type definitions.