### PR TITLE
chore: add new export for actions in fusion-observable

### DIFF
--- a/.changeset/wet-comics-tease.md
+++ b/.changeset/wet-comics-tease.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Added new export for actions

--- a/packages/utils/observable/package.json
+++ b/packages/utils/observable/package.json
@@ -16,6 +16,10 @@
       "import": "./dist/esm/operators/index.js",
       "types": "./dist/types/operators/index.d.ts"
     },
+    "./actions": {
+      "import": "./dist/esm/actions.js",
+      "types": "./dist/types/actions.d.ts"
+    },
     "./react": {
       "import": "./dist/esm/react/index.js",
       "types": "./dist/types/react/index.d.ts"

--- a/packages/utils/observable/src/actions.ts
+++ b/packages/utils/observable/src/actions.ts
@@ -1,0 +1,23 @@
+export * from './ActionError';
+export * from './types/actions.js';
+
+export { actionMapper, type ActionCalls } from './action-mapper.js';
+
+export {
+  createAction,
+  getBaseType,
+  type ActionCreatorWithNonInferrablePayload,
+  type ActionCreatorWithoutPayload,
+  type ActionCreatorWithPayload,
+  type ActionCreatorWithOptionalPayload,
+  type ActionCreatorWithPreparedPayload,
+  type PayloadActionCreator,
+} from './create-action';
+
+export {
+  createAsyncAction,
+  isRequestAction,
+  isCompleteAction,
+  isFailureAction,
+  isSuccessAction,
+} from './create-async-action';


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:

 ReeAdd new export for actions in fusion-observable

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

