### PR TITLE
fix: update useBookmarkNavigate to trigger onCurrentBookmarkChanged 

### DIFF
--- a/.changeset/bright-buses-call.md
+++ b/.changeset/bright-buses-call.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-module-bookmark": patch
+---
+
+update useBookmarkNavigate to trigger on onCurrentBookmarkChanged event

--- a/packages/react/modules/bookmark/src/portal/useBookmarkNavigate.ts
+++ b/packages/react/modules/bookmark/src/portal/useBookmarkNavigate.ts
@@ -23,8 +23,13 @@ export const useBookmarkNavigate = (args: { resolveAppPath: AppPathResolver }): 
   } = useFramework<[BookmarkModule, NavigationModule]>().modules;
 
   useLayoutEffect(() => {
-    const sub = event.addEventListener('onBookmarkChanged', (e) => {
-      const { appKey, context: bookmarkContext } = e.detail;
+    const sub = event.addEventListener('onCurrentBookmarkChanged', (e) => {
+      const appKey = e.detail?.appKey;
+      const bookmarkContext = e.detail?.context;
+
+      if (!appKey || !bookmarkContext) {
+        return;
+      }
 
       const pathname = args.resolveAppPath(appKey);
 


### PR DESCRIPTION
 update useBookmarkNavigate to trigger onCurrentBookmarkChanged 

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

