### PR TITLE
fix(module-bookmark): allow reselection of the current bookmark by removing the existing check

### DIFF
--- a/.changeset/stale-papayas-behave.md
+++ b/.changeset/stale-papayas-behave.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-bookmark": patch
+---
+
+Allow reselection of the current bookmark by removing the check that prevented setting the same bookmark as current. This enables applications to reselect a bookmark even if it is already active, supporting scenarios where application state changes require a re-selection event.

--- a/packages/modules/bookmark/src/BookmarkProvider.ts
+++ b/packages/modules/bookmark/src/BookmarkProvider.ts
@@ -593,10 +593,7 @@ export class BookmarkProvider implements IBookmarkProvider {
   public setCurrentBookmark<T extends BookmarkData>(
     bookmark_or_id: Bookmark<T> | string | null,
   ): Observable<Bookmark<T> | null> {
-    // check if the bookmark is already the current bookmark
-    if (bookmark_or_id == this.currentBookmark) return of(bookmark_or_id);
-
-    this._log?.debug(`setting current bookmark`, bookmark_or_id);
+    this._log?.debug('setting current bookmark', bookmark_or_id);
 
     // resolve the next bookmark
     const next$: Observable<Bookmark<T> | null> =


### PR DESCRIPTION


When a user selects a bookmark, it becomes the current bookmark. However, if the user switches applications and later returns to activate the same bookmark, nothing happens—it is not triggered again. The only way to trigger it is by first selecting a different bookmark and then reselecting the original one. This behavior is unintuitive and problematic.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes: [AB#63484](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/63484)


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

