### PR TITLE
fix(bookmark): remove unnecessary deepEqual check from currentBookmark$ selector

### DIFF
--- a/.changeset/chilly-clubs-talk.md
+++ b/.changeset/chilly-clubs-talk.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-bookmark": patch
+---
+
+Remove unnecessary deepEqual check from the currentBookmark$ selector to ensure the current bookmark is always emitted, even when re-selected. This improves consistency and ensures consumers receive updates as expected.

--- a/packages/modules/bookmark/src/BookmarkProvider.ts
+++ b/packages/modules/bookmark/src/BookmarkProvider.ts
@@ -168,7 +168,7 @@ export class BookmarkProvider implements IBookmarkProvider {
    * Gets the currently active bookmark (if any).
    */
   public get currentBookmark$(): Observable<Bookmark | null | undefined> {
-    return this.#store.select(activeBookmarkSelector, deepEqual);
+    return this.#store.select(activeBookmarkSelector);
   }
 
   /**


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->


Remove unnecessary deepEqual check from the currentBookmark$ selector to ensure the current bookmark is always emitted, even when re-selected. This improves consistency and ensures consumers receive updates as expected.

closes:[AB#63505](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/63505)


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

