### PR TITLE
fix(apps-module): update http client name to 'apps' for service discovery alignment

### DIFF
--- a/.changeset/proud-months-worry.md
+++ b/.changeset/proud-months-worry.md
@@ -1,0 +1,6 @@
+---
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+Update `AppConfigurator` to verify that `http.hasClient` uses `'apps'` (not `'app'`) as http client name. This change aligns the configuration with the service name provided by service discovery.

--- a/packages/modules/app/src/AppConfigurator.ts
+++ b/packages/modules/app/src/AppConfigurator.ts
@@ -38,17 +38,18 @@ export class AppConfigurator
     init: ModuleInitializerArgs<IAppConfigurator, [HttpModule, ServiceDiscoveryModule]>,
   ): Promise<IHttpClient> {
     const http = await init.requireInstance('http');
+    const serviceName = 'apps';
     /** check if the http provider has configure a client */
-    if (http.hasClient(moduleKey)) {
-      return http.createClient(moduleKey);
-    } else {
-      /** load service discovery module */
-      const serviceDiscovery = await init.requireInstance('serviceDiscovery');
-
-      // TODO - remove when refactor portal service!
-      /** resolve and create a client from discovery */
-      return await serviceDiscovery.createClient('apps');
+    if (http.hasClient(serviceName)) {
+      return http.createClient(serviceName);
     }
+
+    /** load service discovery module */
+    const serviceDiscovery = await init.requireInstance('serviceDiscovery');
+
+    // TODO - remove when refactor portal service!
+    /** resolve and create a client from discovery */
+    return await serviceDiscovery.createClient(serviceName);
   }
 
   public setClient(


### PR DESCRIPTION
Update `AppConfigurator` to verify that `http.hasClient` uses `'apps'` (not `'app'`) as http client name. This change aligns the configuration with the service name provided by service discovery.


## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

