### PR TITLE
fix(FFC): correct HTTP client name from 'app' to 'apps' for service discovery alignment

### DIFF
--- a/.changeset/good-pillows-ring.md
+++ b/.changeset/good-pillows-ring.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fixes a bug where the app module was not using the correct configured HTTP client. Updates the configuration to ensure the app module uses the HTTP client that matches its expected name.
+

--- a/packages/cli/src/bin/dev-portal/config.ts
+++ b/packages/cli/src/bin/dev-portal/config.ts
@@ -17,8 +17,8 @@ export const configure = async (config: FrameworkConfigurator) => {
     },
   });
 
-  // Add custom client for app
-  config.configureHttpClient('app', {
+  // Add custom client for apps
+  config.configureHttpClient('apps', {
     baseUri: new URL('/apps-proxy/', window.location.href).href,
     defaultScopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
   });


### PR DESCRIPTION

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:
correct HTTP client name from 'app' to 'apps' for service discovery alignment

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

