### PR TITLE
fix(bookmark): update selector logic to filter bookmarks by current app's appKey

### DIFF
--- a/.changeset/tiny-clowns-cheer.md
+++ b/.changeset/tiny-clowns-cheer.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-module-bookmark": patch
+---
+
+Update selector logic to only return a bookmark if its appKey matches the current app's appKey. This ensures bookmarks are correctly filtered and only relevant bookmarks are returned for the active application.

--- a/packages/modules/bookmark/src/index.ts
+++ b/packages/modules/bookmark/src/index.ts
@@ -26,3 +26,5 @@ export type {
 export { enableBookmark } from './enable-bookmark';
 
 export * from './types';
+
+export { bookmarkWithDataSchema } from './bookmark.schemas';

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -4,7 +4,7 @@ import {
   type useCurrentBookmarkReturn,
   useCurrentBookmark as _useCurrentBookmark,
   type BookmarkModule,
-  type Bookmark,
+  bookmarkWithDataSchema,
 } from '@equinor/fusion-framework-react-module-bookmark';
 
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
@@ -40,7 +40,7 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
 
-  const currentBookmarkAppKey = (currentBookmark as { appKey: string })?.appKey;
+  const currentBookmarkAppKey = bookmarkWithDataSchema<TData>().parse(currentBookmark).appKey;
 
   return {
     currentBookmark: currentBookmarkAppKey === currentApp?.appKey ? currentBookmark : null,

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -40,7 +40,7 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
 
-  const currentBookmarkAppKey = bookmarkWithDataSchema<TData>().parse(currentBookmark).appKey;
+  const currentBookmarkAppKey = bookmarkWithDataSchema().parse(currentBookmark).appKey;
 
   return {
     currentBookmark: currentBookmarkAppKey === currentApp?.appKey ? currentBookmark : null,

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -38,8 +38,11 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     provider: appBookmarkProvider ?? frameworkBookmarkProvider,
     payloadGenerator,
   });
+
+  const currentBookmarkAppKey = currentBookmark?.appKey;
+
   return {
-    currentBookmark: currentBookmark?.appKey === currentApp?.appKey ? currentBookmark : null,
+    currentBookmark: currentBookmarkAppKey === currentApp?.appKey ? currentBookmark : null,
     setCurrentBookmark,
   };
 };

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -1,6 +1,7 @@
 import {
   type BookmarkData,
   type BookmarkPayloadGenerator,
+  type Bookmark,
   useCurrentBookmark as _useCurrentBookmark,
 } from '@equinor/fusion-framework-react-module-bookmark';
 import type { BookmarkModule } from '../../../../modules/bookmark/src';
@@ -37,7 +38,8 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
   return {
-    currentBookmark: currentBookmark?.appKey === currentApp?.appKey ? currentBookmark : null,
+    currentBookmark:
+      (currentBookmark as Bookmark)?.appKey === currentApp?.appKey ? currentBookmark : null,
     setCurrentBookmark,
   };
 };

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -6,6 +6,7 @@ import {
 import type { BookmarkModule } from '../../../../modules/bookmark/src';
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
 import useAppModules from '../useAppModules';
+import { useCurrentApp } from '@equinor/fusion-framework-react/app';
 
 /**
  * By providing a CreateBookMarkFn bookmarks is enabled for the current application.
@@ -22,6 +23,7 @@ import useAppModules from '../useAppModules';
 export const useCurrentBookmark = <TData extends BookmarkData>(
   payloadGenerator?: BookmarkPayloadGenerator<TData>,
 ): ReturnType<typeof _useCurrentBookmark<TData>> => {
+  const { currentApp } = useCurrentApp();
   const appBookmarkProvider = useAppModules<[BookmarkModule]>().bookmark;
   const frameworkBookmarkProvider = useFrameworkModule<BookmarkModule>('bookmark');
   if (!appBookmarkProvider) {
@@ -30,10 +32,14 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
       'application has not enabled bookmarks, this will not work in the future',
     );
   }
-  return _useCurrentBookmark<TData>({
+  const { currentBookmark, setCurrentBookmark } = _useCurrentBookmark<TData>({
     provider: appBookmarkProvider ?? frameworkBookmarkProvider,
     payloadGenerator,
   });
+  return {
+    currentBookmark: currentBookmark?.appKey === currentApp?.appKey ? currentBookmark : null,
+    setCurrentBookmark,
+  };
 };
 
 export default useCurrentBookmark;

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -4,7 +4,6 @@ import {
   type useCurrentBookmarkReturn,
   useCurrentBookmark as _useCurrentBookmark,
   type BookmarkModule,
-  type Bookmark,
   bookmarkWithDataSchema,
 } from '@equinor/fusion-framework-react-module-bookmark';
 

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -4,6 +4,7 @@ import {
   type useCurrentBookmarkReturn,
   useCurrentBookmark as _useCurrentBookmark,
   type BookmarkModule,
+  type Bookmark,
   bookmarkWithDataSchema,
 } from '@equinor/fusion-framework-react-module-bookmark';
 
@@ -40,7 +41,9 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
 
-  const currentBookmarkAppKey = bookmarkWithDataSchema().parse(currentBookmark).appKey;
+  const currentBookmarkAppKey = bookmarkWithDataSchema().safeParse(currentBookmark).success
+    ? bookmarkWithDataSchema().parse(currentBookmark).appKey
+    : null;
 
   return {
     currentBookmark: currentBookmarkAppKey === currentApp?.appKey ? currentBookmark : null,

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -1,10 +1,11 @@
 import {
   type BookmarkData,
   type BookmarkPayloadGenerator,
-  type Bookmark,
+  type useCurrentBookmarkReturn,
   useCurrentBookmark as _useCurrentBookmark,
+  type BookmarkModule,
 } from '@equinor/fusion-framework-react-module-bookmark';
-import type { BookmarkModule } from '../../../../modules/bookmark/src';
+
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
 import useAppModules from '../useAppModules';
 import { useCurrentApp } from '@equinor/fusion-framework-react/app';
@@ -23,7 +24,7 @@ import { useCurrentApp } from '@equinor/fusion-framework-react/app';
  */
 export const useCurrentBookmark = <TData extends BookmarkData>(
   payloadGenerator?: BookmarkPayloadGenerator<TData>,
-): ReturnType<typeof _useCurrentBookmark<TData>> => {
+): useCurrentBookmarkReturn<TData> => {
   const { currentApp } = useCurrentApp();
   const appBookmarkProvider = useAppModules<[BookmarkModule]>().bookmark;
   const frameworkBookmarkProvider = useFrameworkModule<BookmarkModule>('bookmark');
@@ -38,8 +39,7 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
   return {
-    currentBookmark:
-      (currentBookmark as Bookmark)?.appKey === currentApp?.appKey ? currentBookmark : null,
+    currentBookmark: currentBookmark?.appKey === currentApp?.appKey ? currentBookmark : null,
     setCurrentBookmark,
   };
 };

--- a/packages/react/app/src/bookmark/useCurrentBookmark.ts
+++ b/packages/react/app/src/bookmark/useCurrentBookmark.ts
@@ -4,6 +4,7 @@ import {
   type useCurrentBookmarkReturn,
   useCurrentBookmark as _useCurrentBookmark,
   type BookmarkModule,
+  type Bookmark,
 } from '@equinor/fusion-framework-react-module-bookmark';
 
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
@@ -39,7 +40,7 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     payloadGenerator,
   });
 
-  const currentBookmarkAppKey = currentBookmark?.appKey;
+  const currentBookmarkAppKey = (currentBookmark as { appKey: string })?.appKey;
 
   return {
     currentBookmark: currentBookmarkAppKey === currentApp?.appKey ? currentBookmark : null,

--- a/packages/react/modules/bookmark/src/index.ts
+++ b/packages/react/modules/bookmark/src/index.ts
@@ -1,4 +1,4 @@
-export { default, useCurrentBookmark } from './useCurrentBookmark';
+export { default, useCurrentBookmark, type useCurrentBookmarkReturn } from './useCurrentBookmark';
 export { useBookmark, type useBookmarkResult } from './useBookmark';
 export { useBookmarkProvider } from './useBookmarkProvider';
 

--- a/packages/react/modules/bookmark/src/index.ts
+++ b/packages/react/modules/bookmark/src/index.ts
@@ -2,7 +2,7 @@ export { default, useCurrentBookmark, type useCurrentBookmarkReturn } from './us
 export { useBookmark, type useBookmarkResult } from './useBookmark';
 export { useBookmarkProvider } from './useBookmarkProvider';
 
-export { enableBookmark } from '@equinor/fusion-framework-module-bookmark';
+export { enableBookmark, bookmarkWithDataSchema } from '@equinor/fusion-framework-module-bookmark';
 
 export type {
   Bookmark,

--- a/packages/react/modules/bookmark/src/useCurrentBookmark.ts
+++ b/packages/react/modules/bookmark/src/useCurrentBookmark.ts
@@ -8,7 +8,6 @@ import type {
 import { useObservableState } from '@equinor/fusion-observable/react';
 import { useBookmarkProvider } from './useBookmarkProvider';
 import { EMPTY, from } from 'rxjs';
-import { useCurrentApp } from '@equinor/fusion-framework-react/app';
 
 export type useCurrentBookmarkOptions<TData extends BookmarkData> = {
   payloadGenerator?: BookmarkPayloadGenerator<TData>;

--- a/packages/react/modules/bookmark/src/useCurrentBookmark.ts
+++ b/packages/react/modules/bookmark/src/useCurrentBookmark.ts
@@ -35,9 +35,7 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
   const { payloadGenerator, provider = baseProvider } =
     typeof args === 'function' ? { payloadGenerator: args } : (args ?? {});
 
-  const { currentApp } = useCurrentApp();
-
-  const { value: bookmark } = useObservableState(
+  const { value: currentBookmark } = useObservableState(
     useMemo(() => provider?.currentBookmark$ ?? EMPTY, [provider]),
     {
       initial: provider?.currentBookmark,
@@ -59,14 +57,6 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
       return provider.addPayloadGenerator(payloadGenerator);
     }
   }, [provider, payloadGenerator]);
-
-  const currentBookmark = useMemo(() => {
-    if (!bookmark) {
-      return null;
-    }
-
-    return bookmark?.appKey === currentApp?.appKey ? bookmark : null;
-  }, [bookmark, currentApp?.appKey]);
 
   return { currentBookmark: currentBookmark as Bookmark<TData> | null, setCurrentBookmark };
 };

--- a/packages/react/modules/bookmark/src/useCurrentBookmark.ts
+++ b/packages/react/modules/bookmark/src/useCurrentBookmark.ts
@@ -8,6 +8,7 @@ import type {
 import { useObservableState } from '@equinor/fusion-observable/react';
 import { useBookmarkProvider } from './useBookmarkProvider';
 import { EMPTY, from } from 'rxjs';
+import { useCurrentApp } from '@equinor/fusion-framework-react/app';
 
 export type useCurrentBookmarkOptions<TData extends BookmarkData> = {
   payloadGenerator?: BookmarkPayloadGenerator<TData>;
@@ -34,6 +35,8 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
   const { payloadGenerator, provider = baseProvider } =
     typeof args === 'function' ? { payloadGenerator: args } : (args ?? {});
 
+  const { currentApp } = useCurrentApp();
+
   const { value: bookmark } = useObservableState(
     useMemo(() => provider?.currentBookmark$ ?? EMPTY, [provider]),
     {
@@ -57,7 +60,15 @@ export const useCurrentBookmark = <TData extends BookmarkData>(
     }
   }, [provider, payloadGenerator]);
 
-  return { currentBookmark: bookmark as Bookmark<TData> | null, setCurrentBookmark };
+  const currentBookmark = useMemo(() => {
+    if (!bookmark) {
+      return null;
+    }
+
+    return bookmark?.appKey === currentApp?.appKey ? bookmark : null;
+  }, [bookmark, currentApp?.appKey]);
+
+  return { currentBookmark: currentBookmark as Bookmark<TData> | null, setCurrentBookmark };
 };
 
 export default useCurrentBookmark;


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:

Update selector logic to only return a bookmark if its appKey matches the current app's appKey. This ensures bookmarks are correctly filtered and only relevant bookmarks are returned for the active application.



### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

