### PR TITLE
fix(bookmark): Enable MapSet in the bookmark module since a new Set is used in BookmarkState

### DIFF
--- a/.changeset/public-parts-poke.md
+++ b/.changeset/public-parts-poke.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-bookmark": patch
+---
+
+Enable MapSet in the bookmark module since a new Set is used in BookmarkState.

--- a/packages/modules/bookmark/src/BookmarkProvider.reducer.ts
+++ b/packages/modules/bookmark/src/BookmarkProvider.reducer.ts
@@ -12,6 +12,9 @@ import { bookmarkActions, type BookmarkActions } from './BookmarkProvider.action
 import type { BookmarkState } from './BookmarkProvider.store';
 import type { BookmarkFlowError } from './BookmarkProvider.error';
 import type { BookmarkWithoutData } from './types';
+import { enableMapSet } from 'immer';
+
+enableMapSet();
 
 /**
  * Utility function that extracts the base action type from a given action object.


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


Enable MapSet in the bookmark module since a new Set is used in BookmarkState.

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

