### PR TITLE
fix(useHelpCenter): openReleaseNotes

### DIFF
--- a/.changeset/thick-swans-divide.md
+++ b/.changeset/thick-swans-divide.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Added `openReleaseNotes` flag for `useHelpCenter` hook in `@equinor/fusion-framework-react-app`

--- a/packages/react/app/src/help-center/useHelpCenter.ts
+++ b/packages/react/app/src/help-center/useHelpCenter.ts
@@ -69,6 +69,11 @@ export interface HelpCenter {
    * Requesting the portal to open the help sidesheet on the governance tab.
    */
   openGovernance(): void;
+
+  /**
+   * Requesting the portal to open the help sidesheet on the release notes page.
+   */
+  openReleaseNotes(): void;
 }
 
 /**
@@ -125,12 +130,21 @@ export const useHelpCenter = (): HelpCenter => {
     });
   }, [eventModule.dispatchEvent]);
 
+  const openReleaseNotes = useCallback((): void => {
+    eventModule.dispatchEvent(EVENT_NAME, {
+      detail: {
+        page: 'release-notes',
+      },
+    });
+  }, [eventModule.dispatchEvent]);
+
   return {
     openHelp,
     openArticle,
     openFaqs,
     openSearch,
     openGovernance,
+    openReleaseNotes,
   };
 };
 


### PR DESCRIPTION
## Why
Added `openReleaseNotes` flag for `useHelpCenter` hook in `@equinor/fusion-framework-react-app`

closes:
[[Fusion-framework]: useHelpCenter for release notes](https://statoil-proview.visualstudio.com/Fusion%20Core/_workitems/edit/64722)

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

