### PR TITLE
fix: ensure compatibility with ESM loader on Windows by converting outfile path to file:// URL

### DIFF
--- a/.changeset/windows-esm-loader-fix.md
+++ b/.changeset/windows-esm-loader-fix.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-imports": patch
+---
+
+Fixed Windows compatibility issue with ESM loader when importing bundled scripts.
+
+- Added `pathToFileURL` conversion before importing bundled scripts to prevent `ERR_UNSUPPORTED_ESM_URL_SCHEME` errors on Windows
+- Windows absolute paths like `C:\path\to\file.js` are now properly converted to `file:///C:/path/to/file.js` URLs before being passed to the ESM loader
+- This ensures cross-platform compatibility for dynamic imports in the CLI and build tools
+
+The fix addresses the root cause of Windows ESM loader errors where Node.js would interpret Windows drive letters as URL protocols.
+
+This fixes https://github.com/equinor/fusion/issues/642
+
+The issue affects not only Windows but any environment where file paths contain characters that ESM might interpret as URL components (e.g., paths with special characters, drive letters, or percent-encoded characters).

--- a/packages/utils/imports/src/import-script.ts
+++ b/packages/utils/imports/src/import-script.ts
@@ -1,6 +1,7 @@
 import { build, type BuildOptions } from 'esbuild';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { processAccessError } from './error.js';
 
 import { readPackageUp } from 'read-package-up';
@@ -105,7 +106,8 @@ export const importScript = async <M extends EsmModule>(
       return import(dataUrl);
     }
 
-    return import(outfile);
+    // Convert the outfile path to a file:// URL to ensure compatibility with ESM loader on Windows
+    return import(pathToFileURL(outfile).href);
   } catch (error) {
     throw new Error(
       `Failed to bundle '${entryPoint}' with esbuild. Check for syntax errors or unresolved imports.`,


### PR DESCRIPTION
## Why

This PR fixes a Windows compatibility issue with the ESM (ECMAScript Modules) loader in the Fusion Framework CLI. The issue occurs when Node.js tries to dynamically import bundled JavaScript files on Windows systems, where absolute paths like `C:\path\to\file.js` are interpreted as malformed URLs, causing `ERR_UNSUPPORTED_ESM_URL_SCHEME` errors.

### Current behavior
- On Windows, Fusion CLI fails to start apps with `ERR_UNSUPPORTED_ESM_URL_SCHEME` error
- Node.js ESM loader interprets Windows drive letters (like `C:`) as URL protocols instead of file paths
- This prevents any app from starting on Windows systems

### New behavior  
- Windows absolute paths are now properly converted to `file://` URLs before being passed to the ESM loader
- Cross-platform compatibility is maintained for dynamic imports
- The fix works on any system where file paths contain characters that ESM might interpret as URL components

### Does this PR introduce a breaking change?
No - this is a bug fix that improves compatibility without changing the public API.

### Other information

**Fixes:** https://github.com/equinor/fusion/issues/642

The issue affects not only Windows but any environment where file paths contain characters that ESM might interpret as URL components (e.g., paths with special characters, drive letters, or percent-encoded characters).

## Technical Details

**Changes made:**
- Modified `packages/utils/imports/src/import-script.ts` to convert file paths to `file://` URLs before dynamic imports
- Added proper `pathToFileURL` conversion in the `importScript` function
- Created changeset documenting the patch-level version bump for `@equinor/fusion-imports`

**Testing:**
- The fix ensures Windows paths like `C:\Users\path\to\file.js` are converted to `file:///C:/Users/path/to/file.js`
- Maintains backward compatibility with existing Unix-style paths
- No breaking changes to the public API

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

