### PR TITLE
refactor: move vite-tsconfig-paths plugin to dev-server and enhance React support

### DIFF
--- a/.changeset/update-vite-plugins_cli.md
+++ b/.changeset/update-vite-plugins_cli.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+moved plugin `vite-tsconfig-paths` to `@equinor/fusion-framework-dev-server`
+

--- a/.changeset/update-vite-plugins_dev-server.md
+++ b/.changeset/update-vite-plugins_dev-server.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-dev-server": patch
+---
+
+Enhanced dev server configuration with improved React and TypeScript path resolution support.
+
+- Added `@vitejs/plugin-react` for better React development experience
+- Added `vite-tsconfig-paths` for improved TypeScript path resolution
+- Updated `create-dev-server-config.ts` to include both plugins in the vite configuration

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,7 +109,6 @@
     "ora": "^8.0.1",
     "read-package-up": "^11.0.0",
     "vite": "^6.3.5",
-    "vite-plugin-tsconfig-paths": "^1.4.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/helpers/load-vite-config.ts
+++ b/packages/cli/src/bin/helpers/load-vite-config.ts
@@ -1,5 +1,4 @@
 import { loadConfigFromFile, mergeConfig, type UserConfig } from 'vite';
-import tsConfigPaths from 'vite-plugin-tsconfig-paths';
 
 import { basename, dirname, extname } from 'node:path';
 
@@ -50,7 +49,6 @@ export const loadViteConfig = async (env: RuntimeEnv, pkg: ResolvedPackage) => {
   return mergeConfig(
     {
       root,
-      plugins: [(tsConfigPaths as any)()],
       define: {
         // Set environment variables for the build
         'process.env.NODE_ENV': JSON.stringify(env.mode),

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -36,7 +36,9 @@
   "dependencies": {
     "@equinor/fusion-framework-vite-plugin-api-service": "workspace:^",
     "@equinor/fusion-framework-vite-plugin-spa": "workspace:^",
-    "@equinor/fusion-log": "workspace:^"
+    "@equinor/fusion-log": "workspace:^",
+    "@vitejs/plugin-react": "^5.0.2",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
     "typescript": "^5.8.2",

--- a/packages/dev-server/src/create-dev-server-config.ts
+++ b/packages/dev-server/src/create-dev-server-config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, mergeConfig, type UserConfig } from 'vite';
+
+import tsConfigPathsPlugin from 'vite-tsconfig-paths';
+import reactPlugin from '@vitejs/plugin-react';
+
 import apiServicePlugin, {
   createProxyHandler,
 } from '@equinor/fusion-framework-vite-plugin-api-service';
@@ -71,6 +75,8 @@ export const createDevServerConfig = <TEnv extends Partial<TemplateEnv>>(
       }),
     },
     plugins: [
+      reactPlugin(),
+      tsConfigPathsPlugin(),
       apiServicePlugin(
         {
           proxyHandler: createProxyHandler(api.serviceDiscoveryUrl, processServices, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,9 +651,6 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)
-      vite-plugin-tsconfig-paths:
-        specifier: ^1.4.1
-        version: 1.4.1(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -847,6 +844,12 @@ importers:
       '@equinor/fusion-log':
         specifier: workspace:^
         version: link:../utils/log
+      '@vitejs/plugin-react':
+        specifier: ^5.0.2
+        version: 5.0.2(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
     devDependencies:
       typescript:
         specifier: ^5.8.2
@@ -6181,6 +6184,9 @@ packages:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -8054,6 +8060,16 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -8128,11 +8144,6 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-
-  typescript-paths@1.5.1:
-    resolution: {integrity: sha512-lYErSLCON2MSplVV5V/LBgD4UNjMgY3guATdFCZY2q1Nr6OZEu4q6zX/rYMsG1TaWqqQSszg6C9EU7AGWMDrIw==}
-    peerDependencies:
-      typescript: ^4.7.2 || ^5
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -8296,10 +8307,13 @@ packages:
     peerDependencies:
       vite: '>= 2.7'
 
-  vite-plugin-tsconfig-paths@1.4.1:
-    resolution: {integrity: sha512-pGpvsPGDpiM5z7I9ZhBe7H2WAH0gAC2Lh55rM3pE+84V2q7qojNO28wdUl4i/M4XUfJcilhyucmbc9D7IKqpXA==}
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
@@ -14146,6 +14160,8 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.3.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -16295,6 +16311,10 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  tsconfck@3.1.6(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
+
   tslib@1.14.1: {}
 
   tslib@2.6.2: {}
@@ -16350,10 +16370,6 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@4.41.0: {}
-
-  typescript-paths@1.5.1(typescript@5.9.2):
-    dependencies:
-      typescript: 5.9.2
 
   typescript@5.9.2: {}
 
@@ -16515,11 +16531,15 @@ snapshots:
     dependencies:
       vite: 6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)
 
-  vite-plugin-tsconfig-paths@1.4.1(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)):
     dependencies:
-      typescript-paths: 1.5.1(typescript@5.9.2)
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.2)
+    optionalDependencies:
       vite: 6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)
     transitivePeerDependencies:
+      - supports-color
       - typescript
 
   vite@5.4.19(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1):


### PR DESCRIPTION
## Why
This PR refactors the Vite plugin configuration to better separate concerns and enhance development experience:

### What kind of change does this PR introduce?
- **Refactoring**: Moved `vite-tsconfig-paths` plugin from CLI to dev-server package
- **Enhancement**: Added React plugin support to dev-server for better React development experience
- **Dependency Management**: Updated plugin dependencies to use more modern and maintained packages

### What is the current behavior?
- The `vite-plugin-tsconfig-paths` (v1.4.1) plugin was used in the CLI package but not optimally positioned
- No dedicated React plugin support in the dev-server
- TypeScript path resolution was handled inconsistently across packages

### What is the new behavior?
- `vite-tsconfig-paths` (v5.1.4) plugin is now in the dev-server package where it's more appropriately used
- Added `@vitejs/plugin-react` for enhanced React development experience
- Better separation of concerns between CLI and dev-server responsibilities
- Improved TypeScript path resolution specifically for development workflows

### Does this PR introduce a breaking change?
No, this is a backward-compatible refactoring that maintains existing functionality while improving the architecture.

closes: #3327

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).