### PR TITLE
refactor(dev-server): move vite-tsconfig-paths responsibility to CLI

### DIFF
--- a/.changeset/cli-vite-config-refactor.md
+++ b/.changeset/cli-vite-config-refactor.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Enhanced Vite configuration with improved TypeScript path resolution and centralized config loading.
+
+- Added `vite-tsconfig-paths` plugin for better TypeScript path resolution in development
+- Refactored app and portal dev servers to use centralized `loadViteConfig` function
+- Improved Vite config merging with `mergeConfigVite` for better configuration management
+- Added debug logging for Vite and dev server configurations
+- Moved output directory validation to build-time only for better performance

--- a/.changeset/dev-server-removed-tsconfig-paths.md
+++ b/.changeset/dev-server-removed-tsconfig-paths.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-dev-server": patch
+---
+
+Enhanced dev server configuration by removing `vite-tsconfig-paths` plugin.
+
+> The responsibility for adding the `vite-tsconfig-paths` plugin has been moved to `@equinor/fusion-framework-cli`, which now provides it via the `overrides` parameter in `createDevServerConfig`. This ensures consistent TypeScript path resolution in both development and build environments.  
+
+- Removed `vite-tsconfig-paths` dependency from package.json
+- Removed plugin usage from `create-dev-server-config.ts`
+
+
+**Breaking change:** 
+
+If you use `@equinor/fusion-framework-dev-server` outside of the CLI, you must manually add the `vite-tsconfig-paths` plugin to your Vite config overrides to maintain the same TypeScript path resolution behavior.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,6 +109,7 @@
     "ora": "^8.0.1",
     "read-package-up": "^11.0.0",
     "vite": "^6.3.5",
+    "vite-tsconfig-paths": "^5.1.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/helpers/load-vite-config.ts
+++ b/packages/cli/src/bin/helpers/load-vite-config.ts
@@ -1,4 +1,5 @@
 import { loadConfigFromFile, mergeConfig, type UserConfig } from 'vite';
+import tsConfigPaths from 'vite-tsconfig-paths';
 
 import { basename, dirname, extname } from 'node:path';
 
@@ -24,31 +25,34 @@ export const loadViteConfig = async (env: RuntimeEnv, pkg: ResolvedPackage) => {
   const outFile = packageJson.main ?? packageJson.module ?? './dist/bundle.js';
   const entrypoint = resolveEntryPoint(root);
 
-  // Prevent output directory from being the project root
-  if (dirname(outFile) === root) {
-    throw new Error(
-      'outDir cannot be root, please specify package.main or package.module in package.json',
-    );
-  }
+  if (env.command === 'build') {
+    // Prevent output directory from being the project root
+    if (dirname(outFile) === root) {
+      throw new Error(
+        'outDir cannot be root, please specify package.main or package.module in package.json',
+      );
+    }
 
-  // Prevent output directory from being the src directory
-  if (dirname(outFile) === 'src') {
-    throw new Error(
-      'outDir cannot be src, please specify package.main or package.module in package.json',
-    );
-  }
+    // Prevent output directory from being the src directory
+    if (dirname(outFile) === 'src') {
+      throw new Error(
+        'outDir cannot be src, please specify package.main or package.module in package.json',
+      );
+    }
 
-  // Prevent output directory from being the current working directory
-  if (dirname(outFile) === process.cwd()) {
-    throw new Error(
-      'outDir cannot be the current working directory, please specify package.main or package.module in package.json',
-    );
+    // Prevent output directory from being the current working directory
+    if (dirname(outFile) === process.cwd()) {
+      throw new Error(
+        'outDir cannot be the current working directory, please specify package.main or package.module in package.json',
+      );
+    }
   }
 
   // Merge default and local Vite configs
   return mergeConfig(
     {
       root,
+      plugins: [tsConfigPaths()],
       define: {
         // Set environment variables for the build
         'process.env.NODE_ENV': JSON.stringify(env.mode),

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -37,8 +37,7 @@
     "@equinor/fusion-framework-vite-plugin-api-service": "workspace:^",
     "@equinor/fusion-framework-vite-plugin-spa": "workspace:^",
     "@equinor/fusion-log": "workspace:^",
-    "@vitejs/plugin-react": "^5.0.2",
-    "vite-tsconfig-paths": "^5.1.4"
+    "@vitejs/plugin-react": "^5.0.2"
   },
   "devDependencies": {
     "typescript": "^5.8.2",

--- a/packages/dev-server/src/create-dev-server-config.ts
+++ b/packages/dev-server/src/create-dev-server-config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, mergeConfig, type UserConfig } from 'vite';
 
-import tsConfigPathsPlugin from 'vite-tsconfig-paths';
 import reactPlugin from '@vitejs/plugin-react';
 
 import apiServicePlugin, {
@@ -76,7 +75,6 @@ export const createDevServerConfig = <TEnv extends Partial<TemplateEnv>>(
     },
     plugins: [
       reactPlugin(),
-      tsConfigPathsPlugin(),
       apiServicePlugin(
         {
           proxyHandler: createProxyHandler(api.serviceDiscoveryUrl, processServices, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -847,9 +850,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.2
         version: 5.0.2(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5))
     devDependencies:
       typescript:
         specifier: ^5.8.2


### PR DESCRIPTION
## What is the current behavior?
The `@equinor/fusion-framework-dev-server` package includes the `vite-tsconfig-paths` plugin directly in its configuration, which provides TypeScript path resolution for development servers.

## What is the new behavior?
The responsibility for adding the `vite-tsconfig-paths` plugin has been moved to `@equinor/fusion-framework-cli`. The CLI now provides it via the `overrides` parameter in `createDevServerConfig`, ensuring consistent TypeScript path resolution in both development and build environments.

## Does this PR introduce a breaking change?
**Yes** - This is a breaking change for users who use `@equinor/fusion-framework-dev-server` outside of the CLI context. If you use the dev-server package directly, you must manually add the `vite-tsconfig-paths` plugin to your Vite config overrides to maintain the same TypeScript path resolution behavior.

## Other information?
- The dev-server package no longer includes `vite-tsconfig-paths` as a dependency
- This change improves separation of concerns and ensures consistent behavior between CLI and direct usage
- Users of the CLI will see no changes in behavior
- Direct users of the dev-server package need to add the plugin manually

**Migration guide:**
```typescript
// Before (automatic)
import { createDevServerConfig } from '@equinor/fusion-framework-dev-server';

// After (manual plugin addition required)
import { createDevServerConfig } from '@equinor/fusion-framework-dev-server';
import tsConfigPathsPlugin from 'vite-tsconfig-paths';

const config = createDevServerConfig({
  // ... your config
}, {
  plugins: [tsConfigPathsPlugin()]
});
```

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

