### PR TITLE
docs: update migration guide and changelog for Vite configuration changes

### DIFF
--- a/.changeset/cli_document-vite-config-breaking-change.md
+++ b/.changeset/cli_document-vite-config-breaking-change.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Documented missing breaking change for Vite configuration file naming in CLI v11 migration guide and changelog.
+
+- Added detailed explanation of `app.vite.config.ts` → `vite.config.ts` file naming change
+- Emphasized that `vite.config.ts` should be a last resort for custom setups
+- Recommended using `dev-server.config.js` instead to avoid unexpected behavior
+- Updated migration checklist to include the file rename requirement
+- Enhanced v11.0.0 changelog with the breaking change documentation
+
+This addresses the undocumented breaking change that could cause time-consuming debugging for developers upgrading from v10 to v11.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -195,6 +195,7 @@
   - **Dev Portal Modularization:** The dev portal has been moved to a separate package `@equinor/fusion-framework-dev-server`, enabling modular architecture and independent updates. The dev portal can be configured via `dev-server.config.js` and supports live preview and API mocking.
   - **Command Structure:** CLI is now divided into three main groups: `bin` (executable functions), `commands` (CLI commands), and `lib` (for consumers, config, and utilities). This improves organization and modularity.
   - **BREAKING:** The `--service` flag has been removed. The CLI now uses service discovery via Fusion environment variables. All `app -build-???` commands are deprecated and will be removed in the next major version.
+  - **BREAKING:** Vite configuration file naming has changed to follow Vite's standard convention. Rename `app.vite.config.ts` to `vite.config.ts` to ensure your Vite configurations are applied correctly. Note: Using `vite.config.ts` should be a last resort for custom setups - prefer dev-server configuration to avoid unexpected behavior.
 
   - **Dev Server Abstraction:** Vite configuration and dev server functionality has been abstracted into the `@equinor/fusion-framework-dev-server` package. The CLI now provides a higher-level API that handles Vite configuration internally, eliminating the need for users to manage Vite configuration directly while still allowing for customization through configuration options.
 

--- a/packages/cli/docs/migration-v10-to-v11.md
+++ b/packages/cli/docs/migration-v10-to-v11.md
@@ -19,6 +19,18 @@ With v11, we switched to using the Fusion Framework itself for CLI operations. T
 > }
 > ```
 
+### Vite Configuration File Naming
+
+**Breaking Change:** The CLI now uses Vite's standard configuration file naming convention.
+
+- **Old behavior (v10):** CLI looked for `app.vite.config.ts`
+- **New behavior (v11):** CLI now looks for `vite.config.ts` (Vite's default)
+
+> [!WARNING]
+> **Action Required:** If you have a `app.vite.config.ts` file, rename it to `vite.config.ts` to ensure your Vite configurations are applied correctly in v11.
+> 
+> **Important:** Using `vite.config.ts` should be a last resort for custom setups. Instead, prefer configuring your application through the dev-server configuration (`dev-server.config.js`) to avoid unexpected behavior. The CLI provides higher-level configuration options that are better integrated with the Fusion Framework ecosystem.
+
 ### Deprecated App Command Aliases
 
 The following `fusion-framework-cli app` commands have been renamed:
@@ -51,6 +63,7 @@ Authentication behavior has been updated to improve security and consistency:
 
 When upgrading from v10 to v11, ensure you:
 
+- **Rename Vite configuration file** from `app.vite.config.ts` to `vite.config.ts`
 - **Update command names** in all scripts and CI/CD pipelines:
    - `build-pack` → `pack`
    - `build-upload` → `upload` 


### PR DESCRIPTION
- Added breaking change notice regarding the renaming of the Vite configuration file from `app.vite.config.ts` to `vite.config.ts` in both the changelog and migration documentation.
- Emphasized the importance of using the dev-server configuration over direct Vite configuration to avoid unexpected behavior.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
resolves: equinor/fusion#655


### Check off the following:
- [ ] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [ ] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [ ] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

