### PR TITLE
fix(module): remove @internal tags from utility types referenced by public APIs

### DIFF
--- a/.changeset/module_fixed-missing-type-definitions.md
+++ b/.changeset/module_fixed-missing-type-definitions.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-module": patch
+---
+
+Fixed missing type definitions in compiled declaration files.
+
+- Removed @internal JSDoc tags from ModulesObjectInstanceType and ModulesObjectConfigType
+- These utility types are now properly included in the public API since they are referenced by public types
+- Resolves TypeScript compilation errors when consuming the module
+
+Fixes #3383

--- a/packages/modules/module/src/types.ts
+++ b/packages/modules/module/src/types.ts
@@ -299,11 +299,9 @@ export interface IModulesConfig<M extends Array<AnyModule> | Record<string, AnyM
 export type ModulesConfig<M extends Array<AnyModule> | Record<string, AnyModule>> =
   ModulesConfigType<M> & IModulesConfig<M>;
 
-/** === Internal helpers === */
+/** === Utility types === */
 
 /**
- * @internal
- *
  * Maps the keys of a given modules object to their corresponding module instance types.
  *
  * @template TModule - An object type where each property is a module.
@@ -322,8 +320,6 @@ export type ModulesObjectInstanceType<TModule extends Record<string, AnyModule>>
 };
 
 /**
- * @internal
- *
  * Maps an object of modules to their corresponding configuration types.
  *
  * @template M - An object type where each property is a module extending `AnyModule`.


### PR DESCRIPTION
## Why

The compiled TypeScript declaration files (types.d.ts) were missing type definitions that are referenced by public types, causing TypeScript compilation errors when consuming the module.

## What is the current behavior?

TypeScript consumers get compilation errors due to missing type definitions for  and  which are referenced by public types like  and .

## What is the new behavior?

All types referenced by public APIs are now available in the compiled declaration files, allowing TypeScript consumers to use the module without compilation errors.

## Does this PR introduce a breaking change?

No, this is a bug fix that only affects the TypeScript declaration files. No runtime behavior changes.

## Other information?

- Removed  JSDoc tags from  and 
- These utility types are now properly included in the public API since they are referenced by public types
- Updated section comment from "Internal helpers" to "Utility types"
- All tests pass and build succeeds

## closes

Fixes #3383