### PR TITLE
feat(app): add 'template-app' to AppType union

### DIFF
--- a/.changeset/module-app_added-template-app-type.md
+++ b/.changeset/module-app_added-template-app-type.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-app": patch
+---
+
+Added 'template-app' as a new app type to the AppType union.
+
+This change extends the available app types that consumers can use when configuring applications, providing support for template-based apps.

--- a/packages/modules/app/src/types.ts
+++ b/packages/modules/app/src/types.ts
@@ -28,7 +28,7 @@ export interface AppSettings {
 }
 
 // TODO: remove `report` and `launcher` when legacy apps are removed
-export type AppType = 'standalone' | 'report' | 'launcher' | 'template';
+export type AppType = 'standalone' | 'report' | 'launcher' | 'template' | 'template-app';
 
 export type CurrentApp<
   TModules extends Array<AnyModule> = [],


### PR DESCRIPTION
- Introduced 'template-app' as a new app type in the AppType union.
- This enhancement allows consumers to configure applications with template-based apps, expanding the available app types.

Updates the version for @equinor/fusion-framework-module-app to minor.

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

