### PR TITLE
chore: bump immer from 9.0.16 to 10.1.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -993,8 +993,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1042,8 +1042,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1132,8 +1132,8 @@ importers:
         specifier: workspace:^
         version: link:../../utils/observable
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1352,8 +1352,8 @@ importers:
         specifier: workspace:^
         version: link:../../utils/query
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1613,8 +1613,8 @@ importers:
         specifier: workspace:^
         version: link:../../utils/observable
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
     devDependencies:
       '@equinor/fusion':
         specifier: ^3.4.15
@@ -1898,8 +1898,8 @@ importers:
   packages/utils/observable:
     dependencies:
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1941,8 +1941,8 @@ importers:
         specifier: workspace:^
         version: link:../observable
       immer:
-        specifier: ^9.0.16
-        version: 9.0.21
+        specifier: ^10.1.3
+        version: 10.1.3
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -6441,6 +6441,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
 
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
@@ -14636,6 +14639,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immer@10.1.3: {}
 
   immer@9.0.21: {}
 


### PR DESCRIPTION
Fresh update from main - replacing stale PR #857

This PR updates immer from 9.0.16 to 10.1.3 across all packages that use it:
- packages/utils/query
- packages/utils/observable  
- packages/react/legacy-interopt
- packages/modules/widget
- packages/modules/feature-flag
- packages/modules/bookmark
- packages/modules/app

The original PR #857 was from 2023 and used yarn instead of pnpm, making it incompatible with the current project setup.