### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-review-dismissed.yml
+++ b/.github/workflows/pr-review-dismissed.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/31](https://github.com/equinor/fusion-framework/security/code-scanning/31)

To fix this problem, explicitly add a `permissions` block to the job or root workflow, specifying the minimum required permissions. Since this workflow interacts with pull requests—calling `gh pr ready ... --undo`—it requires `pull-requests: write` (to allow modifying PR status) and likely needs `contents: read` to allow repository content access. The safest method is to add this block at the appropriate level (here: job-level for `test`), just before `runs-on:` in the `.github/workflows/pr-review-dismissed.yml`. No changes to functionality are required because permissions most likely match intended access, but the workflow is now more secure and explicit.

No additional libraries, definitions, or method changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
