### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,4 +1,6 @@
 name: pr cleanup
+permissions:
+  contents: read
 on:
   pull_request: 
     types: 


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/30](https://github.com/equinor/fusion-framework/security/code-scanning/30)

To fix the issue, you should add an explicit `permissions:` block to your workflow YAML to scope the GITHUB_TOKEN permissions as narrowly as possible. Since you are only checking out the code and (presumably) clearing a cache based on a branch, the minimal permission to start with is `contents: read`, unless `.github/workflows/actions/clear-cache` requires more.

- In `.github/workflows/pr-cleanup.yml`, directly under the `name:` field (typically at the top), add:
  ```yaml
  permissions:
    contents: read
  ```
  This will set read-only access for repository contents for all jobs, unless a job overrides it. If the `clear-cache` action needs more, you can add specific permissions as needed, but this is the safest starting point.

No changes to imports, or additional definitions, are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
