### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,5 +1,8 @@
 name: pre release
 
+permissions:
+  contents: read
+
 on: 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/20](https://github.com/equinor/fusion-framework/security/code-scanning/20)

To fix this problem, explicitly set the minimum necessary `permissions` for the workflow or, if more granularity is needed, per-job. Since the main job here appears to be versioning or publishing packages, unless projects or steps require extra privileges, a minimally scoped permissions block should be used—typically, `contents: read` at the workflow or job level suffices unless publishing releases or creating pull requests, in which case additional permissions can be added as needed. For the broadest compatibility and minimal permissions, I'll add at the workflow root:

```yaml
permissions:
  contents: read
```

This will protect against unexpected privilege escalation unless a job or step requires more (which is not indicated here). This block should be added after the workflow `name` and before the `on` block (best practice, and as modeled in the recommendation).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
