### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-completed.yml
+++ b/.github/workflows/ci-completed.yml
@@ -1,4 +1,6 @@
 name: ci completed
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/13](https://github.com/equinor/fusion-framework/security/code-scanning/13)

To fix this problem, we need to add a `permissions` block to the workflow file `.github/workflows/ci-completed.yml`. The block should be added at the top level, just after the `name` and before the rest of the workflow (`on`, `concurrency`, `jobs`). As a minimal starting point (least privilege), `contents: read` will suffice for most workflows that do not require write access, but this can be refined according to actual needs if more task-specific permissions are discovered. Since the job delegates to another workflow, minimal read-only permissions at the top level prevent unnecessary write privileges. No imports or other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
