### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,6 @@
 name: cache
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/29](https://github.com/equinor/fusion-framework/security/code-scanning/29)

**General Fix:**  
Add the `permissions:` block to the workflow or the specific job to restrict GITHUB_TOKEN to only the minimum required set of permissions.

**Specific Fix:**  
Add a `permissions:` key at the root of the workflow, directly after the `name:` key (line 2), and before `on:`, with the value `contents: read`. This is the least-privilege starting point, and can be expanded later if more permissions are required. No other code or structure needs to change.

**Files/Regions to Change:**  
Modify `.github/workflows/cache.yml` to insert the following after the existing `name: cache` on line 1.

**Requirements:**  
No new methods, imports, or other definitions are needed. This is a straight YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
