### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
   documentation:
     name: Update documentation
+    permissions:
+      contents: read
     needs: release-pkg
     if: needs.release-pkg.outputs.published == 'true'
     uses: ./.github/workflows/generate-docs.yml


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/fusion-framework/security/code-scanning/17](https://github.com/equinor/fusion-framework/security/code-scanning/17)

To resolve the issue, we should add an explicit `permissions` block to the workflow or individually to each job. Since the job `documentation` is flagged, adding a minimal `permissions` block (typically `read-all`) to this job restricts the GITHUB_TOKEN permissions and adheres to best practices. If the documentation job only needs to read contents and not write or update, setting `permissions: contents: read` is sufficient. If we are unsure about the minimal set, using `permissions: read-all` is a good default starting point and can be further narrowed after checking requirements. The change should be made within the `documentation` job — specifically, right after `name: Update documentation`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
