### PR TITLE
fix: add missing write permissions for pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,7 +1,18 @@
 name: pre release
 
+# This workflow creates pre-release snapshots of all packages
+# It generates changeset files, updates package versions with snapshot tags,
+# and publishes packages to npm with the specified tag (e.g., 'beta')
+# Used for testing releases before final publication
+#
+# WARNING: Pre-release packages are experimental and may contain breaking changes
+# WARNING: Only execute this workflow if you understand the implications of publishing pre-release packages
+
 permissions:
-  contents: read
+  # Required for creating changeset files and modifying package.json files
+  contents: write    
+  # Required for generating GITHUB_TOKEN used by changeset operations
+  id-token: write    
 
 on: 
   workflow_dispatch:


### PR DESCRIPTION
## Why

This PR fixes an issue with PR #3407 which was merged with incomplete permissions.

## What kind of change does this PR introduce?
- Bug fix

## What is the current behavior?
The pre-release workflow only has `contents: read` permission, but it needs to create changeset files, modify package.json files, and use GitHub tokens for changeset operations.

## What is the new behavior?
- Changed `contents: read` to `contents: write` for file modifications
- Added `id-token: write` for GitHub token operations
- Added comprehensive documentation and warnings about pre-release packages

## Does this PR introduce a breaking change?
No

## Other information?
- Follow-up to PR #3407 which was merged prematurely with insufficient permissions
- Pre-release workflow creates changeset files and modifies package.json files
- Added warnings that pre-release packages are experimental
- Added documentation explaining what the workflow does

## closes:
- Fixes insufficient permissions issue from PR #3407

---

- [x] Confirm changes to target branch validation
- [x] Confirm completion of self-review checklist  
- [x] Confirm adherence to code of conduct