### PR TITLE
fix: add missing actions: write permission for pr-cleanup workflow

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,6 +1,17 @@
 name: pr cleanup
+
+# This workflow cleans up cache entries when a pull request is closed
+# It runs the clear-cache action to remove cached build artifacts and dependencies
+# for the specific PR branch to free up storage space and prevent cache bloat
+#
+# Why these permissions are needed:
+# - contents: read - Required to checkout the repository
+# - actions: write - Required for gh actions-cache delete command in clear-cache action
+
 permissions:
   contents: read
+  # Required for gh actions-cache delete command in clear-cache action
+  actions: write    
 on:
   pull_request: 
     types: 


### PR DESCRIPTION
## Why

This PR fixes an issue with PR #3406 which was merged with incomplete permissions.

## What kind of change does this PR introduce?
- Bug fix

## What is the current behavior?
The pr-cleanup workflow only has `contents: read` permission, but it uses the clear-cache action which requires `actions: write` permission for cache deletion operations.

## What is the new behavior?
- Added `actions: write` permission for cache deletion operations
- Added comprehensive documentation explaining workflow purpose and permissions
- Clear breakdown of why each permission is needed

## Does this PR introduce a breaking change?
No

## Other information?
- Follow-up to PR #3406 which was merged prematurely with insufficient permissions
- pr-cleanup workflow cleans up cache entries when PRs are closed
- Uses clear-cache action which requires `actions: write` for `gh actions-cache delete` command
- Added documentation explaining the workflow's purpose and permission requirements

## closes:
- Fixes insufficient permissions issue from PR #3406

---

- [x] Confirm changes to target branch validation
- [x] Confirm completion of self-review checklist  
- [x] Confirm adherence to code of conduct