### PR TITLE
docs: improve publish command documentation clarity

### DIFF
--- a/.changeset/cli_improve-publish-docs.md
+++ b/.changeset/cli_improve-publish-docs.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Improve publish command documentation clarity
+
+- Update app publish command description to clearly explain conditional building behavior
+- Add prominent note explaining when building occurs vs when it doesn't
+- Add complete portal publish command documentation (was missing)
+- Clarify differences between app and portal publish commands
+- Update command overview to include portal publish command
+- Fix CLI source code documentation to match actual behavior
+- Remove incorrect bundle parameter from portal publish examples
+
+Resolves #656

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -338,7 +338,7 @@ pnpm fusion-framework-cli dev --manifest ./app.manifest.local.ts --config ./app.
 
 Publish your application to the Fusion app store (registry) for deployment.
 
-Publish your application to the Fusion app store (registry) for deployment. This command will build (if needed), upload, and tag your app in a single step.
+This command uploads and tags your app for deployment. If no bundle is provided, it will build your app first before uploading and tagging.
 
 | Option/Argument    | Description                                                                                         | Default / Example |
 | ------------------ | --------------------------------------------------------------------------------------------------- | ----------------- |
@@ -363,8 +363,12 @@ pnpm fusion-framework-cli publish --env prod --manifest app.manifest.prod.ts
 pnpm fusion-framework-cli publish --tag latest app-bundle.zip
 ```
 
-> [!NOTE]
-> - If you provide a bundle file, it will be uploaded directly. If not, the CLI will build and bundle your app before uploading.
+> [!IMPORTANT]
+> **Building Behavior**: The publish command behaves differently based on whether you provide a bundle:
+> - **With bundle**: Uploads and tags the provided bundle (no building)
+> - **Without bundle**: Builds, uploads, and tags your app
+> 
+> **Additional Notes**:
 > - The `--tag` option lets you mark the published version (e.g., as `latest` or `preview`) for easier deployment targeting.
 > - Authentication options (`--token`, `--tenantId`, `--clientId`) can be set via CLI flags or environment variables.
 > - If any step fails (build, upload, or tagging), an error will be logged and the process will exit with a non-zero code.

--- a/packages/cli/docs/portal.md
+++ b/packages/cli/docs/portal.md
@@ -156,7 +156,7 @@ pnpm fusion-framework-cli portal publish --tag preview --schema portal.schema.ts
 ```
 
 > [!IMPORTANT]
-> **Building Behavior**: Unlike the app publish command, the portal publish command always builds your portal template before uploading and tagging. There is no option to provide a pre-built bundle.
+> **Building Behavior**: Unlike the app publish command—which only builds your app if a pre-built bundle is not provided—the portal publish command always builds your portal template before uploading and tagging. There is no option to provide a pre-built bundle.
 > 
 > **Additional Notes**:
 > - The `--tag` option lets you mark the published version (e.g., as `latest` or `preview`) for easier deployment targeting.

--- a/packages/cli/docs/portal.md
+++ b/packages/cli/docs/portal.md
@@ -49,6 +49,7 @@ The Fusion Framework CLI provides a suite of commands to support the full portal
 - [Dev](#dev) — Start the portal development server for local development and testing.
 - [Build](#build) — Build your portal template using Vite.
 - [Pack](#pack) — Bundle your portal into a distributable archive for deployment.
+- [Publish](#publish) — Build, upload, and tag your portal template for deployment.
 - [Upload](#upload) — Upload your portal bundle to the Fusion portal registry.
 - [Tag](#tag) — Tag a published portal template version in the Fusion portal registry.
 - [Manifest](#manifest) — Resolve and print the portal manifest for inspection or debugging.
@@ -122,6 +123,45 @@ pnpm fusion-framework-cli portal pack [options]
 pnpm fusion-framework-cli portal pack
 pnpm fusion-framework-cli portal pack --archive my-portal.zip --schema ./portal.schema.ts
 ```
+
+---
+
+### Publish
+
+Build, upload, and tag your portal template for deployment to the Fusion portal registry.
+
+This command builds your portal template, uploads it to the Fusion portal registry, and applies a tag for versioning in a single step.
+
+| Option/Argument    | Description                                                                                         | Default / Example |
+| ------------------ | --------------------------------------------------------------------------------------------------- | ----------------- |
+| `-e`, `--env`      | Target environment for deployment (e.g., `ci`, `fqa`, `fprd`).                                      |                   |
+| `-m`, `--manifest` | Manifest file to use for bundling (e.g., `portal.manifest.ts`) (optional).                         | `portal.manifest.ts` |
+| `-s`, `--schema`   | Schema file to use for bundling (e.g., `portal.schema.ts`) (optional).                             | `portal.schema.ts` |
+| `-t`, `--tag`      | Tag to apply to the published portal (`latest` \| `preview`).                                       | `latest`          |
+| `-d`, `--debug`    | Enable debug mode for verbose logging.                                                              | `false`           |
+| `--token`          | Authentication token for Fusion.                                                                    |                   |
+| `--tenantId`       | Azure tenant ID for authentication.                                                                 |                   |
+| `--clientId`       | Azure client ID for authentication.                                                                 |                   |
+
+**Usage:**
+```sh
+pnpm fusion-framework-cli portal publish [options]
+```
+
+**Examples:**
+```sh
+pnpm fusion-framework-cli portal publish
+pnpm fusion-framework-cli portal publish --env prod --manifest portal.manifest.prod.ts
+pnpm fusion-framework-cli portal publish --tag preview --schema portal.schema.ts
+```
+
+> [!IMPORTANT]
+> **Building Behavior**: Unlike the app publish command, the portal publish command always builds your portal template before uploading and tagging. There is no option to provide a pre-built bundle.
+> 
+> **Additional Notes**:
+> - The `--tag` option lets you mark the published version (e.g., as `latest` or `preview`) for easier deployment targeting.
+> - Authentication options (`--token`, `--tenantId`, `--clientId`) can be set via CLI flags or environment variables.
+> - If any step fails (build, upload, or tagging), an error will be logged and the process will exit with a non-zero code.
 
 ---
 

--- a/packages/cli/src/cli/commands/app/publish.ts
+++ b/packages/cli/src/cli/commands/app/publish.ts
@@ -46,7 +46,9 @@ import { createEnvOption } from '../../options/env.js';
  */
 export const command = withAuthOptions(
   createCommand('publish')
-    .description('Deployment: Upload and tag your Fusion application (builds if no bundle provided).')
+    .description(
+      'Deployment: Upload and tag your Fusion application (builds if no bundle provided).',
+    )
     .addHelpText(
       'after',
       [

--- a/packages/cli/src/cli/commands/app/publish.ts
+++ b/packages/cli/src/cli/commands/app/publish.ts
@@ -17,10 +17,11 @@ import { createEnvOption } from '../../options/env.js';
 /**
  * CLI command: `publish`
  *
- * Builds, uploads, and tags a Fusion application for deployment to the Fusion portal.
+ * Uploads and tags a Fusion application for deployment to the Fusion portal.
  *
  * Features:
- * - Bundles the app, uploads it to the Fusion app store, and applies a tag for versioning.
+ * - Uploads the app bundle to the Fusion app store and applies a tag for versioning.
+ * - Builds the app first if no bundle is provided.
  * - Supports specifying environment, manifest file, and tag.
  * - Debug mode and authentication options are supported.
  *
@@ -45,7 +46,7 @@ import { createEnvOption } from '../../options/env.js';
  */
 export const command = withAuthOptions(
   createCommand('publish')
-    .description('Deployment: Build, upload, and tag your Fusion application.')
+    .description('Deployment: Upload and tag your Fusion application (builds if no bundle provided).')
     .addHelpText(
       'after',
       [

--- a/packages/cli/src/cli/commands/portal/publish.ts
+++ b/packages/cli/src/cli/commands/portal/publish.ts
@@ -25,7 +25,7 @@ import {
  * - Debug mode and authentication options are supported.
  *
  * Usage:
- *   $ ffc portal publish [options]
+ *   $ ffc portal publish [options] - Build, upload, and tag portal template
  *
  * Options:
  *   -d, --debug          Enable debug mode for verbose logging

--- a/packages/cli/src/cli/commands/portal/publish.ts
+++ b/packages/cli/src/cli/commands/portal/publish.ts
@@ -25,10 +25,7 @@ import {
  * - Debug mode and authentication options are supported.
  *
  * Usage:
- *   $ ffc portal publish [bundle] [options]
- *
- * Arguments:
- *   [bundle]             Path to the portal bundle to upload
+ *   $ ffc portal publish [options]
  *
  * Options:
  *   -d, --debug          Enable debug mode for verbose logging
@@ -39,7 +36,7 @@ import {
  * Example:
  *   $ ffc portal publish
  *   $ ffc portal publish --env prod --manifest portal.manifest.prod.ts
- *   $ ffc portal publish --tag latest app.bundle.zip
+ *   $ ffc portal publish --tag preview
  *
  * @see uploadPortalBundle, tagPortal for implementation details
  */
@@ -58,7 +55,7 @@ export const command = withAuthOptions(
         'Examples:',
         '  $ ffc portal publish',
         '  $ ffc portal publish --env prod --manifest portal.manifest.prod.ts',
-        '  $ ffc portal publish --tag latest portal.bundle.zip',
+        '  $ ffc portal publish --tag preview',
       ].join('\n'),
     )
     .option('-d, --debug', 'Enable debug mode for verbose logging', false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement

## What is the current behavior?

- App publish command documentation was misleading about when building occurs
- Portal publish command documentation was completely missing
- CLI source code had incorrect documentation about portal publish bundle parameter

## What is the new behavior?

- App publish command clearly explains conditional building behavior (builds only if no bundle provided)
- Portal publish command has complete documentation explaining it always builds
- CLI source code documentation matches actual command behavior
- Clear distinction between app and portal publish commands

## Does this PR introduce a breaking change?

No

## Other information?

This addresses the issue raised in https://github.com/equinor/fusion/issues/656 where users found the documentation misleading about the publish command behavior.

## closes

- fixes: #3417
- resolves: #3416  
- closes: https://github.com/equinor/fusion/issues/656

## Checkboxes

- [x] Confirm changes to target branch validation
- [x] Confirm completion of self-review checklist  
- [x] Confirm adherence to code of conduct