### PR TITLE
fix: resolve issues for OPTIONS requests in dev server

### DIFF
--- a/.changeset/dev-server_fix-options-cors-headers.md
+++ b/.changeset/dev-server_fix-options-cors-headers.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-dev-server": patch
+---
+
+Fix OPTIONS requests missing Allow header after Vite 7 update
+
+- Disabled Vite's internal CORS handling by setting `server.cors: false`
+- This allows backend services to properly handle OPTIONS requests with correct headers
+- Resolves issue where OPTIONS requests were not forwarded to backend after Vite 7 upgrade
+- Backend services can now include Allow, Access-Control-Allow-Methods, and other CORS headers
+
+closes: #3436

--- a/packages/dev-server/src/create-dev-server-config.ts
+++ b/packages/dev-server/src/create-dev-server-config.ts
@@ -34,6 +34,7 @@ const createDefaultLogger = (lvl: LogLevel = LogLevel.Info, title = 'dev-server'
  * - The `api.processServices` defaults to `defaultProcessServices` if not provided.
  * - The server is configured to run on port 3000.
  * - Includes plugins for API service handling and SPA template environment generation.
+ * - CORS is disabled to allow backend services to handle OPTIONS requests with proper headers.
  *
  * @example
  * ```typescript
@@ -72,6 +73,11 @@ export const createDevServerConfig = <TEnv extends Partial<TemplateEnv>>(
       'process.env': JSON.stringify({
         FUSION_LOG_LEVEL: String(logger.level),
       }),
+    },
+    server: {
+      // Disable Vite's internal CORS handling to allow backend to handle OPTIONS requests properly
+      // This ensures that OPTIONS requests are forwarded to the backend with proper headers
+      cors: false,
     },
     plugins: [
       reactPlugin(),


### PR DESCRIPTION
- Disabled Vite's internal CORS handling to allow backend services to manage OPTIONS requests correctly.
- Ensures proper forwarding of OPTIONS requests with necessary CORS headers, including Allow and Access-Control-Allow-Methods.
- Addresses the issue introduced after the Vite 7 update, improving compatibility with backend services.

closes: #3436

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

