### PR TITLE
fix: improve test isolation in load-env tests

### DIFF
--- a/packages/utils/load-env/tests/load-env.test.ts
+++ b/packages/utils/load-env/tests/load-env.test.ts
@@ -1,15 +1,34 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, beforeEach, vi, expect, type Mocked } from 'vitest';
+import { describe, it, beforeEach, afterEach, vi, expect, type Mocked } from 'vitest';
 import { loadEnv, DEFAULT_ENV_PREFIX } from '../src';
 
 vi.mock('node:fs');
 
 describe('loadEnv', () => {
   const mockFs = fs as Mocked<typeof fs>;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.resetAllMocks();
+    // Clear process.env of any variables starting with DEFAULT_ENV_PREFIX to ensure test isolation
+    for (const key in process.env) {
+      if (key.startsWith(DEFAULT_ENV_PREFIX)) {
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    // Restore original process.env after each test
+    for (const key in process.env) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const key in originalEnv) {
+      process.env[key] = originalEnv[key];
+    }
   });
 
   it('loads environment variables from .env files with default prefix', () => {


### PR DESCRIPTION
Fixes test isolation issues in load-env package tests by properly cleaning up environment variables between test runs.

**Changes:**
- Add beforeEach/afterEach hooks to clear and restore environment variables
- Prevent test pollution from external environment variables starting with DEFAULT_ENV_PREFIX
- Ensure tests run in properly isolated environment

**Testing:**
- All load-env tests now pass consistently
- No impact on other test suites
- Fixes environment variable pollution issues

**Related:**
- This was discovered while processing dependabot PR #3447
- Test failures were preventing automated validation