### PR TITLE
fix(cli): respect explicit HTTPS protocol selection

### DIFF
--- a/.changeset/cli-git-protocol-fix.md
+++ b/.changeset/cli-git-protocol-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fix Git protocol selection to respect user's explicit HTTPS choice instead of auto-detecting SSH when available.
+
+Fixes: https://github.com/equinor/fusion-framework/issues/3462

--- a/packages/cli/src/bin/helpers/ProjectTemplateRepository.ts
+++ b/packages/cli/src/bin/helpers/ProjectTemplateRepository.ts
@@ -147,7 +147,7 @@ export class ProjectTemplateRepository {
       this._setupOutputHandler();
 
       // Auto-detect protocol based on SSH configuration now that git is properly initialized
-      if (!this.#protocol || this.#protocol === 'https') {
+      if (!this.#protocol) {
         try {
           const sshCommand = await this.#git.getConfig('core.sshCommand');
           this.#protocol = sshCommand ? 'ssh' : 'https';


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
🐞 bug fix

<!-- What is the current behavior? -->
When a user explicitly selects HTTPS protocol for Git cloning, the CLI still uses SSH if SSH configuration is detected on the system.

<!-- What is the new behavior? -->
When HTTPS is explicitly selected, the CLI now properly uses HTTPS URLs regardless of SSH configuration availability.

<!-- Does this PR introduce a breaking change? -->
No

<!-- Other information? -->
Fixes: https://github.com/equinor/fusion-framework/issues/3462

closes:

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).