### PR TITLE
fix(dev-portal): re-add support for custom context path extraction and generation

### DIFF
--- a/.changeset/beige-sloths-judge.md
+++ b/.changeset/beige-sloths-judge.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-dev-portal": patch
+---
+
+Re-add support for custom context path extraction and generation


### PR DESCRIPTION
Was introduced in #2930.
Removed in 8fffbfb12daa9748bf5290e5084cd4d409aed253 (cli next).

Ref #2930
Ref 8fffbfb12daa9748bf5290e5084cd4d409aed253

## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

