### PR TITLE
fix(module-services): update jobTitle field to allow nullish values in ApiPersonSchema

### DIFF
--- a/.changeset/flat-parents-smell.md
+++ b/.changeset/flat-parents-smell.md
@@ -1,0 +1,10 @@
+---
+"@equinor/fusion-framework-module-services": patch
+---
+
+Made the `jobTitle` field in `ApiPersonSchema` nullable to ensure external users can access bookmarks even when the `jobTitle` field is not set.
+
+ref:[668](https://github.com/equinor/fusion/issues/668)
+reporter: [EdwardBrunton](https://github.com/EdwardBrunton)
+
+

--- a/packages/modules/services/src/bookmarks/schemas.ts
+++ b/packages/modules/services/src/bookmarks/schemas.ts
@@ -13,7 +13,7 @@ export const ApiPersonSchema = {
     name: z.string(),
     mail: z.string().optional(),
     phoneNumber: z.string().optional(),
-    jobTitle: z.string().optional(),
+    jobTitle: z.string().nullish(),
     accountType: z.enum(['Employee', 'Consultant', 'External', 'Application', 'Local']).optional(),
     accountClassification: z.enum(['Unclassified', 'Internal', 'External']).nullish(),
   }),


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->

update jobTitle field to allow nullish values in ApiPersonSchema
this to enchure external with jobTitle null to get their bookmarks

ref: https://github.com/equinor/fusion/issues/668


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

