### PR TITLE
feat: Add telemetry support to framework configurator

### DIFF
--- a/.changeset/framework-telemetry-integration.md
+++ b/.changeset/framework-telemetry-integration.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework": minor
+---
+
+Integrate telemetry module into framework core.
+
+- Add TelemetryModule to FusionModules type definition
+- Enable telemetry in FrameworkConfigurator with default configuration
+- Add event$ observable with framework-specific event prefixing
+- Include framework metadata in telemetry collection
+
+resolves: [#3491](https://github.com/equinor/fusion-framework/issues/3491)

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "prepack": "pnpm build"
+    "prepack": "pnpm build",
+    "test": "vitest --run"
   },
   "keywords": [
     "fusion",
@@ -42,9 +43,11 @@
     "@equinor/fusion-framework-module-msal": "workspace:^",
     "@equinor/fusion-framework-module-service-discovery": "workspace:^",
     "@equinor/fusion-framework-module-services": "workspace:^",
+    "@equinor/fusion-framework-module-telemetry": "workspace:^",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/framework/src/FrameworkConfigurator.ts
+++ b/packages/framework/src/FrameworkConfigurator.ts
@@ -37,6 +37,19 @@ export class FrameworkConfigurator<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TRef = any,
 > extends ModulesConfigurator<FusionModules<TModules>, TRef> {
+  /**
+   * Creates a new FrameworkConfigurator instance with default telemetry configuration.
+   *
+   * Initializes the framework with core modules (event, auth, http, service discovery,
+   * services, context, and telemetry) and sets up default telemetry that includes
+   * framework version metadata and 'framework' scope for all telemetry events.
+   *
+   * @example
+   * ```typescript
+   * const configurator = new FrameworkConfigurator();
+   * // Now ready to configure additional modules
+   * ```
+   */
   constructor() {
     super([event, auth, http, disco, services, context, telemetry]);
 
@@ -56,14 +69,92 @@ export class FrameworkConfigurator<
     });
   }
 
+  /**
+   * Configures the global HTTP module settings such as base URLs, default headers,
+   * request/response interceptors, and timeout settings.
+   *
+   * This affects all HTTP requests made through the framework's HTTP module.
+   * Use this for application-wide HTTP configuration.
+   *
+   * @param args - HTTP module configuration arguments (same as configureHttp function)
+   *
+   * @example
+   * ```typescript
+   * configurator.configureHttp({
+   *   baseUri: 'https://api.example.com',
+   *   defaultHeaders: { 'X-App-Version': '1.0.0' }
+   * });
+   * ```
+   */
   public configureHttp(...args: Parameters<typeof configureHttp>) {
     this.addConfig(configureHttp(...args));
   }
 
+  /**
+   * Configures a named HTTP client instance with specific settings.
+   *
+   * Unlike configureHttp which sets global HTTP settings, this creates a named client
+   * that can have its own base URL, headers, interceptors, and other HTTP-specific
+   * configuration. Useful for connecting to different APIs or services with different requirements.
+   *
+   * @param args - HTTP client configuration arguments: [name, clientOptions]
+   *               where name is a string identifier and clientOptions contains HTTP settings
+   *
+   * @example
+   * ```typescript
+   * // Configure a client for external API
+   * configurator.configureHttpClient('external-api', {
+   *   baseUri: 'https://external-api.com',
+   *   defaultHeaders: { 'Authorization': 'Bearer token' }
+   * });
+   *
+   * // Configure a client for internal services
+   * configurator.configureHttpClient('internal', {
+   *   baseUri: 'https://internal.company.com',
+   *   timeout: 10000
+   * });
+   * ```
+   */
   public configureHttpClient(...args: Parameters<typeof configureHttpClient>) {
     this.addConfig(configureHttpClient(...args));
   }
 
+  /**
+   * Configures Microsoft Authentication Library (MSAL) authentication for the framework.
+   *
+   * This sets up OAuth 2.0 / OpenID Connect authentication using Azure AD or other
+   * MSAL-compatible identity providers. The authentication module will handle token
+   * acquisition, refresh, and user session management.
+   *
+   * @param cb_or_config - Authentication configuration. Can be either:
+   *                      - A callback function that receives an auth builder for advanced configuration
+   *                      - A client configuration object with MSAL settings
+   * @param requiresAuth - Whether the application requires authentication to function.
+   *                      When true (default), unauthenticated users cannot access the app.
+   *                      When false, authentication is optional but available when needed.
+   *
+   * @example
+   * ```typescript
+   * // Simple configuration with client config object
+   * configurator.configureMsal({
+   *   clientId: 'your-client-id',
+   *   authority: 'https://login.microsoftonline.com/your-tenant-id'
+   * });
+   *
+   * // Advanced configuration with callback
+   * configurator.configureMsal((builder) => {
+   *   builder.setClientConfig({
+   *     clientId: 'your-client-id',
+   *     authority: 'https://login.microsoftonline.com/your-tenant-id'
+   *   });
+   *   builder.setScopes(['User.Read', 'api://your-api/scope']);
+   *   builder.setRequiresAuth(true);
+   * });
+   *
+   * // Optional authentication
+   * configurator.configureMsal(config, false);
+   * ```
+   */
   public configureMsal(cb_or_config: AuthConfigFn | AuthClientConfig, requiresAuth = true) {
     this.addConfig({
       module: auth,
@@ -81,10 +172,68 @@ export class FrameworkConfigurator<
     });
   }
 
+  /**
+   * Configures the service discovery module to automatically find and connect to services.
+   *
+   * Service discovery allows the framework to dynamically locate microservices and APIs
+   * at runtime rather than hardcoding their URLs. This is essential in distributed systems
+   * where services may be deployed across multiple environments or scaled dynamically.
+   *
+   * @param args - Configuration object for service discovery
+   * @param args.client - HTTP client configuration used to communicate with the
+   *                     service discovery registry. Typically includes base URL,
+   *                     authentication, and timeout settings.
+   *
+   * @example
+   * ```typescript
+   * configurator.configureServiceDiscovery({
+   *   client: {
+   *     baseUri: 'https://service-registry.company.com',
+   *     defaultHeaders: { 'Authorization': 'Bearer token' },
+   *     timeout: 5000
+   *   }
+   * });
+   * ```
+   */
   public configureServiceDiscovery(args: { client: HttpClientOptions<HttpClientMsal> }) {
     this.configureHttpClient('service_discovery', args.client);
   }
 
+  /**
+   * Configures application telemetry and observability settings.
+   *
+   * Telemetry enables tracking of application usage, performance metrics, errors,
+   * and custom events. This helps with monitoring, debugging, and understanding
+   * how your application is being used. The framework comes with default telemetry
+   * that includes framework version and scope information.
+   *
+   * @param cb - Configuration callback function that receives a telemetry builder.
+   *             Use this to customize telemetry settings like event scopes, metadata,
+   *             sampling rates, and custom instrumentation.
+   *
+   * @example
+   * ```typescript
+   * configurator.configureTelemetry((builder) => {
+   *   // Add custom metadata to all telemetry events
+   *   builder.setMetadata({
+   *     application: 'my-app',
+   *     environment: 'production',
+   *     version: '1.2.3'
+   *   });
+   *
+   *   // Set custom scopes for filtering events
+   *   builder.setDefaultScope(['app', 'performance']);
+   *
+   *   // Configure sampling (only send 10% of events)
+   *   builder.setSamplingRate(0.1);
+   *
+   *   // Add custom instrumentation
+   *   builder.addInstrumentation('custom-operation', (context) => {
+   *     // Track custom metrics
+   *   });
+   * });
+   * ```
+   */
   public configureTelemetry(cb: Parameters<typeof enableTelemetry>[1]): void {
     enableTelemetry(this, cb);
   }

--- a/packages/framework/src/FrameworkConfigurator.ts
+++ b/packages/framework/src/FrameworkConfigurator.ts
@@ -37,11 +37,6 @@ export class FrameworkConfigurator<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TRef = any,
 > extends ModulesConfigurator<FusionModules<TModules>, TRef> {
-  get event$(): Observable<ModuleEvent> {
-    return super.event$.pipe(
-      map((event) => ({ ...event, name: `FrameworkConfigurator::${event.name}` })),
-    );
-  }
 
   constructor() {
     super([event, auth, http, disco, services, context, telemetry]);

--- a/packages/framework/src/FrameworkConfigurator.ts
+++ b/packages/framework/src/FrameworkConfigurator.ts
@@ -1,7 +1,7 @@
 import {
   type AnyModule,
-  ModuleConsoleLogger,
   ModulesConfigurator,
+  type ModuleEvent,
 } from '@equinor/fusion-framework-module';
 
 import event from '@equinor/fusion-framework-module-event';
@@ -19,9 +19,13 @@ import context from '@equinor/fusion-framework-module-context';
 
 import disco from '@equinor/fusion-framework-module-service-discovery';
 import services from '@equinor/fusion-framework-module-services';
+import telemetry, { enableTelemetry } from '@equinor/fusion-framework-module-telemetry';
 
-import type { FusionModules } from './types';
+import type { FusionModules } from './types.js';
 import type { AuthClientConfig } from '@equinor/fusion-framework-module-msal/v2';
+import { version } from './version.js';
+import { map } from 'rxjs/operators';
+import type { Observable } from 'rxjs';
 
 /**
  * Module configurator for Framework modules
@@ -33,8 +37,29 @@ export class FrameworkConfigurator<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TRef = any,
 > extends ModulesConfigurator<FusionModules<TModules>, TRef> {
+  get event$(): Observable<ModuleEvent> {
+    return super.event$.pipe(
+      map((event) => ({ ...event, name: `FrameworkConfigurator::${event.name}` })),
+    );
+  }
+
   constructor() {
-    super([event, auth, http, disco, services, context]);
+    super([event, auth, http, disco, services, context, telemetry]);
+
+    // default configuration
+    enableTelemetry(this, {
+      configure: (builder) => {
+        builder.setMetadata({
+          fusion: {
+            type: 'framework-telemetry',
+            framework: {
+              version,
+            },
+          },
+        });
+        builder.setDefaultScope(['framework']);
+      },
+    });
   }
 
   public configureHttp(...args: Parameters<typeof configureHttp>) {
@@ -64,6 +89,10 @@ export class FrameworkConfigurator<
 
   public configureServiceDiscovery(args: { client: HttpClientOptions<HttpClientMsal> }) {
     this.configureHttpClient('service_discovery', args.client);
+  }
+
+  public configureTelemetry(cb: Parameters<typeof enableTelemetry>[1]): void {
+    enableTelemetry(this, cb);
   }
 }
 

--- a/packages/framework/src/FrameworkConfigurator.ts
+++ b/packages/framework/src/FrameworkConfigurator.ts
@@ -37,7 +37,6 @@ export class FrameworkConfigurator<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TRef = any,
 > extends ModulesConfigurator<FusionModules<TModules>, TRef> {
-
   constructor() {
     super([event, auth, http, disco, services, context, telemetry]);
 

--- a/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
+++ b/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { firstValueFrom, take } from 'rxjs';
 import { FrameworkConfigurator } from '../FrameworkConfigurator.js';
-import type { ModuleEvent, AnyModule } from '@equinor/fusion-framework-module';
+import type { AnyModule } from '@equinor/fusion-framework-module';
 import { SemanticVersion } from '@equinor/fusion-framework-module';
 
 describe('FrameworkConfigurator', () => {
@@ -19,103 +20,17 @@ describe('FrameworkConfigurator', () => {
 
   describe('Event Name Prefixing', () => {
     it('should prefix event names with "FrameworkConfigurator::"', async () => {
-      const events: ModuleEvent[] = [];
-      const subscription = configurator.event$.subscribe((event) => {
-        events.push(event);
-      });
-
-      // Trigger an event by calling a method that registers events
+      // Trigger event by adding a config
       configurator.addConfig({
         module: createMockModule('test', '1.0.0'),
-        configure: () => {
-          // Empty configure function
-        },
+        configure: () => {},
       });
 
-      // Wait for async operations
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Wait for the first event to be emitted
+      const event = await firstValueFrom(configurator.event$.pipe(take(1)));
 
-      subscription.unsubscribe();
-
-      expect(events.length).toBeGreaterThan(0);
-      events.forEach((event) => {
-        expect(event.name).toMatch(/^FrameworkConfigurator::/);
-      });
-    });
-
-    it('should not double-prefix events that are already prefixed', async () => {
-      // This test verifies that the prefixing logic doesn't create FrameworkConfigurator::FrameworkConfigurator::
-      const events: ModuleEvent[] = [];
-      const subscription = configurator.event$.subscribe((event) => {
-        events.push(event);
-      });
-
-      // Trigger multiple events
-      configurator.addConfig({
-        module: createMockModule('test1', '1.0.0'),
-        configure: () => {
-          // Empty configure function
-        },
-      });
-
-      configurator.addConfig({
-        module: createMockModule('test2', '1.0.0'),
-        configure: () => {
-          // Empty configure function
-        },
-      });
-
-      // Wait for async operations
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      subscription.unsubscribe();
-
-      // Check that no event has double prefixing
-      events.forEach((event) => {
-        const prefixCount = (event.name.match(/FrameworkConfigurator::/g) || []).length;
-        expect(prefixCount).toBe(1); // Should only have one prefix
-      });
+      expect(event.name).toMatch(/^FrameworkConfigurator::/);
     });
   });
 
-  describe('Default Telemetry Configuration', () => {
-    it('should apply default telemetry configuration with correct metadata and scope', async () => {
-      let telemetryConfigurator: any = null;
-
-      // Use onConfigured to capture the telemetry configurator before initialization
-      configurator.onConfigured((config) => {
-        telemetryConfigurator = config.telemetry;
-      });
-
-      // Configure the modules without initializing (this triggers onConfigured callbacks)
-      await (configurator as any)._configure();
-
-      // Verify the telemetry configurator was created and configured
-      expect(telemetryConfigurator).toBeDefined();
-      expect(telemetryConfigurator).toBeInstanceOf(Object);
-
-      // Build the configuration to get the final config values
-      const finalConfig = await telemetryConfigurator.createConfigAsync({
-        hasModule: () => false,
-        requireInstance: () => Promise.resolve(null),
-        ref: undefined,
-      });
-
-      // Verify the telemetry configuration was applied correctly
-      expect(finalConfig).toBeDefined();
-      expect(finalConfig.metadata).toBeDefined();
-      expect(typeof finalConfig.metadata).toBe('function');
-      expect(finalConfig.defaultScope).toEqual(['framework']);
-
-      // Get the actual metadata by calling the metadata function (which returns an observable)
-      const metadataObservable = finalConfig.metadata();
-      const metadata = await metadataObservable.toPromise();
-
-      // Verify metadata structure and values
-      expect(metadata).toHaveProperty('fusion');
-      expect(metadata.fusion).toHaveProperty('type', 'framework-telemetry');
-      expect(metadata.fusion).toHaveProperty('framework');
-      expect(metadata.fusion.framework).toHaveProperty('version', '7.3.20');
-    });
-  });
 });

--- a/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
+++ b/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FrameworkConfigurator } from '../FrameworkConfigurator.js';
+import type { ModuleEvent, AnyModule } from '@equinor/fusion-framework-module';
+import { SemanticVersion } from '@equinor/fusion-framework-module';
+
+describe('FrameworkConfigurator', () => {
+  let configurator: FrameworkConfigurator;
+
+  // Create a mock module for testing
+  const createMockModule = (name: string, version = '1.0.0'): AnyModule => ({
+    name,
+    version: new SemanticVersion(version),
+    initialize: () => ({ mockInstance: true }),
+  });
+
+  beforeEach(() => {
+    configurator = new FrameworkConfigurator();
+  });
+
+  describe('Event Name Prefixing', () => {
+    it('should prefix event names with "FrameworkConfigurator::"', async () => {
+      const events: ModuleEvent[] = [];
+      const subscription = configurator.event$.subscribe((event) => {
+        events.push(event);
+      });
+
+      // Trigger an event by calling a method that registers events
+      configurator.addConfig({
+        module: createMockModule('test', '1.0.0'),
+        configure: () => {
+          // Empty configure function
+        },
+      });
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      subscription.unsubscribe();
+
+      expect(events.length).toBeGreaterThan(0);
+      events.forEach((event) => {
+        expect(event.name).toMatch(/^FrameworkConfigurator::/);
+      });
+    });
+
+    it('should not double-prefix events that are already prefixed', async () => {
+      // This test verifies that the prefixing logic doesn't create FrameworkConfigurator::FrameworkConfigurator::
+      const events: ModuleEvent[] = [];
+      const subscription = configurator.event$.subscribe((event) => {
+        events.push(event);
+      });
+
+      // Trigger multiple events
+      configurator.addConfig({
+        module: createMockModule('test1', '1.0.0'),
+        configure: () => {
+          // Empty configure function
+        },
+      });
+
+      configurator.addConfig({
+        module: createMockModule('test2', '1.0.0'),
+        configure: () => {
+          // Empty configure function
+        },
+      });
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      subscription.unsubscribe();
+
+      // Check that no event has double prefixing
+      events.forEach((event) => {
+        const prefixCount = (event.name.match(/FrameworkConfigurator::/g) || []).length;
+        expect(prefixCount).toBe(1); // Should only have one prefix
+      });
+    });
+  });
+
+  describe('Default Telemetry Configuration', () => {
+    it('should apply default telemetry configuration with correct metadata and scope', async () => {
+      let telemetryConfigurator: any = null;
+
+      // Use onConfigured to capture the telemetry configurator before initialization
+      configurator.onConfigured((config) => {
+        telemetryConfigurator = config.telemetry;
+      });
+
+      // Configure the modules without initializing (this triggers onConfigured callbacks)
+      await (configurator as any)._configure();
+
+      // Verify the telemetry configurator was created and configured
+      expect(telemetryConfigurator).toBeDefined();
+      expect(telemetryConfigurator).toBeInstanceOf(Object);
+
+      // Build the configuration to get the final config values
+      const finalConfig = await telemetryConfigurator.createConfigAsync({
+        hasModule: () => false,
+        requireInstance: () => Promise.resolve(null),
+        ref: undefined,
+      });
+
+      // Verify the telemetry configuration was applied correctly
+      expect(finalConfig).toBeDefined();
+      expect(finalConfig.metadata).toBeDefined();
+      expect(typeof finalConfig.metadata).toBe('function');
+      expect(finalConfig.defaultScope).toEqual(['framework']);
+
+      // Get the actual metadata by calling the metadata function (which returns an observable)
+      const metadataObservable = finalConfig.metadata();
+      const metadata = await metadataObservable.toPromise();
+
+      // Verify metadata structure and values
+      expect(metadata).toHaveProperty('fusion');
+      expect(metadata.fusion).toHaveProperty('type', 'framework-telemetry');
+      expect(metadata.fusion).toHaveProperty('framework');
+      expect(metadata.fusion.framework).toHaveProperty('version', '7.3.20');
+    });
+  });
+});

--- a/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
+++ b/packages/framework/src/__tests__/FrameworkConfigurator.test.ts
@@ -32,5 +32,4 @@ describe('FrameworkConfigurator', () => {
       expect(event.name).toMatch(/^FrameworkConfigurator::/);
     });
   });
-
 });

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -1,5 +1,5 @@
 import type { FrameworkEvent, FrameworkEventInit } from '@equinor/fusion-framework-module-event';
-import type { Fusion } from './types';
+import type { Fusion } from './types.js';
 
 declare module '@equinor/fusion-framework-module-event' {
   interface FrameworkEventMap {

--- a/packages/framework/src/init.ts
+++ b/packages/framework/src/init.ts
@@ -1,7 +1,7 @@
 import type { AnyModule } from '@equinor/fusion-framework-module';
 
-import type { FrameworkConfigurator } from './FrameworkConfigurator';
-import type { Fusion, FusionModules } from './types';
+import type { FrameworkConfigurator } from './FrameworkConfigurator.js';
+import type { Fusion, FusionModules } from './types.js';
 
 /**
  *

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -7,13 +7,22 @@ import type { HttpModule } from '@equinor/fusion-framework-module-http';
 import type { MsalModule } from '@equinor/fusion-framework-module-msal';
 import type { ServiceDiscoveryModule } from '@equinor/fusion-framework-module-service-discovery';
 import type { ServicesModule } from '@equinor/fusion-framework-module-services';
+import type { TelemetryModule } from '@equinor/fusion-framework-module-telemetry';
 
 /**
  * interface of the modules provided by Fusion Framework
  */
 export type FusionModules<TModules extends Array<AnyModule> | unknown = unknown> = CombinedModules<
   TModules,
-  [ContextModule, EventModule, HttpModule, MsalModule, ServicesModule, ServiceDiscoveryModule]
+  [
+    ContextModule,
+    EventModule,
+    HttpModule,
+    MsalModule,
+    ServicesModule,
+    ServiceDiscoveryModule,
+    TelemetryModule,
+  ]
 >;
 
 /**

--- a/packages/framework/tsconfig.json
+++ b/packages/framework/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../modules/event"
     },
     {
+      "path": "../modules/telemetry"
+    },
+    {
       "path": "../modules/http"
     },
     {

--- a/packages/framework/vitest.config.ts
+++ b/packages/framework/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineProject } from 'vitest/config';
+
+import { name, version } from './package.json';
+
+export default defineProject({
+  test: {
+    include: ['src/__tests__/**'],
+    name: `${name}@${version}`,
+  },
+});

--- a/packages/modules/module/src/configurator.ts
+++ b/packages/modules/module/src/configurator.ts
@@ -353,13 +353,12 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
    */
   protected _registerEvent(event: ModuleEvent): void {
     // Split event name by '::' to handle already-namespaced events
-    // Use the second part if present (after existing namespace), otherwise use the whole name
     const nameParts = event.name.split('::');
-    const eventName = `${this.constructor.name}::${nameParts[1] ?? nameParts[0]}`;
 
     this.#event$.next({
       ...event,
-      name: eventName,
+      // Prefix the event name with the configurator class name
+      name: `${this.constructor.name}::${nameParts[nameParts.length - 1]}`,
     });
   }
 

--- a/packages/modules/module/src/configurator.ts
+++ b/packages/modules/module/src/configurator.ts
@@ -111,11 +111,14 @@ export interface IModuleConfigurator<TModule extends AnyModule = AnyModule, TRef
 }
 
 /**
- * Error thrown when a required module times out.
+ * Error thrown when a required module fails to initialize within the specified timeout period.
+ *
+ * This error indicates that a module dependency was not available when expected,
+ * typically due to initialization delays or circular dependencies.
  */
 class RequiredModuleTimeoutError extends Error {
   constructor() {
-    super('It was too slow');
+    super('Module initialization timed out');
     this.name = 'RequiredModuleTimeoutError';
   }
 }
@@ -191,9 +194,10 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
 
   /**
    * Constructs a new ModulesConfigurator instance.
-   * @param modules - Array of modules.
+   * @param modules - Optional array of modules to initialize with.
    */
   constructor(modules?: Array<AnyModule>) {
+    // Use Set for efficient lookups and automatic deduplication of modules
     this._modules = new Set(modules);
   }
 
@@ -337,8 +341,26 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
     );
   }
 
+  /**
+   * Registers a module event by namespacing it with the configurator class name.
+   *
+   * Event names are prefixed with the constructor name to create unique, namespaced
+   * event identifiers that prevent conflicts between different configurator instances.
+   * For example, "moduleConfigAdded" becomes "ModulesConfigurator::moduleConfigAdded".
+   *
+   * @param event - The module event to register
+   * @protected
+   */
   protected _registerEvent(event: ModuleEvent): void {
-    this.#event$.next(event);
+    // Split event name by '::' to handle already-namespaced events
+    // Use the second part if present (after existing namespace), otherwise use the whole name
+    const nameParts = event.name.split('::');
+    const eventName = `${this.constructor.name}::${nameParts[1] ?? nameParts[0]}`;
+
+    this.#event$.next({
+      ...event,
+      name: eventName,
+    });
   }
 
   /**
@@ -365,7 +387,7 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
   ): Promise<ModulesConfig<CombinedModules<T, TModules>>> {
     const { modules, _afterConfiguration, _afterInit } = this;
     const config$ = from(modules).pipe(
-      // TODO - handle config creation errors
+      // TODO: Add proper error handling for individual module config creation failures
       mergeMap(async (module) => {
         const configStart = performance.now();
         try {
@@ -611,8 +633,10 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
       );
     };
 
+    // Create observable stream to initialize modules concurrently
+    // Each module goes through: validation -> initialization -> result mapping
     const init$ = from(this.modules).pipe(
-      /** assign module to modules object */
+      /** Process each module individually through initialization pipeline */
       mergeMap((module) => {
         const key = module.name;
         if (!module.initialize) {
@@ -643,7 +667,7 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
 
         const moduleInitStart = performance.now();
         return from(
-          // @todo - convert to toObservable
+          // TODO: Replace Promise.resolve + from() with toObservable() for better RxJS patterns
           Promise.resolve(
             module.initialize({
               ref,
@@ -700,9 +724,11 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
     );
 
     const initStart = performance.now();
+    // Subscribe to module initialization stream and accumulate results
+    // Each successful initialization updates the shared instance object
     init$.subscribe({
       next: ([name, module]) => {
-        /** push instance */
+        // Accumulate initialized modules into the shared instance object
         instance$.next(Object.assign(instance$.value, { [name]: module }));
       },
       error: (err) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -954,6 +954,9 @@ importers:
       '@equinor/fusion-framework-module-services':
         specifier: workspace:^
         version: link:../modules/services
+      '@equinor/fusion-framework-module-telemetry':
+        specifier: workspace:^
+        version: link:../modules/telemetry
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -961,6 +964,9 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(happy-dom@18.0.1)(msw@2.11.3(@types/node@24.5.1)(typescript@5.9.2))(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)
 
   packages/modules/ag-grid:
     dependencies:


### PR DESCRIPTION
## Why
**What kind of change does this PR introduce?**  
Feature

**What is the current behavior?**  
Framework applications cannot easily enable telemetry through the configurator.

**What is the new behavior?**  
Framework applications can now configure telemetry in startup code with default configuration that includes framework metadata and event tracking.

**Does this PR introduce a breaking change?**  
No

**Other information?**  
This PR addresses TELE-205 by integrating telemetry into the Fusion Framework configurator. The changes include:

* Adding TelemetryModule to the framework core
* Default telemetry configuration with framework metadata
* Event prefixing for framework-specific events
* Public API for custom telemetry configuration
* Added tests for FrameworkConfigurator event prefixing and telemetry integration

Dependencies:  
This PR depends on #3490 which enables core telemetry integration.

closes: #3491

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - [x] _I have validated included files_
  - [x] _My code does not generate new linting warnings_
  - [x] _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).