### PR TITLE
feat: enhance telemetry module with async initialization support

### DIFF
--- a/.changeset/module-telemetry-added.md
+++ b/.changeset/module-telemetry-added.md
@@ -10,5 +10,7 @@ Add new telemetry module for collecting and sending telemetry data.
 - Provide `TelemetryProvider` and `TelemetryConfigurator` for module integration
 - Include comprehensive test coverage for all components
 - Support custom metadata resolution and telemetry item merging
+- async initialization support with `initialize()` method on providers and adapters
+- Enhanced error handling in measurement disposal and metadata resolution
 
 Resolves #3483

--- a/packages/modules/telemetry/package.json
+++ b/packages/modules/telemetry/package.json
@@ -17,6 +17,10 @@
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/types/utils/index.d.ts"
     },
+    "./adapter": {
+      "import": "./dist/esm/adapters/index.js",
+      "types": "./dist/types/adapters/index.d.ts"
+    },
     "./application-insights-adapter": {
       "import": "./dist/esm/adapters/application-insights/index.js",
       "types": "./dist/types/adapters/application-insights/index.d.ts"

--- a/packages/modules/telemetry/src/Measurement.ts
+++ b/packages/modules/telemetry/src/Measurement.ts
@@ -145,7 +145,12 @@ export class Measurement implements IMeasurement {
    */
   [Symbol.dispose]() {
     if (!this.#measured) {
-      this.measure();
+      try {
+        this.measure();
+      } catch {
+        // Silently handle errors during disposal to ensure cleanup always completes
+        // The measurement failure should not prevent proper resource disposal
+      }
     }
   }
 }

--- a/packages/modules/telemetry/src/TelemetryAdapter.ts
+++ b/packages/modules/telemetry/src/TelemetryAdapter.ts
@@ -93,6 +93,10 @@ export abstract class BaseTelemetryAdapter implements ITelemetryAdapter {
    * without performing any initialization. It calls the protected `_initialize` method which
    * subclasses can override to provide custom initialization logic.
    *
+   * TODO: Consider changing return type from Promise<void> to Promise<TelemetryItem[]>
+   * to allow adapters to return telemetry items (errors/warnings) that occurred during
+   * initialization, eliminating the chicken-and-egg problem with reporting init errors.
+   *
    * @returns A promise that resolves when initialization is complete.
    * @sealed
    */

--- a/packages/modules/telemetry/src/TelemetryAdapter.ts
+++ b/packages/modules/telemetry/src/TelemetryAdapter.ts
@@ -9,10 +9,13 @@ import type { TelemetryItem } from './types.js';
  * @property identifier - A unique string that identifies the telemetry adapter.
  * @method processItem - Processes a given telemetry item.
  * @param item - The telemetry item to be processed.
+ * @method initialize - Optional asynchronous initialization method for adapters that require setup.
+ * @returns A promise that resolves when initialization is complete.
  */
-export interface TelemetryAdapter {
+export interface ITelemetryAdapter {
   readonly identifier: string;
   processItem(item: TelemetryItem): void;
+  initialize(): Promise<void>;
 }
 
 /**
@@ -22,7 +25,7 @@ export interface TelemetryAdapter {
  * Subclasses must implement the `_processItem` method to define how telemetry items are handled.
  *
  * @template TelemetryItem - The type representing a telemetry item.
- * @implements {TelemetryAdapter}
+ * @implements {ITelemetryAdapter}
  *
  * @remarks
  * - The adapter can be identified by a unique `identifier`.
@@ -35,9 +38,10 @@ export interface TelemetryAdapter {
  *   }
  * }
  */
-export abstract class BaseTelemetryAdapter implements TelemetryAdapter {
+export abstract class BaseTelemetryAdapter implements ITelemetryAdapter {
   #identifier: string;
   #filter?: (item: TelemetryItem) => boolean;
+  #initialized = false;
 
   /**
    * Gets the unique identifier for this telemetry adapter instance.
@@ -68,10 +72,55 @@ export abstract class BaseTelemetryAdapter implements TelemetryAdapter {
    * @param item - The telemetry item to be processed.
    */
   public processItem(item: TelemetryItem): void {
+    // If the adapter is not initialized, do not process the item
+    if (!this.#initialized) {
+      return;
+    }
+
+    // If a filter is defined and the item does not pass the filter, do not process the item
     if (this.#filter && !this.#filter(item)) {
       return;
     }
+
+    // Delegate the processing of the item to the internal `_processItem` method
     this._processItem(item);
+  }
+
+  /**
+   * Initializes the telemetry adapter asynchronously.
+   *
+   * This method can only be called once. Subsequent calls will return immediately
+   * without performing any initialization. It calls the protected `_initialize` method which
+   * subclasses can override to provide custom initialization logic.
+   *
+   * @returns A promise that resolves when initialization is complete.
+   * @sealed
+   */
+  public async initialize(): Promise<void> {
+    // If the adapter is already initialized, do not initialize it again
+    if (this.#initialized) {
+      return;
+    }
+
+    // Initialize the adapter
+    await this._initialize();
+
+    // Mark the adapter as initialized
+    this.#initialized = true;
+  }
+
+  /**
+   * Protected initialization method that subclasses can override.
+   *
+   * This method is called only once during the adapter's lifetime.
+   * Subclasses should override this method to perform any necessary async setup.
+   * The base implementation is a no-op for adapters that don't need initialization.
+   *
+   * @returns A promise that resolves when initialization is complete.
+   * @protected
+   */
+  protected async _initialize(): Promise<void> {
+    // Default implementation - no-op for adapters that don't need initialization
   }
 
   protected abstract _processItem(item: TelemetryItem): void;

--- a/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
@@ -1,6 +1,7 @@
-import type { MetadataExtractor, TelemetryAdapter, TelemetryItem } from './types.js';
-import type { ITelemetryProvider } from './TelemetryProvider.interface.js';
 import type { ObservableInput } from 'rxjs';
+import type { MetadataExtractor, TelemetryItem } from './types.js';
+import type { ITelemetryProvider } from './TelemetryProvider.interface.js';
+import type { ITelemetryAdapter } from './TelemetryAdapter.js';
 
 /**
  * Configuration options for setting up telemetry within the application.
@@ -12,7 +13,7 @@ import type { ObservableInput } from 'rxjs';
  * @property items$ - Optional observable input stream of telemetry items to be processed.
  */
 export type TelemetryConfig = {
-  adapters?: TelemetryAdapter[];
+  adapters?: ITelemetryAdapter[];
   parent?: ITelemetryProvider;
   metadata?: MetadataExtractor;
   defaultScope?: string[];
@@ -41,7 +42,7 @@ export interface ITelemetryConfigurator {
    * @param adapter - The telemetry adapter instance to register.
    * @returns The configurator instance for method chaining.
    */
-  setAdapter(adapter: TelemetryAdapter): this;
+  setAdapter(adapter: ITelemetryAdapter): this;
 
   /**
    * Sets the metadata to be associated with telemetry events.

--- a/packages/modules/telemetry/src/TelemetryProvider.ts
+++ b/packages/modules/telemetry/src/TelemetryProvider.ts
@@ -1,4 +1,4 @@
-import { from, ObservableInput, Subject, type Observable, type Subscription } from 'rxjs';
+import { from, type ObservableInput, Subject, type Observable, type Subscription } from 'rxjs';
 import type { z } from 'zod';
 
 import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';

--- a/packages/modules/telemetry/src/TelemetryProvider.ts
+++ b/packages/modules/telemetry/src/TelemetryProvider.ts
@@ -1,4 +1,4 @@
-import { from, Subject, type Observable, type Subscription } from 'rxjs';
+import { from, ObservableInput, Subject, type Observable, type Subscription } from 'rxjs';
 import type { z } from 'zod';
 
 import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
@@ -6,13 +6,9 @@ import type { IEventModuleProvider } from '@equinor/fusion-framework-module-even
 
 import type { TelemetryConfig } from './TelemetryConfigurator.interface.js';
 import { version } from './version.js';
-import { TelemetryType } from './static.js';
-import type {
-  MetadataExtractor,
-  TelemetryAdapter,
-  TelemetryAdapters,
-  TelemetryItem,
-} from './types.js';
+import { TelemetryType, TelemetryItemNames } from './static.js';
+import type { ITelemetryAdapter } from './TelemetryAdapter.js';
+import type { MetadataExtractor, TelemetryAdapters, TelemetryItem } from './types.js';
 import {
   TelemetryExceptionSchema,
   TelemetryCustomEventSchema,
@@ -60,7 +56,10 @@ export class TelemetryProvider
   implements ITelemetryProvider
 {
   #items: Subject<TelemetryItem> = new Subject();
-  #adapters: Array<TelemetryAdapter>;
+
+  #initialized = false;
+
+  #adapters: ITelemetryAdapter[] = [];
 
   #defaultScope: string[];
 
@@ -68,6 +67,13 @@ export class TelemetryProvider
 
   get items(): Observable<TelemetryItem> {
     return this.#items.asObservable();
+  }
+
+  /**
+   * Returns true if the provider has been initialized.
+   */
+  get initialized(): boolean {
+    return this.#initialized;
   }
 
   #metadata?: MetadataExtractor;
@@ -83,48 +89,88 @@ export class TelemetryProvider
     this.#adapters = config?.adapters ?? [];
     this.#metadata = config?.metadata;
     this.#defaultScope = config?.defaultScope ?? [];
-
     this.#eventProvider = deps?.event;
-
-    this._initialize(config.parent);
-
-    if (config.items$) {
-      this._addTeardown(
-        from(config.items$).subscribe((item) => {
-          this.track(item);
-        }),
-      );
-    }
   }
 
   /**
-   * Initializes the telemetry provider by setting up necessary connections and teardown logic.
+   * Initializes the telemetry provider with adapters, parent provider, and optional initial items.
    *
-   * @param parent Optional parent telemetry provider to which telemetry data can be relayed.
+   * This method sets up the provider for operation by:
+   * 1. Storing the provided adapters
+   * 2. Initializing all adapters that support async initialization (failures are logged but don't prevent initialization)
+   * 3. Setting up subscriptions for telemetry processing
+   * 4. Handling initial telemetry items if provided
    *
-   * - Connects adapters to process emitted telemetry items.
-   * - Emits telemetry items as events if an event provider is available.
-   * - Relays telemetry data to the parent provider if provided.
-   * - Ensures the internal subject is completed when the provider is destroyed.
-   *
-   * @protected
+   * @param args - Initialization arguments
+   * @param args.adapters - Array of telemetry adapters to use
+   * @param args.parent - Optional parent telemetry provider for relaying data
+   * @param args.initialItems - Optional observable of initial telemetry items to process
+   * @returns A promise that resolves when initialization is complete
    */
-  protected _initialize(parent?: ITelemetryProvider): void {
+  public async initialize(args?: {
+    parent?: ITelemetryProvider;
+    initialItems?: ObservableInput<TelemetryItem>;
+  }): Promise<void> {
+    const { parent, initialItems } = args ?? {};
+
+    // Mark as initialized early to allow adapter connections
+    this.#initialized = true;
+
+    // Initialize all adapters that support async initialization
+    await this._initializeAdapters();
+
     // Connect adapters to the telemetry items, processing each item as it is emitted
     this._addTeardown(this._connectAdapters());
+
+    // If a parent telemetry provider is provided, relay telemetry data to it
+    if (parent) {
+      this._addTeardown(this._relayTelemetryData(parent));
+    }
 
     // Emit telemetry items as events if an event provider is available
     this._addTeardown(this.#items.subscribe(this._dispatchEntityEvent.bind(this)));
 
-    if (parent) {
-      // If a parent telemetry provider is provided, relay telemetry data to it
-      this._addTeardown(this._relayTelemetryData(parent));
+    // Handle initial telemetry items if provided
+    if (initialItems) {
+      this._addTeardown(
+        from(initialItems).subscribe((item) => {
+          this.track(item);
+        }),
+      );
     }
 
     // Ensure the subject is completed when the provider is destroyed
     this._addTeardown(() => {
       this.#items.complete();
     });
+  }
+
+  /**
+   * Initializes all telemetry adapters that support async initialization.
+   * Uses Promise.allSettled to ensure all adapters attempt initialization,
+   * with individual error reporting for any failures.
+   * Subclasses can override this method to customize adapter initialization behavior.
+   *
+   * @protected
+   */
+  protected async _initializeAdapters(): Promise<void> {
+    // Initialize all adapters, do it in parallel
+    const initializationPromises = this.#adapters.map((adapter) => adapter.initialize());
+
+    // Wait for all adapters to settle (either resolve or reject)
+    const results = await Promise.allSettled(initializationPromises);
+
+    // Check each result and dispatch errors for failed initializations
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        const adapter = this.#adapters[index];
+        this._dispatchError(
+          new Error(`Failed to initialize telemetry adapter "${adapter.identifier}"`, {
+            cause: result.reason,
+          }),
+        );
+      }
+    }
   }
 
   /**
@@ -136,12 +182,15 @@ export class TelemetryProvider
    * @protected
    */
   protected _connectAdapters(): Subscription {
+    if (!this.#initialized) {
+      throw new Error('TelemetryProvider is not initialized');
+    }
     return this.#items.subscribe((item) => {
       // Iterate through all registered adapters
       for (const adapter of this.#adapters) {
         try {
           // Let the adapter process the telemetry item
-          adapter.processItem(item);
+          Promise.resolve(adapter.processItem(item));
         } catch (error) {
           // If processing fails, dispatch an error event
           this._dispatchError(
@@ -235,7 +284,9 @@ export class TelemetryProvider
     const mergedItem = mergeTelemetryItem(item, {
       scope: this.#defaultScope,
     });
-    if (this.#metadata) {
+
+    // Skip metadata application for TelemetryMetadataError items to prevent infinite recursion
+    if (this.#metadata && mergedItem.name !== TelemetryItemNames.MetadataError) {
       applyMetadata(this.#metadata, {
         modules: this.#modules,
         item: mergedItem,
@@ -244,7 +295,7 @@ export class TelemetryProvider
         this.#items.next(nextItem);
       });
     } else {
-      // If no metadata extractor is provided, emit the item directly
+      // If no metadata extractor is provided or item is TelemetryMetadataError, emit directly
       this.#items.next(mergedItem);
     }
   }

--- a/packages/modules/telemetry/src/__tests__/TelemetryConfigurator.test.ts
+++ b/packages/modules/telemetry/src/__tests__/TelemetryConfigurator.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TelemetryConfigurator } from '../TelemetryConfigurator.js';
-import type { TelemetryAdapter } from '../types.js';
+import type { ITelemetryAdapter } from '../TelemetryAdapter.js';
 import type { ITelemetryProvider } from '../TelemetryProvider.interface.js';
 import type { ConfigBuilderCallbackArgs } from '@equinor/fusion-framework-module';
 import { lastValueFrom } from 'rxjs';
 import { applyMetadata } from '../utils/resolve-metadata.js';
 import { TelemetryLevel, TelemetryType } from '../static.js';
 
-function createAdapter(id: string): TelemetryAdapter {
+function createAdapter(id: string): ITelemetryAdapter {
   return {
     identifier: id,
     processItem: vi.fn(),
+    initialize: vi.fn(),
   };
 }
 

--- a/packages/modules/telemetry/src/adapters/application-insights/adapter.ts
+++ b/packages/modules/telemetry/src/adapters/application-insights/adapter.ts
@@ -64,7 +64,11 @@ export class ApplicationInsightsAdapter extends BaseTelemetryAdapter {
       try {
         this.#client.addPlugin(plugin);
       } catch (error) {
-        // Log plugin addition failure but don't fail initialization
+        // EXCEPTION: Using console.warn instead of telemetry mechanism due to chicken-and-egg problem.
+        // At construction time, the adapter is not yet initialized, so it cannot use its own telemetry
+        // system to report errors. The TelemetryProvider initializes adapters after construction,
+        // but plugin errors occur during construction. This is a rare exception to the framework's
+        // telemetry error handling pattern, justified by the initialization timing constraint.
         console.warn(
           `Failed to add Application Insights plugin: ${
             error instanceof Error ? error.message : String(error)

--- a/packages/modules/telemetry/src/adapters/console/adapter.ts
+++ b/packages/modules/telemetry/src/adapters/console/adapter.ts
@@ -1,11 +1,12 @@
 import {
-  BaseTelemetryAdapter,
   TelemetryType,
   TelemetryLevel,
   type TelemetryItem,
   type TelemetryException,
   type TelemetryMetric,
 } from '@equinor/fusion-framework-module-telemetry';
+
+import { BaseTelemetryAdapter } from '@equinor/fusion-framework-module-telemetry/adapter';
 
 /**
  * Configuration options for the ConsoleAdapter

--- a/packages/modules/telemetry/src/adapters/index.ts
+++ b/packages/modules/telemetry/src/adapters/index.ts
@@ -1,0 +1,4 @@
+export {
+  BaseTelemetryAdapter,
+  type ITelemetryAdapter,
+} from '../TelemetryAdapter.js';

--- a/packages/modules/telemetry/src/index.ts
+++ b/packages/modules/telemetry/src/index.ts
@@ -10,8 +10,6 @@ export type {
 
 export type { ITelemetryProvider } from './TelemetryProvider.interface.js';
 
-export { BaseTelemetryAdapter, type TelemetryAdapter } from './TelemetryAdapter.js';
-
 export { TelemetryLevel, TelemetryType } from './static.js';
 
 export type {

--- a/packages/modules/telemetry/src/module.ts
+++ b/packages/modules/telemetry/src/module.ts
@@ -2,6 +2,8 @@ import type { Module } from '@equinor/fusion-framework-module';
 
 import type { EventModule } from '@equinor/fusion-framework-module-event';
 
+import { from } from 'rxjs';
+
 import type { ITelemetryProvider } from './TelemetryProvider.interface.js';
 import type { ITelemetryConfigurator } from './TelemetryConfigurator.interface.js';
 import { TelemetryConfigurator } from './TelemetryConfigurator.js';
@@ -48,7 +50,12 @@ export const module = {
   initialize: async (args): Promise<ITelemetryProvider> => {
     const config = await (args.config as TelemetryConfigurator).createConfigAsync(args);
     const event = args.hasModule('event') ? await args.requireInstance('event') : undefined;
-    return new TelemetryProvider(config, { event });
+    const provider = new TelemetryProvider(config, { event });
+    await provider.initialize({
+      parent: config.parent,
+      initialItems: config.items$,
+    });
+    return provider;
   },
 } satisfies TelemetryModule;
 

--- a/packages/modules/telemetry/src/static.ts
+++ b/packages/modules/telemetry/src/static.ts
@@ -49,3 +49,11 @@ export enum TelemetryScope {
   Framework = 'framework',
   Application = 'application',
 }
+
+/**
+ * Standard telemetry item names for common error types.
+ */
+export const TelemetryItemNames = {
+  /** Error name used when metadata extraction fails */
+  MetadataError: 'TelemetryMetadataError',
+} as const;

--- a/packages/modules/telemetry/src/utils/resolve-metadata.ts
+++ b/packages/modules/telemetry/src/utils/resolve-metadata.ts
@@ -1,6 +1,6 @@
 import { toObservable } from '@equinor/fusion-observable';
 
-import { TelemetryType } from '../static.js';
+import { TelemetryType, TelemetryItemNames } from '../static.js';
 import type { MetadataExtractor, MetadataExtractorArgs, TelemetryItem } from '../types.js';
 
 import { merge, of, type Observable } from 'rxjs';
@@ -45,7 +45,7 @@ export const applyMetadata = (
     catchError((error) => {
       const errorItem = TelemetryExceptionSchema.parse({
         type: TelemetryType.Exception,
-        name: 'TelemetryMetadataError',
+        name: TelemetryItemNames.MetadataError,
         exception: error,
         properties: {
           sourceMetricName: args.item.name,


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
This PR introduces enhancements to the core telemetry module by adding comprehensive async initialization support.

<!-- What is the current behavior? -->
The telemetry module currently initializes synchronously, which can block the application startup and doesn't handle adapter initialization failures gracefully.

<!-- What is the new behavior? -->
The telemetry module now supports async initialization with:
- Async `initialize()` method on TelemetryProvider with Promise.allSettled error handling
- `initialized` property to track initialization state
- Individual error reporting for failed adapters without stopping the entire initialization process
- Enhanced BaseTelemetryAdapter with async initialization capabilities
- Application Insights adapter with async client setup

<!-- Does this PR introduce a breaking change? -->
No, this is a backward-compatible enhancement. Existing synchronous usage continues to work.

<!-- Other information? -->
Co-Pilot raised some concerns after [initial telemetry](https://github.com/equinor/fusion-framework/pull/3488), this PR addresses those issues 👌🏻

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).