### PR TITLE
feat: add buffer to ReplaySubject for telemetry event replay

### DIFF
--- a/packages/modules/module/src/configurator.ts
+++ b/packages/modules/module/src/configurator.ts
@@ -158,7 +158,11 @@ export class ModulesConfigurator<TModules extends Array<AnyModule> = Array<AnyMo
     return version;
   }
 
-  #event$: ReplaySubject<ModuleEvent> = new ReplaySubject<ModuleEvent>();
+  // Buffer up to 100 events to prevent memory leaks while ensuring telemetry can capture
+  // module events during configuration. Telemetry attaches via mapConfiguratorEvents and
+  // needs to replay events that occurred before it was ready.
+  // Memory usage: ~24KB for 100 events at ~240 bytes each.
+  #event$: ReplaySubject<ModuleEvent> = new ReplaySubject<ModuleEvent>(100);
   public get event$(): IModulesConfigurator<TModules, TRef>['event$'] {
     return this.#event$.asObservable();
   }


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
Feature enhancement - adds buffer size to ReplaySubject to prevent memory leaks

<!-- What is the current behavior? -->
The ReplaySubject in ModulesConfigurator has unlimited buffer, potentially causing memory leaks

<!-- What is the new behavior? -->
ReplaySubject now buffers up to 100 events to prevent memory leaks while ensuring telemetry can capture all events during configuration

<!-- Does this PR introduce a breaking change? -->
No

<!-- Other information? -->
This enables telemetry to reliably capture module events that occur during configuration, even if telemetry attaches after some events have already been emitted.

closes:

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - [x] _I have validated included files_
  - [x] _My code does not generate new linting warnings_
  - [x] _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).