### PR TITLE
feat(vite-plugins-spa): add comprehensive telemetry integration to SPA bootstrap and service worker

### DIFF
--- a/.changeset/vite-plugin-spa-telemetry-integration.md
+++ b/.changeset/vite-plugin-spa-telemetry-integration.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Add comprehensive telemetry integration to SPA bootstrap and service worker.
+
+- Enable telemetry in SPA bootstrap with ConsoleAdapter
+- Track bootstrap performance for portal loading operations
+- Monitor service worker registration and token acquisition
+- Include user metadata and portal configuration in telemetry
+- Track exceptions and errors throughout SPA lifecycle
+
+resolves: [#3487](https://github.com/equinor/fusion-framework/issues/3487)

--- a/packages/vite-plugins/spa/package.json
+++ b/packages/vite-plugins/spa/package.json
@@ -46,11 +46,11 @@
     "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
-    "@equinor/fusion-framework-module": "workspace:^",
-    "@equinor/fusion-framework-module-http": "workspace:^",
-    "@equinor/fusion-framework-module-msal": "workspace:^",
-    "@equinor/fusion-framework-module-service-discovery": "workspace:^",
-    "@equinor/fusion-framework-module-telemetry": "workspace:^",
+    "@equinor/fusion-framework-module": "workspace:*",
+    "@equinor/fusion-framework-module-http": "workspace:*",
+    "@equinor/fusion-framework-module-msal": "workspace:*",
+    "@equinor/fusion-framework-module-service-discovery": "workspace:*",
+    "@equinor/fusion-framework-module-telemetry": "workspace:*",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/vite-plugins/spa/package.json
+++ b/packages/vite-plugins/spa/package.json
@@ -46,10 +46,11 @@
     "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
-    "@equinor/fusion-framework-module": "workspace:*",
-    "@equinor/fusion-framework-module-http": "workspace:*",
-    "@equinor/fusion-framework-module-msal": "workspace:*",
-    "@equinor/fusion-framework-module-service-discovery": "workspace:*",
+    "@equinor/fusion-framework-module": "workspace:^",
+    "@equinor/fusion-framework-module-http": "workspace:^",
+    "@equinor/fusion-framework-module-msal": "workspace:^",
+    "@equinor/fusion-framework-module-service-discovery": "workspace:^",
+    "@equinor/fusion-framework-module-telemetry": "workspace:^",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -104,7 +104,7 @@ enableTelemetry(configurator, {
     level: TelemetryLevel.Information,
   });
 
-  measurement.clone().resolve(registerServiceWorker(ref), {
+  await measurement.clone().resolve(registerServiceWorker(ref), {
     data: {
       level: TelemetryLevel.Debug,
       name: 'bootstrap::registerServiceWorker',

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -6,7 +6,17 @@ import {
   enableServiceDiscovery,
   type ServiceDiscoveryModule,
 } from '@equinor/fusion-framework-module-service-discovery';
+
+import {
+  enableTelemetry,
+  TelemetryLevel,
+  type TelemetryModule,
+} from '@equinor/fusion-framework-module-telemetry';
+import { ConsoleAdapter } from '@equinor/fusion-framework-module-telemetry/console-adapter';
+
 import { registerServiceWorker } from './register-service-worker.js';
+
+import { version } from '../version.js';
 
 // @todo - add type for portal manifest when available
 type PortalManifest = {
@@ -54,12 +64,52 @@ enableMSAL(configurator, (builder) => {
   builder.setRequiresAuth(Boolean(import.meta.env.FUSION_SPA_MSAL_REQUIRES_AUTH));
 });
 
+enableTelemetry(configurator, {
+  attachConfiguratorEvents: true,
+  configure: (builder) => {
+    builder.setAdapter(new ConsoleAdapter());
+    builder.setMetadata(({ modules }) => {
+      const metadata = {
+        fusion: {
+          spa: {
+            version,
+          },
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: we need to use any here to allow dynamic properties
+      } as Record<string, any>;
+      if (modules?.auth) {
+        metadata.fusion.user = {
+          id: modules.auth.defaultAccount?.homeAccountId,
+          name: modules.auth.defaultAccount?.name,
+          email: modules.auth.defaultAccount?.username,
+        };
+      }
+      return metadata;
+    });
+  },
+});
+
 (async () => {
   // initialize the framework - this will create the framework instance and configure the modules
-  const ref = await configurator.initialize<[ServiceDiscoveryModule, HttpModule, MsalModule]>();
+  const ref =
+    await configurator.initialize<
+      [ServiceDiscoveryModule, HttpModule, MsalModule, TelemetryModule]
+    >();
+
+  const telemetry = ref.telemetry;
 
   // attach service discovery to the framework - append auth token to configured endpoints
-  await registerServiceWorker(ref);
+  using measurement = telemetry.measure({
+    name: 'bootstrap',
+    level: TelemetryLevel.Information,
+  });
+
+  measurement.clone().resolve(registerServiceWorker(ref), {
+    data: {
+      level: TelemetryLevel.Debug,
+      name: 'bootstrap::registerServiceWorker',
+    },
+  });
 
   // create a client for the portal service - this is used to fetch the portal manifest
   const portalClient = await ref.serviceDiscovery.createClient('portal-config');
@@ -67,11 +117,34 @@ enableMSAL(configurator, (builder) => {
   // fetch the portal manifest - this is used to load the portal template
   const portalId = import.meta.env.FUSION_SPA_PORTAL_ID;
   const portalTag = import.meta.env.FUSION_SPA_PORTAL_TAG ?? 'latest';
-  const portal_manifest = await portalClient.json<PortalManifest>(
-    `/portals/${portalId}@${portalTag}`,
-  );
+  const portal_manifest = await measurement
+    .clone()
+    .resolve(portalClient.json<PortalManifest>(`/portals/${portalId}@${portalTag}`), {
+      data: (manifest: PortalManifest) => ({
+        name: 'bootstrap::loadPortalManifest',
+        level: TelemetryLevel.Debug,
+        properties: {
+          portalId,
+          portalTag,
+          templateEntry: manifest.build.templateEntry,
+          manifestVersion: manifest.build.config?.version,
+          assetPath: manifest.build.assetPath,
+        },
+      }),
+    });
 
-  const portal_config = await portalClient.json(`/portals/${portalId}@${portalTag}/config`);
+  const portal_config = await measurement
+    .clone()
+    .resolve(portalClient.json(`/portals/${portalId}@${portalTag}/config`), {
+      data: {
+        name: 'bootstrap::loadPortalConfig',
+        level: TelemetryLevel.Debug,
+        properties: {
+          portalId,
+          portalTag,
+        },
+      },
+    });
 
   // create a entrypoint for the portal - this is used to render the portal
   const el = document.createElement('div');
@@ -84,8 +157,22 @@ enableMSAL(configurator, (builder) => {
 
   // @todo: should test if the entrypoint is external or internal
   // @todo: add proper return type
-  const { render } =
-    await importWithoutVite<Promise<{ render: (...args: unknown[]) => void }>>(portalEntryPoint);
+  const { render } = await measurement
+    .clone()
+    .resolve(
+      importWithoutVite<Promise<{ render: (...args: unknown[]) => void }>>(portalEntryPoint),
+      {
+        data: {
+          name: 'bootstrap::loadPortalSourceCode',
+          level: TelemetryLevel.Debug,
+          properties: {
+            portalId,
+            portalTag,
+            entryPoint: portalEntryPoint,
+          },
+        },
+      },
+    );
 
   // render the portal - this will load the portal template and render it
   render(el, { ref, manifest: portal_manifest, config: portal_config });

--- a/packages/vite-plugins/spa/src/html/register-service-worker.ts
+++ b/packages/vite-plugins/spa/src/html/register-service-worker.ts
@@ -1,16 +1,30 @@
 import type { ModulesInstance } from '@equinor/fusion-framework-module';
 import type { MsalModule } from '@equinor/fusion-framework-module-msal';
+import { TelemetryLevel, type TelemetryModule } from '@equinor/fusion-framework-module-telemetry';
 
-export async function registerServiceWorker(framework: ModulesInstance<[MsalModule]>) {
+export async function registerServiceWorker(
+  framework: ModulesInstance<[MsalModule, TelemetryModule]>,
+) {
+  const telemetry = framework.telemetry;
   if ('serviceWorker' in navigator === false) {
-    console.warn('Service workers are not supported in this browser.');
-    return;
+    const exception = new Error('Service workers are not supported in this browser.');
+    exception.name = 'ServiceWorkerNotSupported';
+    telemetry.trackException({
+      name: `registerServiceWorker.${exception.name}`,
+      exception,
+    });
+    throw exception;
   }
 
   const resourceConfigs = import.meta.env.FUSION_SPA_SERVICE_WORKER_RESOURCES;
   if (!resourceConfigs) {
-    console.warn('Service worker config is not defined.');
-    return;
+    const exception = new Error('Service worker config is not defined.');
+    exception.name = 'ServiceWorkerConfigNotDefined';
+    telemetry.trackException({
+      name: `registerServiceWorker.${exception.name}`,
+      exception,
+    });
+    throw exception;
   }
 
   /**
@@ -34,14 +48,19 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
           // extract scopes from the event data
           const scopes = event.data.scopes as string[];
           if (!scopes || !Array.isArray(scopes)) {
-            throw new Error('Invalid scopes provided');
+            const error = new Error('Invalid scopes provided');
+            error.name = 'InvalidScopesProvided';
+            throw error;
           }
 
           // request a token from the MSAL module
           const token = await framework.auth.acquireToken({ scopes });
 
           if (!token) {
-            throw new Error('Failed to acquire token');
+            const error = new Error('Failed to acquire token');
+            error.name = 'FailedToAcquireToken';
+
+            throw error;
           }
 
           // send the token back to the service worker
@@ -50,6 +69,11 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
             expiresOn: token.expiresOn?.getTime(),
           });
         } catch (error) {
+          const exception = error as Error;
+          telemetry.trackException({
+            name: `serviceWorker.onMessage.${exception.name}`,
+            exception,
+          });
           event.ports[0].postMessage({
             error: (error as Error).message,
           });
@@ -57,14 +81,26 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
       }
     });
 
-    // register the service worker
+    // register the service worker with telemetry
     // updateViaCache: 'none' ensures the service worker script is always fetched fresh
     // This is important during development to pick up code changes
-    const registration = await navigator.serviceWorker.register('/@fusion-spa-sw.js', {
-      type: 'module',
-      scope: '/',
-      updateViaCache: 'none',
+    using measurement = telemetry.measure({
+      name: 'registerServiceWorker',
+      level: TelemetryLevel.Information,
     });
+    const registration = await measurement.clone().resolve(
+      navigator.serviceWorker.register('/@fusion-spa-sw.js', {
+        type: 'module',
+        scope: '/',
+        updateViaCache: 'none',
+      }),
+      {
+        data: {
+          name: 'registerServiceWorker.register',
+          level: TelemetryLevel.Debug,
+        },
+      },
+    );
 
     // Handle service worker updates/installations
     // If there's a service worker waiting or installing, send config when it activates
@@ -88,7 +124,12 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
     });
 
     // wait for the service worker to be ready
-    const readyRegistration = await navigator.serviceWorker.ready;
+    const readyRegistration = await measurement.clone().resolve(navigator.serviceWorker.ready, {
+      data: {
+        name: 'registerServiceWorker.ready',
+        level: TelemetryLevel.Debug,
+      },
+    });
 
     // ensure we have an active service worker before sending config
     const activeWorker = readyRegistration.active;
@@ -100,27 +141,35 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
     // CRITICAL: Wait for the service worker to become the controller
     // This ensures the service worker can intercept fetch requests
     if (!navigator.serviceWorker.controller) {
-      await new Promise<void>((resolve) => {
-        let checkInterval: NodeJS.Timeout;
+      await measurement.clone().resolve(
+        new Promise<void>((resolve) => {
+          let checkInterval: NodeJS.Timeout;
 
-        const finish = () => {
-          clearInterval(checkInterval);
-          navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
-          resolve();
-        };
+          const finish = () => {
+            clearInterval(checkInterval);
+            navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
+            resolve();
+          };
 
-        const onControllerChange = () => finish();
+          const onControllerChange = () => finish();
 
-        // If controllerchange fires, the service worker has taken control
-        navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
+          // If controllerchange fires, the service worker has taken control
+          navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
 
-        // Polling fallback and timeout to prevent infinite waiting
-        checkInterval = setInterval(() => {
-          if (navigator.serviceWorker.controller) finish();
-        }, 200);
+          // Polling fallback and timeout to prevent infinite waiting
+          checkInterval = setInterval(() => {
+            if (navigator.serviceWorker.controller) finish();
+          }, 200);
 
-        setTimeout(finish, 5000);
-      });
+          setTimeout(finish, 5000);
+        }),
+        {
+          data: {
+            name: 'registerServiceWorker.controllerWait',
+            level: TelemetryLevel.Debug,
+          },
+        },
+      );
     }
 
     // send the config to the active service worker
@@ -131,6 +180,9 @@ export async function registerServiceWorker(framework: ModulesInstance<[MsalModu
       sendConfigToServiceWorker(navigator.serviceWorker.controller);
     }
   } catch (error) {
-    console.error('Service Worker registration failed:', error);
+    telemetry.trackException({
+      name: `registerServiceWorker.${(error as Error).name}`,
+      exception: error as Error,
+    });
   }
 }

--- a/packages/vite-plugins/spa/tsconfig.json
+++ b/packages/vite-plugins/spa/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../modules/service-discovery"
     },
     {
+      "path": "../../modules/telemetry"
+    },
+    {
       "path": "../../modules/services"
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,17 +2022,20 @@ importers:
         version: 4.6.2
     devDependencies:
       '@equinor/fusion-framework-module':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../modules/module
       '@equinor/fusion-framework-module-http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../modules/http
       '@equinor/fusion-framework-module-msal':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../modules/msal
       '@equinor/fusion-framework-module-service-discovery':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../modules/service-discovery
+      '@equinor/fusion-framework-module-telemetry':
+        specifier: workspace:^
+        version: link:../../modules/telemetry
       '@rollup/plugin-commonjs':
         specifier: ^28.0.3
         version: 28.0.6(rollup@4.52.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,19 +2022,19 @@ importers:
         version: 4.6.2
     devDependencies:
       '@equinor/fusion-framework-module':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../modules/module
       '@equinor/fusion-framework-module-http':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../modules/http
       '@equinor/fusion-framework-module-msal':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../modules/msal
       '@equinor/fusion-framework-module-service-discovery':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../modules/service-discovery
       '@equinor/fusion-framework-module-telemetry':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../modules/telemetry
       '@rollup/plugin-commonjs':
         specifier: ^28.0.3


### PR DESCRIPTION
### Why
This PR introduces a **feature** that adds comprehensive telemetry integration to the Vite SPA plugin.

### What is the current behavior?
Currently, the SPA plugin does not include any telemetry tracking or monitoring capabilities.

### What is the new behavior?
The SPA plugin now includes:
- Telemetry integration in the bootstrap process with ConsoleAdapter
- Performance tracking for portal loading operations  
- Service worker registration and token acquisition monitoring
- User metadata and portal configuration inclusion in telemetry
- Exception and error tracking throughout the SPA lifecycle

**Does this PR introduce a breaking change?**
No, this is a backward-compatible feature addition.

**Other information?**
This addresses the requirements in issue #3487 for adding telemetry to SPA applications and PWA functionality monitoring.

closes: #3487


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).