### PR TITLE
feat: add telemetry integration and dev server types alignment

### DIFF
--- a/.changeset/dev-portal-telemetry-integration.md
+++ b/.changeset/dev-portal-telemetry-integration.md
@@ -2,11 +2,24 @@
 "@equinor/fusion-framework-dev-portal": minor
 ---
 
-Add telemetry integration to dev portal.
+Add comprehensive telemetry integration to the Fusion Dev Portal.
 
-- Enable telemetry in dev portal configuration
-- Set portal-specific metadata (version, name)
-- Configure telemetry scope and parent relationship
-- Attach configurator events for telemetry tracking
+**New Features:**
+- Enable telemetry tracking for portal usage analytics and monitoring
+- Configure portal-specific metadata including version and name identification
+- Set up telemetry event scoping for portal-specific tracking
+- Attach framework configurator events for comprehensive telemetry coverage
+
+**Technical Implementation:**
+- Integrate `@equinor/fusion-framework-module-telemetry` module
+- Configure telemetry with portal metadata (`type: 'portal-telemetry'`)
+- Set default scope to `['portal']` for event categorization
+- Establish parent-child telemetry relationship for consistent tracking
+- Add TypeScript path references for telemetry module
+
+**Configuration Updates:**
+- Enhanced `config.ts` with detailed telemetry setup and documentation
+- Updated dependency versions to use `workspace:*` for better monorepo compatibility
+- Improved code documentation and developer experience features
 
 resolves: [#3485](https://github.com/equinor/fusion-framework/issues/3485)

--- a/.changeset/typescript-5-9-3-update.md
+++ b/.changeset/typescript-5-9-3-update.md
@@ -1,5 +1,0 @@
----
-"fusion-framework": patch
----
-
-Update TypeScript from 5.9.2 to 5.9.3 for improved performance and bug fixes.

--- a/.changeset/vite-plugin-spa-telemetry-integration.md
+++ b/.changeset/vite-plugin-spa-telemetry-integration.md
@@ -5,9 +5,17 @@
 Add comprehensive telemetry integration to SPA bootstrap and service worker.
 
 - Enable telemetry in SPA bootstrap with ConsoleAdapter
+- Add configurable console logging levels via FUSION_SPA_TELEMETRY_CONSOLE_LEVEL environment variable
 - Track bootstrap performance for portal loading operations
 - Monitor service worker registration and token acquisition
 - Include user metadata and portal configuration in telemetry
 - Track exceptions and errors throughout SPA lifecycle
+- Fix console level filtering logic to properly respect environment variable settings
+
+**Implementation Notes:**
+- Console level filtering defaults to `TelemetryLevel.Information` (1) when env var not set
+- Invalid env var values fallback to logging all telemetry (robust error handling)
+- Backward compatible: existing behavior unchanged when no FUSION_SPA_TELEMETRY_CONSOLE_LEVEL specified
+- Telemetry level mapping: 0=Debug, 1=Information, 2=Warning, 3=Error, 4=Critical
 
 resolves: [#3487](https://github.com/equinor/fusion-framework/issues/3487)

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -1,108 +1,488 @@
 # Fusion Framework Dev Server
 
-This package provides a development server for Fusion Framework applications.
+A powerful development server for Fusion Framework applications, built on Vite with integrated service discovery, API proxying, and portal support.
 
-## Configuration
+## Features
 
-This dev server is focused on Fusion Framework, but under the hood it uses Vite. The configuration is a mix of Vite and Fusion Framework.
-The dev server is created using the `createDevServer` function, which takes a configuration object as an argument.
+- 🚀 **Fast Development**: Powered by Vite for lightning-fast HMR and builds
+- 🔗 **Service Discovery**: Automatic API service discovery and proxying
+- 🏠 **Portal Support**: Built-in portal development with manifest loading
+- 🔧 **API Mocking**: Easy mocking and overriding of API responses
+- 📊 **Telemetry**: Integrated logging and debugging capabilities
+- ⚙️ **Flexible Configuration**: Extensive customization options
 
-The first argument is the generic fusion framework configuration, which simplifies the configuration for the dev server.
+## Quick Start
 
-The second argument is the Vite configuration object, which is optional and overrides the default Vite configuration.
-see [Vite options](https://vite.dev/config/) for more details.
+Here's the minimal setup to get a Fusion Framework dev server running:
 
-> [!TIP]
-const devServer = await createDevServer({
-> You can use the `createDevServerConfig` to generate fusion configuration, then `Vite.mergeConfig` to merge with additional Vite configuration. Then create the dev server with `Vite.createServer`. The `createDevServer` function is a wrapper around this.
+```typescript
+import { createDevServer } from '@equinor/fusion-framework-dev-server';
 
-### Basic Configuration
-
-The dev server requires a basic configuration object to be passed to it.
-
-```ts
 const devServer = await createDevServer({
   spa: {
     templateEnv: {
       portal: {
         id: '@equinor/fusion-framework-dev-portal',
-      }
-      title: 'My Test Dev Server',
+      },
+      title: 'My Fusion App',
       serviceDiscovery: {
-        url: 'https://location.of.your.service.discovery',
-        scopes: ['scope_required'],
+        url: 'https://service-discovery.example.com',
+        scopes: ['api://example.com/user_impersonation'],
       },
       msal: {
-        clientId: 'dev-client-id',
-        tenantId: 'dev-tenant-id',
+        clientId: 'your-client-id',
+        tenantId: 'your-tenant-id',
         redirectUri: '/authentication/login-callback',
         requiresAuth: 'true',
       },
     },
   },
+  api: {
+    serviceDiscoveryUrl: 'https://service-discovery.example.com',
+  },
+});
+
+await devServer.listen();
+devServer.printUrls();
+```
+
+## Configuration
+
+The dev server accepts a configuration object with the following structure:
+
+### SPA Configuration
+
+Configure the Single Page Application environment and template generation:
+
+```typescript
+{
+  spa: {
+    templateEnv: {
+      // Portal configuration
+      portal: {
+        id: 'your-portal-id', // Portal identifier
+      },
+
+      // Application title
+      title: 'My Application',
+
+      // Service discovery settings
+      serviceDiscovery: {
+        url: 'https://service-discovery.example.com',
+        scopes: ['scope1', 'scope2'],
+      },
+
+      // Authentication configuration
+      msal: {
+        clientId: 'your-client-id',
+        tenantId: 'your-tenant-id',
+        redirectUri: '/authentication/login-callback',
+        requiresAuth: 'true', // or 'false'
+      },
+
+      // Optional telemetry configuration (browser console logging)
+      telemetry: {
+        consoleLevel: 1, // 0=Debug, 1=Information, 2=Warning, 3=Error, 4=Critical
+      },
+
+      // Optional service worker configuration
+      serviceWorker: {
+        resources: [
+          {
+            url: '/api',
+            rewrite: '/api-v1',
+            scopes: ['api://example.com/user_impersonation'],
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+### API Configuration
+
+Configure API proxying and service discovery:
+
+```typescript
+{
+  api: {
+    // Required: Service discovery endpoint
+    serviceDiscoveryUrl: 'https://service-discovery.example.com',
+
+    // Optional: Custom service processing
+    processServices: (services, route) => {
+      // Process and return services with routes
+      return processServices(services, route);
+    },
+
+    // Optional: Additional API routes
+    routes: [
+      {
+        match: '/api/custom/*',
+        middleware: (req, res) => {
+          // Custom middleware logic
+          res.end(JSON.stringify({ custom: 'response' }));
+        },
+      },
+    ],
+  },
+}
+```
+
+### Logging Configuration
+
+Configure CLI/server-side logging levels and custom loggers:
+
+```typescript
+{
+  log: {
+    // Optional: CLI log level (0=None, 1=Error, 2=Warning, 3=Info, 4=Debug)
+    level: 3, // Default is Info level
+
+    // Optional: Custom logger instance
+    logger: new ConsoleLogger('my-dev-server'),
+  },
+}
+```
+
+> [!NOTE]
+> **Telemetry vs CLI Logging**: The `telemetry.consoleLevel` controls logging output in the browser console (visible to end users), while `log.level` controls server-side logging in the terminal/command line (visible to developers). These use different logging systems with different level mappings.
+
+### Main Functions
+
+#### `createDevServer(options, overrides?)`
+
+Creates and configures a development server instance.
+
+**Parameters:**
+- `options` (`DevServerOptions`): Configuration object for the dev server
+- `overrides` (`UserConfig`): Optional Vite configuration overrides
+
+**Returns:** `Promise<ViteDevServer>` - Configured Vite development server
+
+**Example:**
+```typescript
+const devServer = await createDevServer(config);
+await devServer.listen();
+```
+
+#### `createDevServerConfig(options, overrides?)`
+
+Creates a Vite configuration object for the dev server.
+
+**Parameters:**
+- `options` (`DevServerOptions`): Configuration object for the dev server
+- `overrides` (`UserConfig`): Optional Vite configuration overrides
+
+**Returns:** `UserConfig` - Vite configuration object
+
+### Utility Functions
+
+#### `processServices(data, args)`
+
+Processes service discovery data and generates proxy routes.
+
+**Parameters:**
+- `data` (`FusionService[]`): Array of services from service discovery
+- `args.route` (`string`): Base route for proxying
+- `args.request` (`IncomingMessage`): HTTP request object
+
+**Returns:** Object with processed services and routes
+
+### Types
+
+#### `DevServerOptions<TEnv>`
+
+Configuration options for the development server.
+
+```typescript
+type DevServerOptions<TEnv extends Partial<FusionTemplateEnv>> = {
+  spa?: {
+    templateEnv: TEnv | TemplateEnvFn<TEnv>;
+  };
+  api: {
+    serviceDiscoveryUrl: string;
+    processServices?: ApiDataProcessor<FusionService[]>;
+    routes?: ApiRoute[];
+  };
+  log?: {
+    level?: number;
+    logger?: ConsoleLogger;
+  };
+};
+```
+
+#### `FusionService`
+
+Represents a service in the Fusion ecosystem.
+
+```typescript
+type FusionService = {
+  key: string;    // Service identifier
+  uri: string;    // Service endpoint URL
+  name: string;   // Human-readable service name
+};
+```
+
+## Examples
+
+### Basic Portal Development
+
+```typescript
+import { createDevServer } from '@equinor/fusion-framework-dev-server';
+
+const devServer = await createDevServer({
+  spa: {
+    templateEnv: {
+      portal: { id: 'my-portal' },
+      title: 'My Portal',
+      serviceDiscovery: {
+        url: 'https://service-discovery.example.com',
+        scopes: ['api://example.com/user_impersonation'],
+      },
+      msal: {
+        clientId: process.env.CLIENT_ID!,
+        tenantId: process.env.TENANT_ID!,
+        redirectUri: '/authentication/login-callback',
+        requiresAuth: 'true',
+      },
+    },
+  },
+  api: {
+    serviceDiscoveryUrl: 'https://service-discovery.example.com',
+  },
+});
+
+await devServer.listen();
+```
+
+### Adding Mock Services
+
+```typescript
+import { createDevServer, processServices } from '@equinor/fusion-framework-dev-server';
+
+const devServer = await createDevServer({
+  spa: { /* ... spa config ... */ },
+  api: {
+    serviceDiscoveryUrl: 'https://service-discovery.example.com',
+    processServices: (data, route) => {
+      const { data: services, routes } = processServices(data, route);
+
+      // Add mock services
+      return {
+        data: services.concat({
+          key: 'mock-api',
+          name: 'Mock API Service',
+          uri: '/mock-api',
+        }),
+        routes: routes.concat({
+          match: '/mock-api/*',
+          middleware: (req, res) => {
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ mock: 'data' }));
+          },
+        }),
+      };
+    },
+  },
 });
 ```
 
-### Adding Service Discovery
+### Custom Vite Configuration
 
-By adding configuration to the `api` object, you can add service discovery to your dev server. This is useful for mocking API requests and setting up routes. see [@equinor/fusion-framework-vite-plugin-api-service](../vite-plugins/api-service/README.md) for more details.
+```typescript
+import { createDevServer } from '@equinor/fusion-framework-dev-server';
+import { defineConfig } from 'vite';
 
-```ts
-createDevServer(
-  {
-    // Adding proxying for service discovery
-    api: {
-      // proxy target for service discovery
-      serviceDiscoveryUrl: 'https://location.of.your/service/discovery',
-      // method for modifying the service discovery response and setting up routes
-      processServices: (dataResponse, route) => {
-        const { data, routes } = processServices(dataResponse, route);
-        return {
-          data: data.concat({
-            key: 'portals',
-            name: 'Portal Service - MOCK',
-            uri: '/@fusion-api/portals',
-          }),
-          routes,
-        };
-      },
+const devServer = await createDevServer(
+  { /* ... dev server config ... */ },
+  defineConfig({
+    server: {
+      port: 3001,
+      host: '0.0.0.0',
     },
-    routes: [ /** add proxy and middleware routes */]
-  }
+    define: {
+      __DEV__: true,
+    },
+  })
 );
 ```
 
 
-## Proxying API Requests
+## Troubleshooting
 
-Sometimes proxy requests need authentication tokens, or need to be rewritten to a different path. The dev server can handle this by using the `serviceWorker` configuration.
+### Common Issues
 
-see [Vite server Proxy](https://vite.dev/config/server-options#server-proxy) for more details for setting up the proxy.
+#### "Cannot find module '@equinor/fusion-framework-dev-server'"
 
-```ts
-createDevServer(
-  {
-    ... // add basic configuration here
+**Solution:** Make sure the package is installed and you're using the correct import path.
 
-    // intercepting requests to /api and rewriting them to /api-v1 and adding auth token
-    serviceWorker: {
-      resources: [
-        {
-          url: '/api',
-          rewrite: '/api-v1',
-          scopes: ['scope1', 'scope2'],
-        },
-      ],
-    }
-  }, 
-  {
-    proxy: {
-      '/api': {
-        target: 'https://api.example.com',
-        changeOrigin: true,
-        pathRewrite: { '^/api': '' },
+```bash
+pnpm add -D @equinor/fusion-framework-dev-server
+```
+
+#### Service Discovery Connection Failed
+
+**Problem:** The dev server can't connect to the service discovery endpoint.
+
+**Solutions:**
+1. Check that `serviceDiscoveryUrl` is correct and accessible
+2. Verify network connectivity to the service discovery endpoint
+3. Check for authentication requirements
+
+#### Portal Manifest Not Loading
+
+**Problem:** Portal configuration isn't loading properly.
+
+**Solutions:**
+1. Verify the portal ID is correct in the `spa.templateEnv.portal.id` field
+2. Check that the portal service is available and responding
+3. Ensure proper authentication is configured
+
+#### API Routes Not Working
+
+**Problem:** Custom API routes or service proxying isn't functioning.
+
+**Solutions:**
+1. Check the `routes` configuration in the `api` section
+2. Verify route patterns match the expected request paths
+3. Ensure middleware functions are properly implemented
+4. Check for conflicts with existing routes
+
+#### Authentication Issues
+
+**Problem:** MSAL authentication isn't working.
+
+**Solutions:**
+1. Verify `clientId` and `tenantId` are correct
+2. Check that `redirectUri` matches your application configuration
+3. Ensure the required scopes are properly configured
+4. Check browser console for authentication errors
+
+### Debug Logging
+
+Enable debug logging to troubleshoot issues:
+
+#### CLI/Server-Side Debug Logging
+```typescript
+const devServer = await createDevServer({
+  // ... config
+  log: {
+    level: 4, // Debug level (0=None, 1=Error, 2=Warning, 3=Info, 4=Debug)
+  },
+});
+```
+
+#### Browser Console Telemetry Logging
+```typescript
+{
+  spa: {
+    templateEnv: {
+      // ... other config
+      telemetry: {
+        consoleLevel: 0, // Debug level (0=Debug, 1=Information, 2=Warning, 3=Error, 4=Critical)
       },
     },
+  },
+}
+```
+
+## Advanced Usage
+
+### Custom Service Processing
+
+For advanced service discovery manipulation:
+
+```typescript
+import { createDevServer, processServices } from '@equinor/fusion-framework-dev-server';
+
+const devServer = await createDevServer({
+  api: {
+    serviceDiscoveryUrl: 'https://service-discovery.example.com',
+    processServices: (services, route) => {
+      const { data, routes } = processServices(services, route);
+
+      // Filter out development-only services in production
+      const filteredData = data.filter(service =>
+        process.env.NODE_ENV !== 'production' || !service.key.includes('dev')
+      );
+
+      // Add custom routes for specific services
+      const customRoutes = routes.map(route => ({
+        ...route,
+        // Add custom headers or modify proxy behavior
+      }));
+
+      return { data: filteredData, routes: customRoutes };
+    },
+  },
+});
+```
+
+### Integration with Build Tools
+
+The dev server works seamlessly with the Fusion Framework CLI:
+
+```bash
+# Use with CLI for automatic configuration
+npx @equinor/fusion-framework-cli app dev
+
+# Or portal development
+npx @equinor/fusion-framework-cli portal dev
+```
+
+### Custom Plugins
+
+Extend the dev server with custom Vite plugins:
+
+```typescript
+import { createDevServer } from '@equinor/fusion-framework-dev-server';
+import myCustomPlugin from 'my-custom-vite-plugin';
+
+const devServer = await createDevServer(
+  { /* ... config ... */ },
+  {
+    plugins: [myCustomPlugin()],
   }
 );
 ```
+
+## Migration Guide
+
+### From Direct Vite Usage
+
+If you're migrating from a direct Vite setup:
+
+1. Replace your Vite configuration with the dev server configuration
+2. Move service discovery logic to the `api.processServices` function
+3. Configure portal settings in `spa.templateEnv`
+4. Update your start script to use `createDevServer`
+
+**Before:**
+```typescript
+// vite.config.ts
+export default defineConfig({
+  plugins: [react(), /* other plugins */],
+  server: {
+    proxy: { /* proxy config */ },
+  },
+});
+```
+
+**After:**
+```typescript
+import { createDevServer } from '@equinor/fusion-framework-dev-server';
+
+const devServer = await createDevServer({
+  // Move your config here
+});
+```
+
+## Contributing
+
+This package is part of the Fusion Framework monorepo. See the main [contributing guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+ISC

--- a/packages/dev-server/src/create-dev-server-config.ts
+++ b/packages/dev-server/src/create-dev-server-config.ts
@@ -24,7 +24,7 @@ const createDefaultLogger = (lvl: LogLevel = LogLevel.Info, title = 'dev-server'
  *
  * @template TEnv - A type extending `Partial<TemplateEnv>` that represents the environment variables for the template.
  * @param options - The options for configuring the development server.
- * @param options.spa - Configuration for the Single Page Application (SPA), including template environment settings.
+ * @param options.spa - Optional configuration for the Single Page Application (SPA), including template environment settings.
  * @param options.api - Configuration for the API, including service discovery URL, routes, and service processing logic.
  *
  * @returns A `UserConfig` object that defines the Vite development server configuration.

--- a/packages/dev-server/src/types.ts
+++ b/packages/dev-server/src/types.ts
@@ -20,7 +20,7 @@ export { UserConfig as DevServerOverrides } from 'vite';
  *
  * @template TEnv - The type of the environment variables, extending Partial<FusionTemplateEnv>.
  *
- * @property spa - Single Page Application (SPA) specific options.
+ * @property spa - Optional Single Page Application (SPA) specific options.
  * @property spa.templateEnv - The template environment configuration or a function returning it.
  *
  * @property api - API proxy configuration options.

--- a/packages/vite-plugins/spa/README.md
+++ b/packages/vite-plugins/spa/README.md
@@ -40,36 +40,6 @@ A powerful Vite plugin for building Single Page Applications (SPAs) with the Fus
 >
 > The plugin is written in a modular fashion, allowing for easy customization and extension __IF__ the developer has a deep understanding of the Fusion Framework and its internals.
 
-## Table of Contents
-
-- [Fusion Framework Vite SPA Plugin](#fusion-framework-vite-spa-plugin)
-  - [Table of Contents](#table-of-contents)
-  - [What It Does](#what-it-does)
-  - [How the Plugin Works](#how-the-plugin-works)
-  - [Getting Started](#getting-started)
-  - [Configuration Options](#configuration-options)
-    - [Basic Configuration](#basic-configuration)
-    - [Service Discovery](#service-discovery)
-    - [MSAL](#msal)
-    - [Service Worker](#service-worker)
-  - [Configuring through `.env` File](#configuring-through-env-file)
-    - [How Environment Variables Work](#how-environment-variables-work)
-    - [Naming Convention](#naming-convention)
-    - [Example Conversion](#example-conversion)
-    - [Complete `.env` Example](#complete-env-example)
-  - [Advanced Customization](#advanced-customization)
-    - [Providing a Custom Template](#providing-a-custom-template)
-    - [Providing Custom Bootstrap](#providing-custom-bootstrap)
-  - [Examples](#examples)
-    - [Basic SPA Configuration](#basic-spa-configuration)
-    - [Using with API Service Plugin](#using-with-api-service-plugin)
-  - [Troubleshooting \& FAQ](#troubleshooting--faq)
-    - [Common Issues](#common-issues)
-    - [Known Issues](#known-issues)
-    - [Best Practices \& FAQ](#best-practices--faq)
-  - [Contributing](#contributing)
-
-
 ## What It Does
 
 The plugin:
@@ -280,7 +250,41 @@ When the above `fetch` request is made, the following happens:
 > The `url` path doesn't need to correspond to an actual endpoint—it's simply a pattern used for matching requests. This allows you to emulate proxy services in production environments without changing your application code.
 
 > [!TIP]
-> For enhanced development capabilities, consider using the `@equinor/fusion-framework-vite-plugin-api-service` plugin. This plugin creates a dynamic proxy service that can handle requests to the `/@fusion-api/app` path by intercepting them in the dev-server and routing them based on service discovery configuration.  
+> For enhanced development capabilities, consider using the `@equinor/fusion-framework-vite-plugin-api-service` plugin. This plugin creates a dynamic proxy service that can handle requests to the `/@fusion-api/app` path by intercepting them in the dev-server and routing them based on service discovery configuration.
+
+## Telemetry
+
+The Fusion Framework SPA plugin includes built-in telemetry configuration that automatically sets up console logging for development and debugging purposes. The plugin uses the `@equinor/fusion-framework-module-telemetry` module to provide structured logging with different severity levels.
+
+### Telemetry Levels
+
+The telemetry system supports the following severity levels (ordered from lowest to highest):
+
+- **Debug** (0): Debugging information useful during development
+- **Information** (1): General information about the system's operation
+- **Warning** (2): Indicates a potential issue that is not critical
+- **Error** (3): Represents an error that has occurred, but the system can continue running
+- **Critical** (4): A severe error that may cause the system to stop functioning
+
+### Console Logging
+
+By default, the plugin enables console logging for all telemetry events. You can control the minimum log level displayed in the console using the `FUSION_SPA_TELEMETRY_CONSOLE_LEVEL` environment variable.
+
+```typescript
+// Environment variable configuration
+FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=2  // Only show Warning, Error, and Critical events
+```
+
+When set to a valid number, only telemetry items with a level **greater than or equal to** the specified value will be logged to the console. For example:
+- `FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=0` → Shows all telemetry events (Debug, Information, Warning, Error, Critical)
+- `FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=1` → Shows Information, Warning, Error, and Critical events
+- `FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=2` → Shows Warning, Error, and Critical events
+
+If the environment variable is not set, the default is `FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=1` (Information level and above). If the environment variable contains an invalid value, all telemetry events will be logged to the console.
+
+### Custom Telemetry Configuration
+
+For advanced telemetry setup (such as Application Insights integration), you can customize the telemetry configuration by providing a custom bootstrap file. See the [Providing Custom Bootstrap](#providing-custom-bootstrap) section for details.
 
 ## Configuring through `.env` File
 
@@ -336,6 +340,9 @@ FUSION_SPA_MSAL_TENANT_ID=my-tenant-id
 FUSION_SPA_MSAL_CLIENT_ID=my-client-id
 FUSION_SPA_MSAL_REDIRECT_URI=https://my-app.com/auth-callback
 FUSION_SPA_MSAL_REQUIRES_AUTH=true
+
+# Telemetry configuration
+FUSION_SPA_TELEMETRY_CONSOLE_LEVEL=2  # Only log Verbose, Debug, and Information events to console
 
 # Service Worker configuration (as JSON string)
 FUSION_SPA_SERVICE_WORKER_RESOURCES=[{"url":"/app-proxy","rewrite":"/@fusion-api/app","scopes":["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/.default"]}]
@@ -465,6 +472,9 @@ export default defineConfig({
           clientId: process.env.CLIENT_ID,
           redirectUri: 'http://localhost:3000/auth-callback',
           requiresAuth: 'true',
+        },
+        telemetry: {
+          consoleLevel: 2, // Show Warning, Error, and Critical events
         },
       }),
     }),

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -67,7 +67,18 @@ enableMSAL(configurator, (builder) => {
 enableTelemetry(configurator, {
   attachConfiguratorEvents: true,
   configure: (builder) => {
-    builder.setAdapter(new ConsoleAdapter());
+    const consoleLevel = Number(import.meta.env.FUSION_SPA_TELEMETRY_CONSOLE_LEVEL ?? TelemetryLevel.Information);
+
+    if (!isNaN(consoleLevel)) {
+      builder.setAdapter(
+        new ConsoleAdapter({
+          filter: (item) => item.level >= consoleLevel,
+        }),
+      );
+    } else {
+      // If environment variable is set but invalid, log all telemetry
+      builder.setAdapter(new ConsoleAdapter());
+    }
     builder.setMetadata(({ modules }) => {
       const metadata = {
         fusion: {

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -67,17 +67,19 @@ enableMSAL(configurator, (builder) => {
 enableTelemetry(configurator, {
   attachConfiguratorEvents: true,
   configure: (builder) => {
-    const consoleLevel = Number(import.meta.env.FUSION_SPA_TELEMETRY_CONSOLE_LEVEL ?? TelemetryLevel.Information);
+    const consoleLevel = Number(
+      import.meta.env.FUSION_SPA_TELEMETRY_CONSOLE_LEVEL ?? TelemetryLevel.Information,
+    );
 
-    if (!isNaN(consoleLevel)) {
+    if (Number.isNaN(consoleLevel)) {
+      // If environment variable is set but invalid, log all telemetry
+      builder.setAdapter(new ConsoleAdapter());
+    } else {
       builder.setAdapter(
         new ConsoleAdapter({
           filter: (item) => item.level >= consoleLevel,
         }),
       );
-    } else {
-      // If environment variable is set but invalid, log all telemetry
-      builder.setAdapter(new ConsoleAdapter());
     }
     builder.setMetadata(({ modules }) => {
       const metadata = {

--- a/packages/vite-plugins/spa/src/types.ts
+++ b/packages/vite-plugins/spa/src/types.ts
@@ -17,6 +17,10 @@ export type FusionTemplateEnv = {
   /** Template bootstrap file path */
   bootstrap: string;
 
+  telemetry?: {
+    consoleLevel?: number;
+  };
+
   /** Id of the portal to load */
   portal: {
     id: string;


### PR DESCRIPTION
## Why

**What kind of change does this PR introduce?**
This PR introduces comprehensive telemetry integration across the SPA vite plugin and dev portal, along with type alignment fixes for the dev server.

**What is the current behavior?**
- SPA bootstrap lacks telemetry tracking for performance and error monitoring
- Dev portal has no telemetry integration for usage analytics
- Dev server types have JSDoc misalignment with optional SPA configuration

**What is the new behavior?**
- SPA bootstrap now includes telemetry with configurable console logging levels
- Dev portal has full telemetry integration with portal-specific metadata
- Dev server types are properly aligned with optional configuration

**Does this PR introduce a breaking change?**
No, this PR maintains backward compatibility. All changes are additive and include fallback behavior.

**References:**
- [#3485](https://github.com/equinor/fusion-framework/issues/3485)
- [#3487](https://github.com/equinor/fusion-framework/issues/3487)

closes: #3525 #3526

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).