### PR TITLE
refactor: reorder ModuleEventLevel enum to match TelemetryLevel sequence

### DIFF
--- a/packages/modules/module/src/types.ts
+++ b/packages/modules/module/src/types.ts
@@ -353,18 +353,19 @@ export type ModuleInstance = ModulesInstanceType<Modules>;
 /**
  * Defines the severity levels for module events.
  * Used to categorize events by their importance and impact.
+ * Matches the TelemetryLevel enum sequence for consistency.
  */
 export enum ModuleEventLevel {
-  /** No event level specified (default/unknown) */
-  NONE = 0,
-  /** Error events that indicate failures or critical issues */
-  Error = 1,
+  /** Debug events that provide detailed internal information for troubleshooting */
+  Debug = 0,
+  /** Information events that provide general operational details */
+  Information = 1,
   /** Warning events that indicate potential issues but don't prevent operation */
   Warning = 2,
-  /** Information events that provide general operational details */
-  Information = 3,
-  /** Debug events that provide detailed internal information for troubleshooting */
-  Debug = 4,
+  /** Error events that indicate failures or critical issues */
+  Error = 3,
+  /** Critical events that indicate severe failures */
+  Critical = 4,
 }
 
 /**


### PR DESCRIPTION
## Why

### What kind of change does this PR introduce?
This PR introduces a refactor to improve consistency between the ModuleEventLevel enum and the TelemetryLevel enum.

### What is the current behavior?
The ModuleEventLevel enum had values in a different order than TelemetryLevel, with NONE=0, Error=1, Warning=2, Information=3, Debug=4.

### What is the new behavior?
The enum now matches TelemetryLevel sequence: Debug=0, Information=1, Warning=2, Error=3, Critical=4. A new Critical level has been added as the highest severity.

### Does this PR introduce a breaking change?
No, this is a refactor that maintains the same enum structure and values, just reordered for consistency.

### Other information?
ref: #3483 #3490


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).