### PR TITLE
chore: update person component dependencies for improved functionality

### DIFF
--- a/.changeset/dependency-updates-person-components.md
+++ b/.changeset/dependency-updates-person-components.md
@@ -1,8 +1,7 @@
 ---
 "@equinor/fusion-dev-portal": patch
 "app-react-people": patch
-"@equinor/fusion-react-people-resolver": patch
-"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-react-components-people-provider": patch
 ---
 
 Updated person component dependencies for improved functionality and bug fixes.

--- a/.changeset/dependency-updates-person-components.md
+++ b/.changeset/dependency-updates-person-components.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-dev-portal": patch
+"app-react-people": patch
+"@equinor/fusion-react-people-resolver": patch
+"@equinor/fusion-framework-cli": patch
+---
+
+Updated person component dependencies for improved functionality and bug fixes.
+
+- Updated `@equinor/fusion-react-person` from `^0.10.3` to `^0.10.10` in app-react-people cookbook
+- Updated `@equinor/fusion-wc-person` from `^3.1.8` to `^3.2.4` in dev-portal and people-resolver packages

--- a/cookbooks/app-react-people/package.json
+++ b/cookbooks/app-react-people/package.json
@@ -28,7 +28,7 @@
     "@equinor/eds-core-react": "^0.49.0",
     "@equinor/eds-icons": "^0.22.0",
     "@equinor/fusion-framework-module-navigation": "workspace:^",
-    "@equinor/fusion-react-person": "^0.10.3",
+    "@equinor/fusion-react-person": "^0.10.10",
     "@remix-run/router": "^1.8.0",
     "react-router-dom": "^6.16.0",
     "styled-components": "^6.0.7"

--- a/packages/dev-portal/package.json
+++ b/packages/dev-portal/package.json
@@ -47,7 +47,7 @@
     "@equinor/fusion-react-side-sheet": "1.3.11",
     "@equinor/fusion-react-styles": "^0.6.4",
     "@equinor/fusion-wc-chip": "^1.2.2",
-    "@equinor/fusion-wc-person": "^3.1.8",
+    "@equinor/fusion-wc-person": "^3.2.4",
     "@material-ui/styles": "^4.11.5",
     "@types/dotenv": "^8.2.3",
     "@types/react": "^18.2.50",

--- a/packages/react/components/people-resolver/package.json
+++ b/packages/react/components/people-resolver/package.json
@@ -36,7 +36,7 @@
     "@equinor/fusion-framework-module-app": "workspace:^",
     "@equinor/fusion-framework-module-bookmark": "workspace:^",
     "@equinor/fusion-framework-module-event": "workspace:^",
-    "@equinor/fusion-wc-person": "^3.1.8",
+    "@equinor/fusion-wc-person": "^3.2.4",
     "@types/react": "^18.2.50",
     "react": "^18.2.0",
     "typescript": "^5.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/modules/navigation
       '@equinor/fusion-react-person':
-        specifier: ^0.10.3
-        version: 0.10.7(react@18.3.1)
+        specifier: ^0.10.10
+        version: 0.10.10(react@18.3.1)
       '@remix-run/router':
         specifier: ^1.8.0
         version: 1.23.0
@@ -870,8 +870,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       '@equinor/fusion-wc-person':
-        specifier: ^3.1.8
-        version: 3.2.1
+        specifier: ^3.2.4
+        version: 3.2.4
       '@material-ui/styles':
         specifier: ^4.11.5
         version: 4.11.5(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1567,8 +1567,8 @@ importers:
         specifier: workspace:^
         version: link:../../../modules/event
       '@equinor/fusion-wc-person':
-        specifier: ^3.1.8
-        version: 3.2.1
+        specifier: ^3.2.4
+        version: 3.2.4
       '@types/react':
         specifier: ^18.2.50
         version: 18.3.24
@@ -2483,8 +2483,8 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
 
-  '@equinor/fusion-react-person@0.10.7':
-    resolution: {integrity: sha512-QHkGmPA6wL5rNfS9LsZa8BukAfKecJ6s/epOrOmLmG18aGFpX5E5y6QorCn0JjNPcXWu1fsgJJrmK+Vwu82TMA==}
+  '@equinor/fusion-react-person@0.10.10':
+    resolution: {integrity: sha512-TauYPO7G3b35qtI0xJWEYaxmacANJ3eYMOaiJmoj8TQgPwZqXygn50zmjNURJuKcswZGSbOU4TfBH9etLRCSJw==}
 
   '@equinor/fusion-react-progress-indicator@0.3.0':
     resolution: {integrity: sha512-NNVkTq0gRJYqobHEBPpWG7bFw3JhLlRhsd8AmCFfvQwdRCRnrf5cStql2bb+apetmRalJvH0U1+1swtT3vhFVg==}
@@ -2574,8 +2574,8 @@ packages:
   '@equinor/fusion-wc-list@1.1.4':
     resolution: {integrity: sha512-IZyG+Jyv7vJzQyYJg8RsIlars0q8Ix2LT+Vh1E26p70rBdZZzmU2q1KATOyyEr8vWJSX9HlFMuYTg+N26Mxtdg==}
 
-  '@equinor/fusion-wc-person@3.2.1':
-    resolution: {integrity: sha512-FVdpSsda7ZL4RzsauWgo2N8H2eq6i0BGB+6UinOILk9irdfVJrYxH21k/hrJnbxDT0AYZhyLnABtYZi04D2IGg==}
+  '@equinor/fusion-wc-person@3.2.4':
+    resolution: {integrity: sha512-F+RqZVFuzeo5EKgs3QANmEnBiCqK7OEKmVrCjVx6dMDky5h1C5CT4ERFLTouiqreS4icRiABetIarR7x5tmRmg==}
 
   '@equinor/fusion-wc-picture@3.1.1':
     resolution: {integrity: sha512-TeZd46sjyg43HHlbE4h9Ebk9wCBnif5j9XGodIdVTCaC7rLz2YEd7C6RS7vj3nS+goFIZmowiUUmg6gZemzY4w==}
@@ -9656,10 +9656,10 @@ snapshots:
       '@equinor/fusion-wc-icon': 2.3.1
       react: 18.3.1
 
-  '@equinor/fusion-react-person@0.10.7(react@18.3.1)':
+  '@equinor/fusion-react-person@0.10.10(react@18.3.1)':
     dependencies:
       '@equinor/fusion-react-utils': 2.2.3(react@18.3.1)
-      '@equinor/fusion-wc-person': 3.2.1
+      '@equinor/fusion-wc-person': 3.2.4
     transitivePeerDependencies:
       - react
 
@@ -9799,7 +9799,7 @@ snapshots:
       '@material/mwc-list': 0.27.0
       lit: 3.3.0
 
-  '@equinor/fusion-wc-person@3.2.1':
+  '@equinor/fusion-wc-person@3.2.4':
     dependencies:
       '@equinor/fusion-wc-avatar': 3.2.3
       '@equinor/fusion-wc-badge': 1.3.2


### PR DESCRIPTION

Updated person component dependencies for improved functionality and bug fixes.

- Updated `@equinor/fusion-react-person` from `^0.10.3` to `^0.10.10` in app-react-people cookbook
- Updated `@equinor/fusion-wc-person` from `^3.1.8` to `^3.2.4` in dev-portal and people-resolver packages


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

