### PR TITLE
feat: enable portal proxy for testing apps in real portal environments

### DIFF
--- a/.changeset/cli-portal-proxy-docs.md
+++ b/.changeset/cli-portal-proxy-docs.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Enhanced CLI documentation with comprehensive portal proxy configuration guide.
+
+- Added detailed portal proxy configuration section in dev-server-config.md
+- Documented portal proxy behavior, use cases, and benefits
+- Provided complete code examples for portal proxy setup
+- Fixed broken relative links in application.md
+- Improved documentation navigation and consistency
+
+These documentation updates provide developers with complete guidance for configuring and using portal proxy functionality in development environments.

--- a/.changeset/cli-portal-proxy-support.md
+++ b/.changeset/cli-portal-proxy-support.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-cli": minor
+---
+
+Enhanced CLI with portal proxy support for testing apps in real portal environments ([Issue #3546](https://github.com/equinor/fusion-framework/issues/3546)).
+
+- Added `/portal-proxy` service worker resource configuration to CLI dev server
+- Routes portal proxy requests to Fusion portal service API (`/@fusion-api/portal-config`)
+- Enhanced dev server creation with improved logging and error handling
+- Exported `defineDevServerConfig` helper for type-safe portal configuration
+- Updated `ffc app dev` command with better logging support
+
+This enables developers to run `ffc app dev` to test against real portals, supporting configuration of portal ID and version tags for targeted testing scenarios.

--- a/.changeset/dev-portal-portal-proxy-support.md
+++ b/.changeset/dev-portal-portal-proxy-support.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-dev-portal": patch
+---
+
+Enhanced dev-portal with portal proxy service worker configuration ([Issue #3546](https://github.com/equinor/fusion-framework/issues/3546)).
+
+- Added `/portal-proxy` service worker resource configuration in dev-server.ts
+- Routes portal proxy requests to Fusion portal service API (`/@fusion-api/portals`)
+- Enables portal proxy functionality for testing against real portal environments
+
+This change supports the portal proxy feature by configuring the service worker to properly route portal requests through the dev-server proxy system.

--- a/.changeset/spa_portal_proxy_feature.md
+++ b/.changeset/spa_portal_proxy_feature.md
@@ -1,0 +1,24 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": minor
+---
+
+Enhanced SPA plugin with portal proxy support for testing apps in real portal environments ([Issue #3546](https://github.com/equinor/fusion-framework/issues/3546)).
+
+- Added `proxy` option to portal configuration to enable `/portal-proxy` routing
+- Added `FUSION_SPA_PORTAL_PROXY` environment variable support
+- Updated TypeScript types to include portal proxy configuration
+- Updated documentation with portal proxy usage examples
+
+This feature enables developers to load real portal implementations instead of the default developer portal, supporting configuration of portal ID and version tags for targeted testing scenarios.
+
+**Migration:**
+No migration required - the `proxy` option defaults to `false`, maintaining existing behavior.
+
+**Example usage:**
+```ts
+portal: {
+  id: 'my-portal',
+  tag: 'latest',
+  proxy: true, // Routes through /portal-proxy/
+}
+```

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -107,7 +107,7 @@ pnpm fusion-framework-cli publish --env <environment>
 pnpm fusion-framework-cli app config --publish --env <environment>
 ```
 
-> **Tip:** For CI/CD and automation, set the `FUSION_TOKEN` environment variable. See [Authentication](./docs/auth.md) for details.
+> **Tip:** For CI/CD and automation, set the `FUSION_TOKEN` environment variable. See [Authentication](auth.md) for details.
 
 ---
 
@@ -131,7 +131,7 @@ pnpm fusion-framework-cli app config --publish --env <environment>
 - **Missing manifest/config:** Ensure `app.manifest.ts` and `app.config.ts` exist in your project root.
 - **Environment variables:** Use `.env` files or your CI/CD system to inject secrets and config values.
 - **Command help:** Run any command with `--help` for detailed usage and options.
-- **Still stuck?** See [Troubleshooting](#troubleshooting--faq) or [Authentication](./docs/auth.md).
+- **Still stuck?** See [Troubleshooting](#troubleshooting--faq) or [Authentication](auth.md).
 
 ---
 
@@ -295,6 +295,7 @@ export default defineAppConfig((env, args) => {
 
 The Fusion Framework CLI provides a suite of commands to support the full application lifecycle, from development to deployment. Below is an overview of all available commands with quick links to their detailed usage:
 
+- [Create](#create) — Create new Fusion applications from templates.
 - [Dev](#dev) — Start the development server with hot reloading.
 - [Publish](#publish) — Build, upload, and tag your app for deployment.
 - [Config](#config) — Generate or upload your app configuration.
@@ -304,9 +305,60 @@ The Fusion Framework CLI provides a suite of commands to support the full applic
 - [Tag](#tag) — Tag a published app version for release management.
 - [Manifest](#manifest) — Generate your app manifest file.
 - [Check](#check) — Verify your app's registration status.
+- [Disco](#disco) — Service discovery operations.
 - [Aliases](#aliases) — Deprecated commands and their replacements.
 
 Refer to each section below for detailed options, usage, and examples.
+
+### Create
+
+Create new Fusion applications from predefined templates. This command provides an interactive way to scaffold new projects with proper structure and configuration.
+
+```sh
+# Create a new app with interactive template selection
+pnpm fusion-framework-cli create app my-app
+
+# Create with a specific template
+pnpm fusion-framework-cli create app my-app --template react-app
+
+# Create in a specific directory
+pnpm fusion-framework-cli create app my-app --directory ./projects
+```
+
+**Options:**
+- `-t, --template <type>` - Template type to use (will prompt if not specified)
+- `-d, --directory <path>` - Directory to create the app in (default: current directory)
+
+For detailed information about creating applications, see [Creating Apps](creating-apps.md).
+
+### Disco
+
+Service discovery operations for resolving and inspecting Fusion services.
+
+#### Resolve
+
+Resolve and display information about a service registered in Fusion service discovery.
+
+```sh
+# Resolve a service in the current environment
+pnpm fusion-framework-cli disco resolve my-service
+
+# Resolve in a specific environment
+pnpm fusion-framework-cli disco resolve my-service --env prod
+
+# Silent mode for scripting
+pnpm fusion-framework-cli disco resolve my-service --silent
+```
+
+**Options:**
+- `--env <environment>` - Environment to use (prod, test, etc.)
+- `--silent` - Silent mode, outputs only JSON for scripting
+- Authentication options: `--token`, `--tenantId`, `--clientId`
+
+**Useful for:**
+- Finding service endpoints for API calls
+- Debugging service connectivity issues
+- Getting service metadata and configuration
 
 ### Dev
 
@@ -609,7 +661,7 @@ pnpm fusion-framework-cli app check --env prod --debug
 > - This change aligns with industry standards and prepares for future CLI enhancements.
 > - Deprecated commands will be removed in future versions—update your scripts and workflows now to avoid breaking changes.
 > 
-> For a full migration guide, see [Migration v10 to v11](./migration-v10-to-v11.md).
+> For a full migration guide, see [Migration v10 to v11](migration-v10-to-v11.md).
 
 The CLI will warn you and redirect to the new command when you use a deprecated alias, applying any necessary options automatically. See the table below for mappings:
 

--- a/packages/cli/docs/dev-server-config.md
+++ b/packages/cli/docs/dev-server-config.md
@@ -259,7 +259,6 @@ export default defineDevServerConfig(() => ({
       // Override portal configuration
       portal: {
         id: 'my-custom-portal',
-        tag: 'development'
       },
 
       // Modify service discovery
@@ -293,6 +292,32 @@ export default defineDevServerConfig(() => ({
 - `2`: Warning (shows warnings, errors, critical - default)
 - `3`: Error (shows only errors and critical messages)
 - `4`: Critical (shows only critical messages - least verbose)
+
+### Portal Proxy Configuration
+
+**When you need it**: You want to control how portal assets are loaded during development - either from the Fusion portal service or from locally installed portal packages.
+
+**How it works**:
+- **`proxy: true`**: Routes portal assets through the dev-server's `/portal-proxy` endpoint, which fetches content from the Fusion portal service
+- **`proxy: false`** (default): Loads portal assets directly from `node_modules` (typically `@equinor/fusion-dev-server` or another portal package installed locally)
+
+```typescript
+export default defineDevServerConfig(() => ({
+  spa: {
+    templateEnv: {
+      portal: {
+        id: 'fusion',
+        tag: 'latest',
+        proxy: true // Load portal from Fusion portal service via /portal-proxy
+      }
+    }
+  }
+}));
+```
+
+**Benefits**:
+- **`proxy: true`**: Access production portal templates or custom portal deployments via the Fusion portal service
+- **`proxy: false`**: Use locally installed portal packages for offline development or custom portal development
 
 ### CLI Logging
 

--- a/packages/cli/docs/dev-server.md
+++ b/packages/cli/docs/dev-server.md
@@ -12,6 +12,8 @@ The Fusion Framework dev-server is your complete local development solution for 
 
 🛠️ **Flexible Configuration** - Easy setup for both applications and portals with environment-specific overrides
 
+📝 **Configurable Development** - Optional `dev-server.config.ts` file for API mocking, service discovery customization, and environment variable overrides
+
 ## Quick Start
 
 ```bash
@@ -27,6 +29,8 @@ The dev-server automatically detects your project type, loads configuration file
 ## Configuration
 
 For detailed information about configuring the dev-server, see [Dev Server Configuration](dev-server-config.md).
+
+The dev-server automatically loads configuration from a `dev-server.config.ts` file in your project root, allowing you to customize API mocking, service discovery, and development environment settings without modifying your application code.
 
 ## Key Features
 

--- a/packages/cli/src/bin/app-dev.ts
+++ b/packages/cli/src/bin/app-dev.ts
@@ -149,7 +149,7 @@ export const startAppDevServer = async (options?: StartAppDevServerOptions) => {
   log?.start('Starting app development server...');
 
   // Create the dev server configuration, including portal and app settings
-  const devServer = await createDevServer(env, devServerConfig, viteConfig);
+  const devServer = await createDevServer(env, devServerConfig, { overrides: viteConfig, log });
 
   await devServer.listen();
 

--- a/packages/cli/src/cli/commands/app/dev.ts
+++ b/packages/cli/src/cli/commands/app/dev.ts
@@ -11,6 +11,7 @@ import { startAppDevServer, ConsoleLogger } from '@equinor/fusion-framework-cli/
  * - Launches the development server for your application.
  * - Supports custom manifest/config files, runtime environment, and port selection.
  * - Debug mode available for verbose logging.
+ * - Automatic loading of dev-server.config.ts for API mocking and customization.
  *
  * Usage:
  *   $ ffc app dev [options]
@@ -22,12 +23,17 @@ import { startAppDevServer, ConsoleLogger } from '@equinor/fusion-framework-cli/
  *   --env <environment>  Runtime environment for the dev server (default: local)
  *   --port <port>        Port for the development server (default: 3000)
  *
+ * Configuration:
+ *   dev-server.config.ts  Optional configuration file for API mocking, service discovery,
+ *                         and development environment customization
+ *
  * Example:
  *   $ ffc app dev
  *   $ ffc app dev --port 4000
  *   $ ffc app dev --manifest ./app.manifest.local.ts --config ./app.config.ts
  *
  * @see startAppDevServer for implementation details
+ * @see dev-server-config.md for configuration options
  */
 export const command = createCommand('dev')
   .description('Start the application in development mode.')
@@ -35,10 +41,16 @@ export const command = createCommand('dev')
     'after',
     [
       '',
+      'Configuration:',
+      '  dev-server.config.ts  Optional configuration file for API mocking, service discovery,',
+      '                         and development environment customization',
+      '',
       'Examples:',
       '  $ ffc app dev',
       '  $ ffc app dev --port 4000',
       '  $ ffc app dev --manifest ./app.manifest.local.ts --config ./app.config.ts',
+      '',
+      'See https://equinor.github.io/fusion-framework/cli/docs/dev-server-config.html for configuration options.',
     ].join('\n'),
   )
   .option('--debug', 'Enable debug mode')

--- a/packages/cli/src/cli/commands/portal/dev.ts
+++ b/packages/cli/src/cli/commands/portal/dev.ts
@@ -11,6 +11,7 @@ import { ConsoleLogger, startPortalDevServer } from '@equinor/fusion-framework-c
  * - Launches the development server for your portal.
  * - Supports custom runtime environment and port selection.
  * - Debug mode available for verbose logging.
+ * - Automatic loading of dev-server.config.ts for API mocking and customization.
  *
  * Usage:
  *   $ ffc portal dev [options]
@@ -20,12 +21,17 @@ import { ConsoleLogger, startPortalDevServer } from '@equinor/fusion-framework-c
  *   --env <environment>  Runtime environment for the dev server (default: local)
  *   --port <port>        Port for the development server (default: 3000)
  *
+ * Configuration:
+ *   dev-server.config.ts  Optional configuration file for API mocking, service discovery,
+ *                         and development environment customization
+ *
  * Example:
  *   $ ffc portal dev
  *   $ ffc portal dev --port 4000
  *   $ ffc portal dev --debug
  *
  * @see startPortalDevServer for implementation details
+ * @see dev-server-config.md for configuration options
  */
 export const command = createCommand('dev')
   .description('Start a local development server for the Fusion portal.')
@@ -33,10 +39,16 @@ export const command = createCommand('dev')
     'after',
     [
       '',
+      'Configuration:',
+      '  dev-server.config.ts  Optional configuration file for API mocking, service discovery,',
+      '                         and development environment customization',
+      '',
       'Examples:',
       '  $ ffc portal dev',
       '  $ ffc portal dev --port 4000',
       '  $ ffc portal dev --debug',
+      '',
+      'See https://equinor.github.io/fusion-framework/cli/docs/dev-server-config.html for configuration options.',
     ].join('\n'),
   )
   .option('--debug', 'Enable debug mode')

--- a/packages/cli/src/cli/main.ts
+++ b/packages/cli/src/cli/main.ts
@@ -54,7 +54,7 @@ program.description(
     '',
     '• Run fusion <command> --help for details on any command.',
     '• For documentation, issues, and source code, visit:',
-    `  ${pkg.packageJson.homepage}`,
+    '  https://equinor.github.io/fusion-framework/cli/',
   ].join('\n'),
 );
 program.version(pkg.packageJson.version, '-V, --version', 'CLI version');

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -3,7 +3,12 @@ export type { RuntimeEnv } from './types.js';
 export { resolvePackage, type ResolvedPackage } from './utils/resolve-package.js';
 export { resolveEntryPoint } from './utils/resolve-source-entry-point.js';
 
-export { loadDevServerConfig } from './load-dev-server-config.js';
+export {
+  loadDevServerConfig,
+  defineDevServerConfig,
+  type DevServerConfigExport,
+  type DevServerConfigFn,
+} from './load-dev-server-config.js';
 
 // Legacy imports - these will be removed in the next major version
 // @todo - remove these imports, introduced in v11

--- a/packages/dev-portal/dev-server.ts
+++ b/packages/dev-portal/dev-server.ts
@@ -53,6 +53,11 @@ if (serviceScopes.length === 0) {
               rewrite: '/@fusion-api/help',
               scopes: serviceScopes,
             },
+            {
+              url: '/portal-proxy',
+              rewrite: '/@fusion-api/portals',
+              scopes: serviceScopes,
+            },
           ],
         },
       },

--- a/packages/vite-plugins/spa/README.md
+++ b/packages/vite-plugins/spa/README.md
@@ -116,6 +116,7 @@ fusionSpaPlugin({
       //   2. An ID from the Fusion Portal Service
       //   3. Any other configured portal ID
       tag: 'latest', // (Optional) Version tag (defaults to 'latest')
+      proxy: false, // (Optional) Whether to proxy portal requests through /portal-proxy (defaults to false)
     },
 
     // Service Discovery configuration
@@ -145,6 +146,36 @@ fusionSpaPlugin({
   })
 });
 ```
+
+### Portal Proxy
+
+The portal proxy feature allows you to route portal entry point requests through a `/portal-proxy` path prefix. When enabled, the plugin will attempt to load portal code from URLs prefixed with `/portal-proxy/`, which can be useful when working with proxy servers or development environments that need to intercept and route portal requests.
+
+**Behavior:**
+
+- `proxy: true` → Portal loads from `/portal-proxy/{assetPath}/{templateEntry}` (allows proxy interception)
+- `proxy: false` → Portal loads from `{assetPath}/{templateEntry}` (direct loading)
+
+**Configuration Options:**
+
+- `proxy`: When set to `true`, portal entry points will be prefixed with `/portal-proxy`
+
+**When to Use Portal Proxy:**
+
+- Development environments where portal assets need to be served through a proxy
+- Deployment scenarios requiring portal routing through specific paths
+- When working with the API Service Plugin for advanced portal loading
+
+**Example:**
+
+```ts
+portal: {
+  id: 'my-portal',
+  tag: 'latest',
+  proxy: true, // Portal will be loaded from /portal-proxy/{assetPath}/{templateEntry}
+}
+```
+
 See [@equinor/fusion-framework-vite-plugin-api-service](https://github.com/equinor/fusion-framework/tree/main/packages/vite-plugins/api-service) for advanced API proxying.
 
 ### Service Discovery
@@ -330,6 +361,8 @@ import.meta.env.FUSION_SPA_SERVICE_WORKER_RESOURCES
 # Application basics
 FUSION_SPA_TITLE=My App
 FUSION_SPA_PORTAL_ID=my-portal  # Can be a package name, Fusion Portal Service ID, or any configured portal ID
+FUSION_SPA_PORTAL_TAG=latest    # (Optional) Version tag (defaults to 'latest')
+FUSION_SPA_PORTAL_PROXY=false   # (Optional) Whether to proxy portal requests through /portal-proxy (defaults to false)
 
 # Service Discovery configuration
 FUSION_SPA_SERVICE_DISCOVERY_URL=https://my-server.com/service-discovery

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -130,6 +130,7 @@ enableTelemetry(configurator, {
   // fetch the portal manifest - this is used to load the portal template
   const portalId = import.meta.env.FUSION_SPA_PORTAL_ID;
   const portalTag = import.meta.env.FUSION_SPA_PORTAL_TAG ?? 'latest';
+  const portalProxy = import.meta.env.FUSION_SPA_PORTAL_PROXY ?? false;
   const portal_manifest = await measurement
     .clone()
     .resolve(portalClient.json<PortalManifest>(`/portals/${portalId}@${portalTag}`), {
@@ -164,7 +165,11 @@ enableTelemetry(configurator, {
   document.body.innerHTML = '';
   document.body.appendChild(el);
 
-  const portalEntryPoint = [portal_manifest.build.assetPath, portal_manifest.build.templateEntry]
+  const portalEntryPoint = [
+    portalProxy ? '/portal-proxy' : '',
+    portal_manifest.build.assetPath,
+    portal_manifest.build.templateEntry,
+  ]
     .filter(Boolean)
     .join('/');
 

--- a/packages/vite-plugins/spa/src/types.ts
+++ b/packages/vite-plugins/spa/src/types.ts
@@ -25,6 +25,7 @@ export type FusionTemplateEnv = {
   portal: {
     id: string;
     tag?: string;
+    proxy?: boolean;
   };
 
   /** Service discovery configuration */


### PR DESCRIPTION
## Why
**What kind of change does this PR introduce?**  
Feature - adds portal proxy functionality to enable testing applications against real portal implementations instead of developer portals.

**What is the current behavior?**  
Applications can only be tested against developer portals, limiting the ability to test against production-like environments.

**What is the new behavior?**  
Applications can now be tested against real portal implementations by configuring `portal: { proxy: true }` in dev server configuration.

**Does this PR introduce a breaking change?**  
No - the `proxy` option defaults to `false`, maintaining existing behavior.

**Other information?**  
This addresses issue #3546 and enables developers to test against production portals during development.

## Testing Instructions

To test the portal proxy feature:

1. **Create a dev server config** with portal proxy enabled:
   ```ts
   // dev-server.config.ts
   import { defineDevServerConfig } from '@equinor/fusion-framework-cli';

   export default defineDevServerConfig(() => {
     return {
       spa: {
         templateEnv: {
           portal: {
             id: 'fusion', // Replace with your portal ID
             tag: 'latest',
             proxy: true, // Enable portal proxy
           },
         },
       },
     };
   });
   ```

2. **Run the dev server**:
   ```bash
   ffc app dev --config ./dev-server.config.ts
   ```

3. **Verify the behavior**:
   - Portal assets will be loaded from the Fusion portal service via `/@fusion-api/portals`
   - Service worker will intercept and proxy portal requests
   - Application will render using the real portal implementation

**For testing**, use the app-react cookbook as a reference. Create your own `dev-server.config.ts` file in your project root with the portal proxy configuration above.

closes: https://github.com/equinor/fusion-framework/issues/3546 AB#65473

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - [x] I have validated included files
  - [x] My code does not generate new linting warnings
  - [x] My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).