### PR TITLE
fix(cli): enhance release annotations to include CLI version and requ…

### DIFF
--- a/.changeset/cli_fix-annotations-cli-version.md
+++ b/.changeset/cli_fix-annotations-cli-version.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fixed release annotations to always include CLI version and required metadata.
+
+- Added `cliVersion` property to `ReleaseAnnotations` type
+- Ensured annotations are always returned (removed undefined return type)
+- Added fallback annotations for local builds with default values
+- Improved type safety by making annotations consistently available
+
+Thanks to @odinr for reporting in issue #3540.


### PR DESCRIPTION
Fixed release annotations to always include CLI version and required metadata.

- Added `cliVersion` property to `ReleaseAnnotations` type
- Ensured annotations are always returned (removed undefined return type)
- Added fallback annotations for local builds with default values
- Improved type safety by making annotations consistently available

closes: #3540


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

