### PR TITLE
feat(cli): add host option for development server configuration

### DIFF
--- a/.changesets/host-flag-for-app-dev.md
+++ b/.changesets/host-flag-for-app-dev.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-cli": minor
+---
+
+Add `--host` support to the `ffc app dev` command and the `startAppDevServer` API so callers can override the dev server host (for example `0.0.0.0`).
+
+This is a non-breaking enhancement that allows specifying the server host from the CLI or programmatically.
+
+Example:
+
+```bash
+ffc app dev --host 0.0.0.0 --port 4000
+```

--- a/packages/cli/src/bin/app-dev.ts
+++ b/packages/cli/src/bin/app-dev.ts
@@ -48,6 +48,11 @@ export interface StartAppDevServerOptions {
    * Port for the development server (optional, defaults to 3000).
    */
   port?: number;
+
+  /**
+   * Host for the development server (optional, defaults to 'localhost').
+   */
+  host?: string;
 }
 
 /**
@@ -113,7 +118,7 @@ export const startAppDevServer = async (options?: StartAppDevServerOptions) => {
   const viteConfig = mergeConfigVite(localViteConfig, {
     server: {
       port: options?.port || 3000,
-      host: localViteConfig.server?.host || 'localhost',
+      host: options?.host || localViteConfig.server?.host || 'localhost',
       fs: {
         allow: allowFs,
       },

--- a/packages/cli/src/cli/commands/app/dev.ts
+++ b/packages/cli/src/cli/commands/app/dev.ts
@@ -22,6 +22,7 @@ import { startAppDevServer, ConsoleLogger } from '@equinor/fusion-framework-cli/
  *   --config <path>      Path to the app config file (app.config[.env]?.[ts,js,json])
  *   --env <environment>  Runtime environment for the dev server (default: local)
  *   --port <port>        Port for the development server (default: 3000)
+ *   --host <host>        Host for the development server (default: localhost)
  *
  * Configuration:
  *   dev-server.config.ts  Optional configuration file for API mocking, service discovery,
@@ -31,6 +32,7 @@ import { startAppDevServer, ConsoleLogger } from '@equinor/fusion-framework-cli/
  *   $ ffc app dev
  *   $ ffc app dev --port 4000
  *   $ ffc app dev --manifest ./app.manifest.local.ts --config ./app.config.ts
+ *   $ ffc app dev --host 0.0.0.0
  *
  * @see startAppDevServer for implementation details
  * @see dev-server-config.md for configuration options
@@ -49,6 +51,7 @@ export const command = createCommand('dev')
       '  $ ffc app dev',
       '  $ ffc app dev --port 4000',
       '  $ ffc app dev --manifest ./app.manifest.local.ts --config ./app.config.ts',
+      '  $ ffc app dev --host 0.0.0.0',
       '',
       'See https://equinor.github.io/fusion-framework/cli/docs/dev-server-config.html for configuration options.',
     ].join('\n'),
@@ -58,6 +61,7 @@ export const command = createCommand('dev')
   .option('--config <path>', 'Path to the app config file (app.config[.env]?.[ts,js,json])')
   .option('--env <environment>', 'Runtime environment for the dev server', 'local')
   .option('--port <port>', 'Port for the development server', '3000')
+  .option('--host <host>', 'Host for the development server')
   .action(async (options) => {
     const log = new ConsoleLogger('app:dev', { debug: options.debug });
 
@@ -68,6 +72,7 @@ export const command = createCommand('dev')
       config: options.config,
       env: options.env,
       port: options.port,
+      host: options.host,
     });
     log.succeed('Development server started successfully.');
   });


### PR DESCRIPTION
## Why
<!-- What kind of change does this PR introduce? -->
<!-- What is the current behavior? -->
<!-- What is the new behavior? -->
<!-- Does this PR introduce a breaking change? -->
<!-- Other information? -->
closes:

Add `--host` support to the `ffc app dev` command and the `startAppDevServer` API so callers can override the dev server host (for example `0.0.0.0`).


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).

