### PR TITLE
refactor(msal): replace deprecated defaultClient with client property

### DIFF
--- a/.changeset/msal-refactor-client-property.md
+++ b/.changeset/msal-refactor-client-property.md
@@ -1,0 +1,10 @@
+---
+"@equinor/fusion-framework-module-msal": minor
+---
+
+Refactored AuthProvider to use a cleaner `client` property instead of deprecated `defaultClient`.
+
+- Added `client` property to IAuthProvider interface
+- Replaced deprecated `defaultClient` getter with `client` getter
+- Updated internal references to use private `#client` field
+- Maintained backward compatibility through proxy provider with deprecation warning


### PR DESCRIPTION
## Why

**What kind of change does this PR introduce?**
Refactoring - Replacing deprecated API with cleaner implementation

**What is the current behavior?**
The AuthProvider uses a deprecated `defaultClient` getter that internally calls `getClient()`

**What is the new behavior?**
The AuthProvider now exposes a clean `client` property that directly accesses the private `#client` field

**Does this PR introduce a breaking change?**
No - Backward compatibility is maintained through the proxy provider with deprecation warnings

**Other information?**
This change improves the API design by providing direct access to the client property instead of going through a deprecated getter method.

closes:


### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr`s](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).

- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).