### PR TITLE
fix(cli): add missing is-mergeable-object dependency

### DIFF
--- a/.changeset/add-is-mergeable-object-dependency.md
+++ b/.changeset/add-is-mergeable-object-dependency.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fix app development error by adding missing `is-mergeable-object` dependency
+
+Added `is-mergeable-object` as a direct dependency to resolve runtime errors when using the CLI's app development features. This package is required by `deepmerge` but was not explicitly declared as a dependency, causing module resolution failures during app development.
+
+**Changes:**
+- Added `is-mergeable-object@^1.1.1` to dependencies in `packages/cli/package.json`
+
+**Impact:**
+- Fixes "Cannot find module 'is-mergeable-object'" errors during app development
+- Ensures proper dependency resolution for CLI tools that use deepmerge functionality
+- No breaking changes - this is purely a dependency fix

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,6 +109,7 @@
     "@types/inquirer": "^9.0.9",
     "commander": "^14.0.1",
     "deepmerge": "^4.3.1",
+    "is-mergeable-object": "^1.1.1",
     "execa": "^9.6.0",
     "inquirer": "^12.9.6",
     "is-path-inside": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,6 +719,9 @@ importers:
       inquirer:
         specifier: ^12.9.6
         version: 12.9.6(@types/node@24.7.1)
+      is-mergeable-object:
+        specifier: ^1.1.1
+        version: 1.1.1
       is-path-inside:
         specifier: ^4.0.0
         version: 4.0.0


### PR DESCRIPTION
## Why

This PR fixes app development errors caused by a missing dependency in the CLI package. The  package requires  but it wasn't explicitly declared as a dependency, causing module resolution failures during app development.

**What changed:**
- Added  as a direct dependency in 

**What problem does this solve:**
- Fixes "Cannot find module 'is-mergeable-object'" errors during app development
- Ensures proper dependency resolution for CLI tools that use deepmerge functionality

**Breaking changes:**
- None - this is purely a dependency fix

closes: N/A (bug fix, no related issue)

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing prs](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).