### PR TITLE
fix(vite-plugin-spa): improve Windows path compatibility

### DIFF
--- a/.changeset/fix-cli-windows-compatibility.md
+++ b/.changeset/fix-cli-windows-compatibility.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Fix Windows compatibility issue in SPA Vite plugin
+
+Previously, the plugin was using direct `.pathname` access on URL objects which could cause issues on Windows due to path separator differences. This change replaces the direct pathname access with `fileURLToPath()` and `normalizePath()` from Vite to ensure proper cross-platform path handling.
+
+**Changes:**
+- Import `normalizePath` from Vite for consistent path normalization
+- Use `fileURLToPath()` to properly convert file URLs to paths
+- Apply `normalizePath()` to ensure consistent path separators across platforms
+
+This fix ensures the CLI and development server work correctly on Windows systems.

--- a/packages/vite-plugins/spa/src/plugin.ts
+++ b/packages/vite-plugins/spa/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vite';
+import { normalizePath, type Plugin } from 'vite';
 
 import { fileURLToPath } from 'node:url';
 
@@ -88,7 +88,9 @@ export const plugin = <TEnv extends TemplateEnv = TemplateEnv>(
       config.server.fs ??= {};
       config.server.fs.allow ??= [];
       // allow access to the html directory
-      config.server.fs.allow.push(new URL('../html', import.meta.url).pathname);
+
+      const htmlDir = fileURLToPath(new URL('../html', import.meta.url));
+      config.server.fs.allow.push(normalizePath(htmlDir));
 
       log?.info(`plugin configured for ${env.FUSION_SPA_PORTAL_ID}`);
     },


### PR DESCRIPTION
## Why
This PR fixes CLI compatibility issues on Windows by improving path handling in the SPA Vite plugin.

Previously, the plugin was using direct .pathname access on URL objects which could cause issues on Windows due to path separator differences. This change ensures proper cross-platform path handling.

## Changes
- Replace direct .pathname access with fileURLToPath() for cross-platform compatibility
- Use normalizePath() from Vite to ensure consistent path separators across platforms
- Add proper imports for the new path handling utilities

## Impact
- Fixes CLI issues on Windows systems
- Maintains backward compatibility
- No breaking changes

closes: N/A

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - I have validated included files
  - My code does not generate new linting warnings
  - My PR is not a duplicate
- [x] Confirm that the I have completed the self-review checklist.
- [x] Confirm that my changes meet our code of conduct.