### PR TITLE
fix(spa): add peer dependencies to SPA Vite plugin

### DIFF
--- a/.changeset/spa-peer-dependencies.md
+++ b/.changeset/spa-peer-dependencies.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Add peer dependencies to SPA Vite plugin
+
+Added peer dependencies to ensure proper dependency resolution for the SPA Vite plugin. This change declares the Fusion Framework modules that the plugin expects to be available in the consuming application:
+
+- `@equinor/fusion-framework-module`
+- `@equinor/fusion-framework-module-http`
+- `@equinor/fusion-framework-module-msal`
+- `@equinor/fusion-framework-module-service-discovery`
+- `@equinor/fusion-framework-module-telemetry`
+
+This ensures that consumers are aware of the required dependencies and helps prevent runtime errors due to missing modules.

--- a/packages/vite-plugins/spa/package.json
+++ b/packages/vite-plugins/spa/package.json
@@ -58,5 +58,12 @@
     "rollup": "^4.39.0",
     "typescript": "^5.8.2",
     "vite": "^7.1.9"
+  },
+  "peerDependencies": {
+    "@equinor/fusion-framework-module": "workspace:*",
+    "@equinor/fusion-framework-module-http": "workspace:*",
+    "@equinor/fusion-framework-module-msal": "workspace:*",
+    "@equinor/fusion-framework-module-service-discovery": "workspace:*",
+    "@equinor/fusion-framework-module-telemetry": "workspace:*"
   }
 }


### PR DESCRIPTION
## Why

This PR adds peer dependencies to the  package to ensure proper dependency resolution and prevent runtime errors due to missing modules.

### What changed
- Added peer dependencies to  for the SPA Vite plugin
- Created changeset documenting the change as a patch release

### Peer dependencies added:
- `@equinor/fusion-framework-module`
- `@equinor/fusion-framework-module-http`
- `@equinor/fusion-framework-module-msal`
- `@equinor/fusion-framework-module-service-discovery`
- `@equinor/fusion-framework-module-telemetry`

### Why these changes are needed
The SPA Vite plugin expects these Fusion Framework modules to be available in consuming applications. By declaring them as peer dependencies, we:
- Make the required dependencies explicit to consumers
- Help prevent runtime errors due to missing modules
- Follow npm best practices for plugin packages
- Ensure proper dependency resolution in monorepo environments

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr's](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).