### PR TITLE
fix: update GitHub Actions internal references after move to standard location

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Setup node and install deps
-      uses: ./.github/workflows/actions/node-setup
+      uses: ./.github/actions/node-setup
 
     - name: Generate version
       shell: bash

--- a/.github/actions/changeset-snapshot/action.yml
+++ b/.github/actions/changeset-snapshot/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: generate patch for all packages
       shell: bash
-      run: sh ./.github/workflows/actions/changeset-snapshot/create-pre-release-changeset.sh ${{ inputs.tag }}
+      run: sh ./.github/actions/changeset-snapshot/create-pre-release-changeset.sh ${{ inputs.tag }}
 
     - name: Generate status
       id: status


### PR DESCRIPTION
This PR fixes internal references in GitHub Actions that were missed when moving actions from `.github/workflows/actions/` to `.github/actions/`.

## Changes
- Fix `changeset-snapshot/action.yml` to reference script at new location
- Fix `build-docs/action.yml` to reference node-setup action at new location

## What kind of change does this PR introduce?
This is a bug fix that resolves broken internal action references.

## What is the current behavior?
GitHub Actions workflows were failing because some actions contained references to the old action location.

## What is the new behavior?
All GitHub Actions now correctly reference the new standard `.github/actions/` location.

## Does this PR introduce a breaking change?
No, this is an internal fix that doesn't affect consumers.

## Other information?
This completes the migration to the standard GitHub Actions directory structure.