### PR TITLE
refactor: make AuthProvider extend BaseModuleProvider

### DIFF
--- a/packages/modules/msal/.changeset/msal-auth-provider-fix.md
+++ b/packages/modules/msal/.changeset/msal-auth-provider-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-msal": patch
+---
+
+Fixed AuthProvider to properly extend BaseModuleProvider, eliminating module initialization warnings about provider inheritance.
+
+The AuthProvider class now inherits the standard version property and dispose method from BaseModuleProvider, ensuring proper integration with the Fusion Framework's module system.

--- a/packages/modules/msal/src/v2/provider.ts
+++ b/packages/modules/msal/src/v2/provider.ts
@@ -6,7 +6,7 @@ import type { AuthClientConfig } from './configurator';
 import type { AccountInfo, AuthenticationResult } from './types';
 import type { IProxyProvider } from '../types';
 import { resolveVersion } from '../versioning/resolve-version';
-import { SemanticVersion } from '@equinor/fusion-framework-module';
+import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
 
 export interface IAuthProvider {
   // readonly defaultClient: AuthClient;
@@ -47,12 +47,11 @@ export interface IAuthProvider {
   handleRedirect(): Promise<void | null>;
 }
 
-export class AuthProvider implements IAuthProvider, IProxyProvider {
+export class AuthProvider
+  extends BaseModuleProvider<AuthClientConfig>
+  implements IAuthProvider, IProxyProvider
+{
   #client: AuthClient;
-
-  get version(): SemanticVersion {
-    return new SemanticVersion(MsalModuleVersion.Latest);
-  }
 
   get defaultAccount(): AccountInfo | undefined {
     return this.client.account;
@@ -64,6 +63,10 @@ export class AuthProvider implements IAuthProvider, IProxyProvider {
   }
 
   constructor(protected _config: AuthClientConfig) {
+    super({
+      version: MsalModuleVersion.Latest,
+      config: _config,
+    });
     this.#client = this.createClient();
   }
 
@@ -146,7 +149,7 @@ export class AuthProvider implements IAuthProvider, IProxyProvider {
             return target.version;
           case 'client':
             return target.client;
-          // @ts-expect-error - this is deprecated since version 5.0.1
+          // @ts-expect-error this is deprecated since version 5.0.1
           case 'defaultClient':
             console.warn('defaultClient is deprecated, use client instead');
             return target.client;


### PR DESCRIPTION
## Why

**What kind of change does this PR introduce?**  
Code improvement/refactor

**Why is this change needed?**  
AuthProvider should extend BaseModuleProvider for proper integration with the Fusion Framework's module system, eliminating initialization warnings.

**What is the current behavior?**  
AuthProvider implements IAuthProvider and IProxyProvider but does not extend BaseModuleProvider, which causes warnings during module initialization.

**What is the new behavior?**  
AuthProvider now properly extends BaseModuleProvider, eliminating initialization warnings and ensuring better integration.

**Does this PR introduce a breaking change?**  
No

**Additional context**  
The AuthProvider class now inherits the standard version property and dispose method from BaseModuleProvider, ensuring proper integration with the Fusion Framework's module system.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)