### PR TITLE
fix(cli): correct config parameter passing in app config publish command

### DIFF
--- a/.changeset/fix-app-config-publish-parameter.md
+++ b/.changeset/fix-app-config-publish-parameter.md
@@ -1,0 +1,22 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+## Fix app config publish parameter
+
+Fixed a bug in the `app config` command where the `config` parameter was incorrectly referenced as `options.config` when calling `publishAppConfig`. This was causing the publish functionality to fail when a custom config file path was provided.
+
+### What Changed
+- Corrected parameter passing in `packages/cli/src/cli/commands/app/config.ts`
+- Changed `config: options.config` to `config` in the `publishAppConfig` call
+
+### Impact
+- The `ffc app config --publish` command now correctly uses the provided config file argument
+- Fixes the issue where custom config files were not being passed to the publish function
+- No breaking changes to the CLI interface
+
+### Example
+```bash
+# This now works correctly with custom config files
+ffc app config my-custom.config.ts --publish --manifest app.manifest.ts --env prod
+```

--- a/packages/cli/src/cli/commands/app/config.ts
+++ b/packages/cli/src/cli/commands/app/config.ts
@@ -95,7 +95,7 @@ export const command = withAuthOptions(
           process.exit(1);
         }
         return publishAppConfig({
-          config: options.config,
+          config,
           manifest: options.manifest,
           environment: options.env,
           auth: 'token' in options ? { token: options.token } : options,


### PR DESCRIPTION
## Why
Fixed a bug in the `ffc app config --publish` command where the `config` parameter was incorrectly referenced as `options.config` when calling `publishAppConfig`. This was causing the publish functionality to fail when a custom config file path was provided.

### What Changed
- Corrected parameter passing in `packages/cli/src/cli/commands/app/config.ts`
- Changed `config: options.config` to `config` in the `publishAppConfig` call

### Impact
- The `ffc app config --publish` command now correctly uses the provided config file argument
- Fixes the issue where custom config files were not being passed to the publish function
- No breaking changes to the CLI interface

### Example
```bash
# This now works correctly with custom config files
ffc app config my-custom.config.ts --publish --manifest app.manifest.ts --env prod
```

### Testing
- Manual testing with custom config files
- Verified the publish command works with both default and custom config paths

### Check off the following:
- [x] Confirm that I checked changes to branch which I am merging into.
  - _I have validated included files_
  - _My code does not generate new linting warnings_
  - _My PR is not a duplicate, [check existing pr's](https://github.com/equinor/fusion-framework/pulls)_
- [x] Confirm that the I have completed the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md).
- [x] Confirm that my changes meet our [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md).