### PR TITLE
fix(service-discovery): ServiceDiscoveryProvider extends BaseModuleProvider

### DIFF
--- a/.changeset/service-discovery-provider-fix.md
+++ b/.changeset/service-discovery-provider-fix.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-service-discovery": patch
+---
+
+Fix ServiceDiscoveryProvider to extend BaseModuleProvider, ensuring proper module interface implementation and preventing configuration errors.

--- a/packages/modules/service-discovery/src/provider.ts
+++ b/packages/modules/service-discovery/src/provider.ts
@@ -1,4 +1,5 @@
 import { configureHttpClient } from '@equinor/fusion-framework-module-http';
+import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
 
 import type { ModulesConfigurator, ModuleType } from '@equinor/fusion-framework-module';
 import type {
@@ -6,6 +7,8 @@ import type {
   HttpModule,
   IHttpClient,
 } from '@equinor/fusion-framework-module-http';
+
+import { version } from './version';
 
 import type { Service } from './types';
 import type { ServiceDiscoveryConfig } from './configurator';
@@ -69,11 +72,19 @@ export interface IServiceDiscoveryProvider {
   readonly config: ServiceDiscoveryConfig;
 }
 
-export class ServiceDiscoveryProvider implements IServiceDiscoveryProvider {
+export class ServiceDiscoveryProvider
+  extends BaseModuleProvider<ServiceDiscoveryConfig>
+  implements IServiceDiscoveryProvider
+{
   constructor(
     public readonly config: ServiceDiscoveryConfig,
     protected readonly _http: ModuleType<HttpModule>,
-  ) {}
+  ) {
+    super({
+      version,
+      config,
+    });
+  }
 
   public resolveServices(): Promise<Service[]> {
     return this.config.discoveryClient.resolveServices();


### PR DESCRIPTION
## Why

**Why is this change needed?**
The ServiceDiscoveryProvider was not extending BaseModuleProvider, which caused configuration errors when enabling the service-discovery module.

**What is the current behavior?**
The ServiceDiscoveryProvider only implemented the IServiceDiscoveryProvider interface but did not extend BaseModuleProvider, leading to module configuration errors.

**What is the new behavior?**
The ServiceDiscoveryProvider now properly extends BaseModuleProvider, ensuring correct module interface implementation and preventing configuration errors.

**Does this PR introduce a breaking change?** 
No, this is a bug fix that makes the provider conform to expected interface requirements.

**Additional context**
This fix ensures that the service-discovery module provider follows the same pattern as other module providers in the framework.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)