### PR TITLE
refactor: feature flag provider improvements

### DIFF
--- a/.changeset/feature-flag-module-provider-fix.md
+++ b/.changeset/feature-flag-module-provider-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-feature-flag": patch
+---
+
+Fix FeatureFlagProvider to extend BaseModuleProvider, ensuring proper framework integration and consistent provider lifecycle management.
+
+Provider now correctly implements IModuleProvider interface through BaseModuleProvider inheritance.


### PR DESCRIPTION
## Why

**Why is this change needed?**

The FeatureFlagProvider needed to properly extend BaseModuleProvider to ensure correct framework integration and consistent provider lifecycle management.

**What is the current behavior?**

The FeatureFlagProvider was not extending BaseModuleProvider, which could lead to inconsistent provider lifecycle management and integration issues with the framework.

**What is the new behavior?**

FeatureFlagProvider now extends BaseModuleProvider and correctly implements the IModuleProvider interface through BaseModuleProvider inheritance, ensuring proper framework integration and consistent provider lifecycle management.

**Does this PR introduce a breaking change?**

No - this is an internal refactoring that maintains the same public API.

**Additional context**

This change improves the reliability and consistency of the feature flag module within the Fusion Framework.

**Related issues**

closes:

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - [x] _Included files validated_
  - [x] _No new linting warnings_
  - [x] _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)