### PR TITLE
refactor: fix ApiProvider to extend BaseModuleProvider

### DIFF
--- a/.changeset/fusion-framework-module-services-provider-fix.md
+++ b/.changeset/fusion-framework-module-services-provider-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-services": patch
+---
+
+Fix ApiProvider to extend BaseModuleProvider, ensuring proper framework integration and consistent provider lifecycle management.
+
+Provider now correctly implements IModuleProvider interface through BaseModuleProvider inheritance.

--- a/packages/modules/services/src/module.ts
+++ b/packages/modules/services/src/module.ts
@@ -61,7 +61,7 @@ export const module: ServicesModule = {
     if (!config.createClient) {
       throw Error('missing configuration for creating API client');
     }
-    return new ApiProvider(config as Required<IApiConfigurator>);
+    return new ApiProvider({ createClient: config.createClient });
   },
 };
 

--- a/packages/modules/services/src/provider.ts
+++ b/packages/modules/services/src/provider.ts
@@ -1,7 +1,10 @@
 import type { IHttpClient } from '@equinor/fusion-framework-module-http';
+import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
 import type { ClientMethod } from './types';
+import type { IApiConfigurator } from './configurator';
 
 import type { ApiClientFactory } from './types';
+import { version } from './version.js';
 import { ContextApiClient } from './context';
 import BookmarksApiClient from './bookmarks/client';
 import { NotificationApiClient } from './notification';
@@ -76,12 +79,18 @@ const validateResponse = async (response: Response) => {
   }
 };
 
+type ApiProviderConfig<TClient extends IHttpClient = IHttpClient> = {
+  createClient: ApiClientFactory<TClient>;
+};
+
 export class ApiProvider<TClient extends IHttpClient = IHttpClient>
+  extends BaseModuleProvider<ApiProviderConfig<TClient>>
   implements IApiProvider<TClient>
 {
   protected _createClientFn: ApiClientFactory<TClient>;
-  constructor({ createClient }: ApiProviderCtorArgs<TClient>) {
-    this._createClientFn = createClient;
+  constructor(config: ApiProviderConfig<TClient>) {
+    super({ version, config });
+    this._createClientFn = config.createClient;
   }
 
   public async createNotificationClient<TMethod extends keyof ClientMethod>(


### PR DESCRIPTION
## Why

**Why is this change needed?**
This refactor fixes the ApiProvider class to properly extend BaseModuleProvider, ensuring correct framework integration and consistent provider lifecycle management.

**What is the current behavior?**
The ApiProvider was not properly inheriting from BaseModuleProvider, which could lead to inconsistent provider lifecycle management and potential integration issues with the Fusion Framework.

**What is the new behavior?**
ApiProvider now correctly extends BaseModuleProvider and implements the IModuleProvider interface through proper inheritance, ensuring consistent provider lifecycle management across the framework.

**Does this PR introduce a breaking change?**
No, this is an internal refactor that maintains the same public API while fixing the inheritance structure.

**Additional context**
This change improves the robustness of the services module by ensuring proper framework integration patterns are followed.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings introduced by these changes_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)