### PR TITLE
Refactor ContextProvider to extend BaseModuleProvider and include ver…

### DIFF
--- a/.changeset/context-module-provider-fix.md
+++ b/.changeset/context-module-provider-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-context": patch
+---
+
+Fix ContextProvider to extend BaseModuleProvider, ensuring proper framework integration and consistent provider lifecycle management.
+
+Provider now correctly implements IModuleProvider interface through BaseModuleProvider inheritance.

--- a/packages/modules/context/src/ContextProvider.ts
+++ b/packages/modules/context/src/ContextProvider.ts
@@ -12,6 +12,9 @@ import {
 
 import type { ContextModuleConfig } from './configurator';
 
+import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
+import { version } from './version.js';
+
 import { ContextClient } from './client/ContextClient';
 import type { ContextItem, QueryContextParameters, RelatedContextParameters } from './types';
 import type { ModuleType } from '@equinor/fusion-framework-module';
@@ -325,7 +328,10 @@ export interface IContextProvider {
  * provider.setCurrentContextById('context-id').subscribe(...);
  * ```
  */
-export class ContextProvider implements IContextProvider {
+export class ContextProvider
+  extends BaseModuleProvider<ContextModuleConfig>
+  implements IContextProvider
+{
   #contextClient: ContextClient;
   #contextQuery: Query<Array<ContextItem>, QueryContextParameters>;
   #contextRelated?: Query<Array<ContextItem>, RelatedContextParameters>;
@@ -376,6 +382,8 @@ export class ContextProvider implements IContextProvider {
     parentContext?: IContextProvider;
   }) {
     const { config, event } = args;
+
+    super({ version, config });
 
     if (args.parentContext) {
       console.warn(


### PR DESCRIPTION
## Why

**What kind of change does this PR introduce?**  
Bug fix - Provider integration

**What is the current behavior?**  
The `ContextProvider` class in the context module does not properly extend `BaseModuleProvider`, causing a warning to be logged during module initialization: "Provider for module context does not extend BaseModuleProvider". This prevents proper framework integration and consistent provider lifecycle management.

**What is the new behavior?**  
The `ContextProvider` now correctly extends `BaseModuleProvider<ContextModuleConfig>`, ensuring it follows the same pattern as other framework providers (like `FeatureFlagProvider`, `ServiceDiscoveryProvider`, etc.) and properly implements the `IModuleProvider` interface through inheritance.

**Does this PR introduce a breaking change?**  
No - this is an internal implementation change that maintains the same public API and behavior.

**Other information?**  
This fix resolves the telemetry warning that was being generated in the Fusion Dev Portal (version 1.2.2) when the context module was initialized.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
  - [x] Local Checks: `pnpm test && pnpm build` passed
  - [x] Changeset: Created patch changeset for `@equinor/fusion-framework-module-context`
  - [x] Manual Testing: Verified build and tests pass
  - [x] PR Quality: Description and issue context provided
- [x] Confirm changes to target branch validation
  - [x] Included files validated (ContextProvider.ts, changeset)
  - [x] No new linting warnings
  - [x] Not a duplicate PR (checked existing PRs)
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)