### PR TITLE
fix: correct React hooks dependencies in useHelpCenter

### DIFF
--- a/.changeset/react-app_hooks-dependencies-fix.md
+++ b/.changeset/react-app_hooks-dependencies-fix.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Fix React hooks dependency arrays in useHelpCenter to prevent exhaustive dependencies linting errors.
+
+Changed dependency arrays from `[eventModule.dispatchEvent]` to `[eventModule]` in all useCallback hooks to properly track all dependencies used within the callbacks.

--- a/packages/react/app/src/help-center/useHelpCenter.ts
+++ b/packages/react/app/src/help-center/useHelpCenter.ts
@@ -88,7 +88,7 @@ export const useHelpCenter = (): HelpCenter => {
         page: 'home',
       },
     });
-  }, [eventModule.dispatchEvent]);
+  }, [eventModule]);
 
   const openArticle = useCallback(
     (articleId: string): void => {
@@ -99,7 +99,7 @@ export const useHelpCenter = (): HelpCenter => {
         },
       });
     },
-    [eventModule.dispatchEvent],
+    [eventModule],
   );
 
   const openFaqs = useCallback((): void => {
@@ -108,7 +108,7 @@ export const useHelpCenter = (): HelpCenter => {
         page: 'faqs',
       },
     });
-  }, [eventModule.dispatchEvent]);
+  }, [eventModule]);
 
   const openSearch = useCallback(
     (search: string): void => {
@@ -119,7 +119,7 @@ export const useHelpCenter = (): HelpCenter => {
         },
       });
     },
-    [eventModule.dispatchEvent],
+    [eventModule],
   );
 
   const openGovernance = useCallback((): void => {
@@ -128,7 +128,7 @@ export const useHelpCenter = (): HelpCenter => {
         page: 'governance',
       },
     });
-  }, [eventModule.dispatchEvent]);
+  }, [eventModule]);
 
   const openReleaseNotes = useCallback((): void => {
     eventModule.dispatchEvent(EVENT_NAME, {
@@ -136,7 +136,7 @@ export const useHelpCenter = (): HelpCenter => {
         page: 'release-notes',
       },
     });
-  }, [eventModule.dispatchEvent]);
+  }, [eventModule]);
 
   return {
     openHelp,


### PR DESCRIPTION
## Why

**Why is this change needed?**
This change fixes 12 React hooks exhaustive dependencies linting errors in the useHelpCenter component. The current dependency arrays were incorrectly specifying `eventModule.dispatchEvent` instead of the entire `eventModule` object, which violates React's exhaustive dependencies rule.

**What is the current behavior?**
The useHelpCenter hook has incorrect dependency arrays in all useCallback hooks, causing linting errors:
- `useCallback` hooks specify `[eventModule.dispatchEvent]` in dependencies
- This triggers `useExhaustiveDependencies` linting errors because the hooks use the entire `eventModule` object

**What is the new behavior?**
After this fix:
- All `useCallback` hooks now correctly specify `[eventModule]` in their dependency arrays
- No more linting errors related to exhaustive dependencies
- Proper dependency tracking ensures hooks work correctly with React's reconciliation

**Does this PR introduce a breaking change?** 
No, this is a bug fix with no breaking changes. The functionality remains identical, only the dependency arrays are corrected.

**Additional context**
- Fixed 6 useCallback hooks in the useHelpCenter component
- All changes are internal to the hook implementation
- No public API changes
- Includes proper changeset for versioning

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)