### PR TITLE
feat(module-msal): update MSAL module with v4 compatibility

### DIFF
--- a/packages/modules/msal/src/MsalConfigurator.ts
+++ b/packages/modules/msal/src/MsalConfigurator.ts
@@ -10,6 +10,7 @@ import {
 import { MsalClient, type MsalClientConfig, type IMsalClient } from './MsalClient';
 import { createClientLogCallback } from './create-client-log-callback';
 import { LogLevel } from '@azure/msal-browser';
+import { version } from './version';
 
 /**
  * Zod schema for telemetry configuration validation.
@@ -20,7 +21,7 @@ const TelemetryConfigSchema = z.object({
   provider: z.custom<ITelemetryProvider>().optional(),
   metadata: z.record(z.string(), z.unknown()).optional().default({
     module: 'msal',
-    version: MsalModuleVersion.Latest,
+    version,
   }),
   scope: z.array(z.string()).optional().default(['framework', 'authentication']),
 });
@@ -76,7 +77,9 @@ export class MsalConfigurator extends BaseConfigBuilder<MsalConfig> {
    *
    * @default Latest
    */
-  public version = MsalModuleVersion.Latest as const;
+  public get version(): string {
+    return version;
+  }
 
   /**
    * Creates a new MSAL configurator instance.

--- a/packages/modules/msal/src/MsalProxyProvider.interface.ts
+++ b/packages/modules/msal/src/MsalProxyProvider.interface.ts
@@ -15,7 +15,6 @@ import type { IMsalProvider as IMsalProvider_v2 } from './v2/MsalProvider.interf
 type ProxyProviderMap = {
   [MsalModuleVersion.V2]: IMsalProvider_v2;
   [MsalModuleVersion.V4]: IMsalProvider;
-  [MsalModuleVersion.Latest]: IMsalProvider;
 };
 
 /**
@@ -29,7 +28,8 @@ type ProxyProviderMap = {
  * This interface should ideally be defined in the @equinor/fusion-framework-module package
  * for broader framework compatibility.
  *
- * @property version - The current version of the provider
+ * @property version - The semantic version of the provider
+ * @property msalVersion - The MSAL module version enum value
  * @property createProxyProvider - Method to create a version-specific proxy provider
  *
  * @example
@@ -42,8 +42,21 @@ type ProxyProviderMap = {
  * ```
  */
 export interface IProxyProvider {
-  /** Current version of the provider (MSAL module version) */
-  version: string | SemVer;
+  /**
+   * The semantic version of the provider.
+   *
+   * This represents the actual version number of the MSAL implementation,
+   * following semantic versioning (semver) standards.
+   */
+  readonly version: string | SemVer;
+
+  /**
+   * The MSAL module version enum value indicating the API compatibility level.
+   *
+   * This property specifies which MSAL version's API surface this provider implements,
+   * allowing for version-specific behavior and proxy provider creation.
+   */
+  msalVersion: MsalModuleVersion;
 
   /**
    * Creates a proxy provider compatible with the specified MSAL version.

--- a/packages/modules/msal/src/module.ts
+++ b/packages/modules/msal/src/module.ts
@@ -4,11 +4,11 @@ import {
   SemanticVersion,
 } from '@equinor/fusion-framework-module';
 
-import { MsalModuleVersion } from './static';
-
 import { MsalConfigurator } from './MsalConfigurator';
 import { MsalProvider, type IMsalProvider } from './MsalProvider';
 import type { MsalClientConfig } from './MsalClient';
+
+import { version } from './version';
 
 /**
  * MSAL authentication module configuration.
@@ -32,7 +32,7 @@ export type MsalModule = Module<'auth', IMsalProvider, MsalConfigurator, [MsalMo
  */
 export const module: MsalModule = {
   name: 'auth',
-  version: new SemanticVersion(MsalModuleVersion.Latest),
+  version: new SemanticVersion(version),
   configure: () => new MsalConfigurator(),
   initialize: async (init) => {
     const config = await init.config.createConfigAsync(init);
@@ -47,9 +47,8 @@ export const module: MsalModule = {
     const hostProvider = init.ref?.auth;
     if (hostProvider) {
       try {
-        return hostProvider.createProxyProvider(
-          config.version as MsalModuleVersion,
-        ) as IMsalProvider;
+        const proxyProvider = hostProvider.createProxyProvider(config.version);
+        return proxyProvider;
       } catch (error) {
         console.error('MsalModule::Failed to create proxy provider', error);
         // Fallback to host provider to prevent app breakage during migration

--- a/packages/modules/msal/src/static.ts
+++ b/packages/modules/msal/src/static.ts
@@ -1,5 +1,3 @@
-import { version } from './version';
-
 /**
  * Module identifier for the MSAL authentication module.
  *
@@ -36,6 +34,4 @@ export enum MsalModuleVersion {
   V2 = 'v2',
   /** MSAL v4 (current major version) */
   V4 = 'v4',
-  /** Latest module version (automatically set from package.json) */
-  Latest = version,
 }

--- a/packages/modules/msal/src/v2/MsalProvider.interface.ts
+++ b/packages/modules/msal/src/v2/MsalProvider.interface.ts
@@ -1,3 +1,5 @@
+import type { SemVer } from 'semver';
+import type { MsalModuleVersion } from '../static';
 import type { IPublicClientApplication } from './IPublicClientApplication.interface';
 import type { AccountInfo, AuthenticationResult } from './types';
 
@@ -9,6 +11,12 @@ import type { AccountInfo, AuthenticationResult } from './types';
  * under the hood. This is useful for gradual migration scenarios.
  */
 export interface IMsalProvider {
+  /** Current version of the provider (MSAL module version) */
+  version: string | SemVer;
+
+  /** Current MSAL module version */
+  msalVersion: MsalModuleVersion;
+
   /**
    * The MSAL PublicClientApplication instance (v2 compatible)
    */

--- a/packages/modules/msal/src/v2/create-proxy-client.ts
+++ b/packages/modules/msal/src/v2/create-proxy-client.ts
@@ -133,6 +133,7 @@ export function createProxyClient(client: IMsalClient): IAuthClient {
             return await target.acquireToken({
               request: {
                 scopes: options?.scopes || [],
+                account: target.getActiveAccount() ?? undefined,
                 loginHint: options?.loginHint,
               },
               behavior: behavior,

--- a/packages/modules/msal/src/v2/create-proxy-provider.ts
+++ b/packages/modules/msal/src/v2/create-proxy-provider.ts
@@ -3,7 +3,7 @@ import type { IMsalProvider as IMsalProvider_v2 } from './MsalProvider.interface
 import type { AccountInfo as AccountInfo_v2 } from './types';
 import { createProxyClient } from './create-proxy-client';
 import { mapAccountInfo } from './map-account-info';
-import type { MsalModuleVersion } from '../static';
+import { MsalModuleVersion } from '../static';
 
 /**
  * Creates a proxy provider for MSAL v2 compatibility.
@@ -34,6 +34,12 @@ export function createProxyProvider(provider: IMsalProvider): IMsalProvider_v2 {
   const proxy = new Proxy(provider, {
     get: (target: IMsalProvider, prop: keyof IMsalProvider_v2) => {
       switch (prop) {
+        case 'version': {
+          return provider.version;
+        }
+        case 'msalVersion': {
+          return MsalModuleVersion.V2;
+        }
         case 'client': {
           // Return the v2-compatible client wrapper
           return v2Client as unknown as IMsalProvider_v2['client'];
@@ -133,6 +139,9 @@ export function createProxyProvider(provider: IMsalProvider): IMsalProvider_v2 {
           };
         }
         default: {
+          if (prop === 'then') {
+            return undefined;
+          }
           // Exhaustive check to ensure all v2 properties are handled
           const exhaustiveCheck: never = prop;
           // Fallback: return original property from target for any unhandled cases

--- a/packages/modules/msal/src/versioning/resolve-version.ts
+++ b/packages/modules/msal/src/versioning/resolve-version.ts
@@ -1,9 +1,34 @@
-import semver, { type SemVer } from 'semver';
+import semver, { SemVer } from 'semver';
 
 import { MsalModuleVersion } from '../static';
 
 import { VersionError } from './VersionError';
 import type { ResolvedVersion } from './types';
+
+import { version as latestVersionString } from '../version';
+
+/**
+ * Maps a version string or object to the corresponding MSAL module enum version.
+ *
+ * @param version - The version string or SemVer object to map
+ * @returns The corresponding MsalModuleVersion enum value
+ *
+ * @example
+ * ```typescript
+ * mapVersionToEnumVersion('2.1.0') // returns MsalModuleVersion.V2
+ * mapVersionToEnumVersion('7.0.0') // returns MsalModuleVersion.V4
+ * ```
+ */
+function mapVersionToEnumVersion(version: string | SemVer): MsalModuleVersion {
+  const coercedVersion = semver.coerce(version);
+  if (!coercedVersion) {
+    throw new Error(`Invalid version: ${version}`);
+  }
+  if (semver.satisfies(coercedVersion, '<6.0.0')) {
+    return MsalModuleVersion.V2;
+  }
+  return MsalModuleVersion.V4;
+}
 
 /**
  * Resolves and validates a version string against the latest available MSAL version.
@@ -49,28 +74,27 @@ export function resolveVersion(version?: string | SemVer): ResolvedVersion {
   const warnings: string[] = [];
 
   // Parse the requested version, defaulting to latest if not provided
-  const versionString = version || MsalModuleVersion.Latest;
+  let wantedVersion = version ? semver.coerce(version) : semver.coerce(latestVersionString);
 
   // Parse versions using coerce for backward compatibility
-  const latestVersion = semver.coerce(MsalModuleVersion.Latest);
+  const latestVersion = semver.coerce(latestVersionString);
 
   // This should never happen! Indicates version.ts was not generated correctly
   // This is a critical build-time issue that needs immediate attention
   if (!latestVersion) {
     throw new VersionError(
-      `Failed to parse latest version "${MsalModuleVersion.Latest}" - this indicates the version.ts file was not generated correctly. Check for import errors in the build process.`,
-      versionString,
-      MsalModuleVersion.Latest,
+      `Failed to parse latest version "${latestVersionString}" - this indicates the version.ts file was not generated correctly. Check for import errors in the build process.`,
+      wantedVersion || '<unknown version>',
+      latestVersionString,
     );
   }
 
-  let wantedVersion: SemVer | null = semver.coerce(versionString);
   // Validate that the requested version is a valid semver
   if (!wantedVersion) {
     const missingVersionWarning = new VersionError(
-      `Failed to parse requested version "${versionString}"`,
-      versionString,
-      MsalModuleVersion.Latest,
+      `Failed to parse requested version "${version || '<unknown version>'}"`,
+      wantedVersion || '<unknown version>',
+      latestVersion,
     );
     warnings.push(missingVersionWarning.message);
     wantedVersion = latestVersion;
@@ -98,24 +122,7 @@ export function resolveVersion(version?: string | SemVer): ResolvedVersion {
 
   // Find the corresponding enum version for the requested major version
   // This is used for module configuration and feature detection
-  let enumVersion = Object.values(MsalModuleVersion).find(
-    (x) => semver.coerce(x)?.major === wantedVersion.major,
-  );
-
-  // If no matching enum version is found, fall back to the latest available
-  // This allows forward compatibility with future versions
-  if (!enumVersion) {
-    enumVersion = MsalModuleVersion.Latest;
-    // Only warn if this is a future version (higher than latest)
-    if (wantedVersion.major > latestVersion.major) {
-      const fallbackWarning = new VersionError(
-        `Requested major version ${wantedVersion.major} is greater than the latest major version ${latestVersion.major}. Falling back to latest version.`,
-        wantedVersion,
-        latestVersion,
-      );
-      warnings.push(fallbackWarning.message);
-    }
-  }
+  const enumVersion = mapVersionToEnumVersion(wantedVersion);
 
   // Return comprehensive version resolution result
   return {


### PR DESCRIPTION
## Why

**Why is this change needed?**
Update the MSAL module to support Microsoft Authentication Library v4, which includes breaking API changes and new features.

**What is the current behavior?**
The MSAL module currently supports older versions of the Microsoft Authentication Library.

**What is the new behavior?**
The MSAL module now supports MSAL v4 with updated APIs, improved compatibility, and enhanced version resolution logic.

**Does this PR introduce a breaking change?** 
Yes - this updates the MSAL module to v4 which includes breaking API changes. Consumers will need to update their MSAL configurations and potentially their authentication flow implementations.

**Additional context**
This update includes:
- Refactored MsalConfigurator for v4 API changes
- Updated MsalProvider interfaces and implementation
- Modified proxy providers for v4 compatibility
- Updated version resolution logic for MSAL v4
- Added comprehensive tests for version resolution

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)