### PR TITLE
fix: telemetry module documentation examples

### DIFF
--- a/.changeset/framework_module_telemetry_doc_fixes.md
+++ b/.changeset/framework_module_telemetry_doc_fixes.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-module-telemetry": patch
+---
+
+Fix incorrect TSDoc examples in telemetry module documentation.
+
+- Remove non-existent `setFilter` method references from TelemetryConfigurator documentation
+- Fix exception examples to include required `exception` property
+- Correct metric examples to have `value` at top level instead of in properties
+- Update scope properties to use array format instead of single strings
+- Improve formatting of trackException example for better readability

--- a/packages/modules/telemetry/README.md
+++ b/packages/modules/telemetry/README.md
@@ -377,7 +377,6 @@ const configure = (configurator: IModulesConfigurator<any, any>) => {
       }
     });
     args.config.setDefaultScope(['portal']);
-    args.config.setFilter((item) => item.scope.includes('portal'));
     }
   });
 };

--- a/packages/modules/telemetry/src/TelemetryConfigurator.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.ts
@@ -26,7 +26,7 @@ import type { ITelemetryAdapter } from './TelemetryAdapter.js';
  * Configures telemetry settings for the application.
  *
  * The `TelemetryConfigurator` class extends `BaseConfigBuilder` to provide a fluent API for
- * setting up telemetry adapters, metadata, default scopes, parent providers, and filters.
+ * setting up telemetry adapters, metadata, default scopes, and parent providers.
  *
  * @example
  * ```typescript
@@ -34,13 +34,13 @@ import type { ITelemetryAdapter } from './TelemetryAdapter.js';
  *   .setAdapter(myAdapter)
  *   .setMetadata({ app: 'my-app' })
  *   .setDefaultScope(['user', 'session'])
- *   .setParent(parentProvider)
- *   .setFilter(myFilter);
+ *   .setParent(parentProvider);
  * ```
  *
  * @remarks
  * - Adapters are managed internally and can be set using `setAdapter`.
- * - Metadata, default scope, parent provider, and filter can be configured via their respective methods.
+ * - Metadata, default scope, and parent provider can be configured via their respective methods.
+ * - Filters should be applied directly to individual adapters when they are created.
  * - All setter methods return `this` for method chaining.
  *
  * @see BaseConfigBuilder

--- a/packages/modules/telemetry/src/TelemetryProvider.interface.ts
+++ b/packages/modules/telemetry/src/TelemetryProvider.interface.ts
@@ -48,25 +48,27 @@ export interface ITelemetryProvider {
    *   name: 'user_login',
    *   properties: { userId: '123' },
    *   level: TelemetryLevel.Information,
-   *   scope: TelemetryScope.Application
+   *   scope: [TelemetryScope.Application]
    * });
    *
    * // Track an exception
    * provider.track({
    *   type: TelemetryType.Exception,
    *   name: 'api_error',
-   *   properties: { message: 'Request failed', code: 500 },
+   *   exception: new Error('Request failed'),
+   *   properties: { code: 500 },
    *   level: TelemetryLevel.Error,
-   *   scope: TelemetryScope.Application
+   *   scope: [TelemetryScope.Application]
    * });
    *
    * // Track a metric
    * provider.track({
    *   type: TelemetryType.Metric,
    *   name: 'load_time',
-   *   properties: { duration: 1234 },
+   *   value: 1234,
+   *   properties: { page: 'home' },
    *   level: TelemetryLevel.Information,
-   *   scope: TelemetryScope.Application
+   *   scope: [TelemetryScope.Application]
    * });
    *
    * // Track a custom telemetry item
@@ -74,8 +76,8 @@ export interface ITelemetryProvider {
    *   type: TelemetryType.Custom,
    *   name: 'custom_event',
    *   properties: { foo: 'bar' },
-   *   level: TelemetryLevel.Verbose,
-   *   scope: TelemetryScope.Application
+   *   level: TelemetryLevel.Debug,
+   *   scope: [TelemetryScope.Application]
    * });
    */
   track<T extends TelemetryItem>(item: T): void;
@@ -89,6 +91,8 @@ export interface ITelemetryProvider {
    * provider.trackEvent({
    *   name: 'user_signup',
    *   properties: { userId: '456' },
+   *   level: TelemetryLevel.Information,
+   *   scope: [TelemetryScope.Application]
    * });
    */
   trackEvent(item: Omit<TelemetryItem, 'type'> & { type?: TelemetryType.Event }): void;
@@ -101,7 +105,8 @@ export interface ITelemetryProvider {
    * @example
    * provider.trackException({
    *   name: 'api_error',
-   *   properties: { message: 'Request failed', code: 500 },
+   *   exception: new Error('Request failed'),
+   *   properties: { code: 500 },
    * });
    */
   trackException(data: Omit<z.input<typeof TelemetryExceptionSchema>, 'type'>): void;

--- a/packages/modules/telemetry/src/TelemetryProvider.ts
+++ b/packages/modules/telemetry/src/TelemetryProvider.ts
@@ -338,7 +338,11 @@ export class TelemetryProvider
    *
    * @param data - The exception data (without type)
    * @example
-   * provider.trackException({ name: 'api_error', metadata: { code: 500 } });
+   * provider.trackException({
+   *   name: 'api_error',
+   *   exception: new Error('API failed'),
+   *   metadata: { code: 500 }
+   * });
    */
   public trackException(data: Omit<z.input<typeof TelemetryExceptionSchema>, 'type'>): void {
     this._track(TelemetryExceptionSchema.parse({ ...data, type: TelemetryType.Exception }));


### PR DESCRIPTION
## Why

**Why is this change needed?**
Fix incorrect TSDoc examples in the telemetry module that don't match the actual API, making the documentation confusing for developers.

**What is the current behavior?**
Several TSDoc examples in the telemetry module contain errors:
- References to non-existent `setFilter` method
- Exception examples missing required `exception` property
- Metric examples with incorrect `value` placement
- Scope properties using wrong format

**What is the new behavior?**
All TSDoc examples now correctly demonstrate the proper usage of telemetry tracking methods with accurate property structures and required fields.

**Does this PR introduce a breaking change?**
No, this only fixes documentation examples.

**Additional context**
These changes improve developer experience by providing correct, copy-pasteable examples in the IDE IntelliSense.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)