### PR TITLE
feat(telemetry): add filtering options for adapter and relay messages

### DIFF
--- a/.changeset/module-telemetry_add-filtering.md
+++ b/.changeset/module-telemetry_add-filtering.md
@@ -1,0 +1,42 @@
+---
+"@equinor/fusion-framework-module-telemetry": minor
+---
+
+Add filtering options for telemetry messages passed from provider to adapters and parent providers.
+
+**New Features**
+
+- **`setAdapterFilter`**: Filter which telemetry items are passed to adapters
+- **`setRelayFilter`**: Filter which telemetry items are relayed to parent providers
+
+**Usage**
+
+```typescript
+enableTelemetry(configurator, {
+  configure: (builder) => {
+    // Only send exceptions to adapters
+    builder.setAdapterFilter((item) => item.type === TelemetryType.Exception);
+    
+    // Only relay important events to parent provider
+    builder.setRelayFilter((item) => 
+      item.type === TelemetryType.Exception || 
+      item.scope?.includes('critical')
+    );
+  }
+});
+```
+
+**Hierarchical Filtering**
+
+This feature enables filtering at each level of hierarchical telemetry setups (bootstrap → portal → apps), allowing:
+- Portal instances to filter which events reach bootstrap adapters
+- App instances to filter which events reach portal providers
+- Performance optimization by filtering unnecessary telemetry before processing
+- Privacy control by preventing sensitive telemetry from flowing up the hierarchy
+
+**Backward Compatibility**
+
+Existing code continues to work without filters - all items pass through by default when no filters are configured.
+
+Closes: https://github.com/equinor/fusion-framework/issues/3774
+

--- a/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
@@ -12,6 +12,8 @@ import type { ConfigBuilderCallback } from '@equinor/fusion-framework-module';
  * @property metadata - Optional function or extractor to provide additional metadata for telemetry items.
  * @property defaultScope - Optional array of strings defining the default scope for telemetry events.
  * @property items$ - Optional observable input stream of telemetry items to be processed.
+ * @property adapterFilter - Optional filter function to determine which telemetry items should be passed to adapters.
+ * @property relayFilter - Optional filter function to determine which telemetry items should be relayed to parent providers.
  */
 export type TelemetryConfig = {
   adapters?: Record<string, ITelemetryAdapter>;
@@ -19,6 +21,8 @@ export type TelemetryConfig = {
   metadata?: MetadataExtractor;
   defaultScope?: string[];
   items$?: ObservableInput<TelemetryItem>;
+  adapterFilter?: (item: TelemetryItem) => boolean;
+  relayFilter?: (item: TelemetryItem) => boolean;
 };
 
 /**
@@ -78,4 +82,22 @@ export interface ITelemetryConfigurator {
    * @returns The configurator instance for method chaining.
    */
   attachItems(item$: ObservableInput<TelemetryItem>): this;
+
+  /**
+   * Sets a filter function to determine which telemetry items should be passed to adapters.
+   * Only items for which the filter returns `true` will be sent to adapters.
+   *
+   * @param filter - Function that receives a telemetry item and returns true if it should be sent to adapters
+   * @returns The configurator instance for method chaining
+   */
+  setAdapterFilter(filter: (item: TelemetryItem) => boolean): this;
+
+  /**
+   * Sets a filter function to determine which telemetry items should be relayed to the parent provider.
+   * Only items for which the filter returns `true` will be relayed to the parent.
+   *
+   * @param filter - Function that receives a telemetry item and returns true if it should be relayed
+   * @returns The configurator instance for method chaining
+   */
+  setRelayFilter(filter: (item: TelemetryItem) => boolean): this;
 }

--- a/packages/modules/telemetry/src/TelemetryConfigurator.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.ts
@@ -21,6 +21,7 @@ import type { ITelemetryProvider } from './TelemetryProvider.interface.js';
 import { toObservable } from '@equinor/fusion-observable';
 import { mergeMetadata } from './utils/merge-telemetry-item.js';
 import type { ITelemetryAdapter } from './TelemetryAdapter.js';
+import type { TelemetryItem } from './types.js';
 
 /**
  * Configures telemetry settings for the application.
@@ -155,6 +156,30 @@ export class TelemetryConfigurator
 
   public attachItems(item$: TelemetryConfig['items$']): this {
     this._set('items$', item$);
+    return this;
+  }
+
+  /**
+   * Sets a filter function to determine which telemetry items should be passed to adapters.
+   * Only items for which the filter returns `true` will be sent to adapters.
+   *
+   * @param filter - Function that receives a telemetry item and returns true if it should be sent to adapters
+   * @returns The configurator instance for method chaining
+   */
+  public setAdapterFilter(filter: (item: TelemetryItem) => boolean): this {
+    this._set('adapterFilter', filter);
+    return this;
+  }
+
+  /**
+   * Sets a filter function to determine which telemetry items should be relayed to the parent provider.
+   * Only items for which the filter returns `true` will be relayed to the parent.
+   *
+   * @param filter - Function that receives a telemetry item and returns true if it should be relayed
+   * @returns The configurator instance for method chaining
+   */
+  public setRelayFilter(filter: (item: TelemetryItem) => boolean): this {
+    this._set('relayFilter', filter);
     return this;
   }
 }


### PR DESCRIPTION
## Why

**Why is this change needed?**
Currently, the telemetry module sends all telemetry items to all registered adapters and relays all items to parent providers without any filtering mechanism at the provider level. This is problematic in hierarchical setups (bootstrap → portal → apps) where portal instances cannot control which events reach bootstrap adapters, and app instances cannot control which events reach portal providers.

**What is the current behavior?**
- All adapters receive all telemetry items, even if they're not interested in them
- All items are relayed to parent providers without any filtering
- In hierarchical setups, all telemetry flows up the chain without filtering at each level
- No way to configure filtering at the module configuration level

**What is the new behavior?**
- Added `setAdapterFilter` method to filter which telemetry items are passed to adapters
- Added `setRelayFilter` method to filter which telemetry items are relayed to parent providers
- Filters can be configured when enabling the telemetry module via the configurator
- Enables hierarchical filtering for bootstrap → portal → apps scenarios

**Does this PR introduce a breaking change?**
No. This is a backward-compatible addition. Existing code continues to work without filters - all items pass through by default when no filters are configured.

**Additional context**
This implementation addresses the requirements in issue #3774. The filters are applied at the provider level before items reach adapters or are relayed, providing configuration-level control over message routing.

**Related issues**
closes: #3774

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)