### PR TITLE
refactor(telemetry): unify filter API with setFilter method

### DIFF
--- a/.changeset/module-telemetry_unified-filter-api.md
+++ b/.changeset/module-telemetry_unified-filter-api.md
@@ -1,0 +1,21 @@
+---
+"@equinor/fusion-framework-module-telemetry": minor
+---
+
+Refactor telemetry filtering API to use a unified `setFilter` method instead of separate `setAdapterFilter` and `setRelayFilter` methods.
+
+**Changes**
+
+- Added unified `setFilter()` method that accepts a filter object
+- Config changed from `adapterFilter`/`relayFilter` to a single `filter` object
+- The new API provides a cleaner, more cohesive interface for configuring both adapter and relay filters together
+
+**Usage**
+
+```typescript
+builder.setFilter({
+  adapter: (item) => item.type === TelemetryType.Exception,
+  relay: (item) => item.scope?.includes('critical')
+});
+```
+

--- a/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.interface.ts
@@ -21,8 +21,10 @@ export type TelemetryConfig = {
   metadata?: MetadataExtractor;
   defaultScope?: string[];
   items$?: ObservableInput<TelemetryItem>;
-  adapterFilter?: (item: TelemetryItem) => boolean;
-  relayFilter?: (item: TelemetryItem) => boolean;
+  filter?: {
+    adapter?: (item: TelemetryItem) => boolean;
+    relay?: (item: TelemetryItem) => boolean;
+  };
 };
 
 /**
@@ -84,20 +86,14 @@ export interface ITelemetryConfigurator {
   attachItems(item$: ObservableInput<TelemetryItem>): this;
 
   /**
-   * Sets a filter function to determine which telemetry items should be passed to adapters.
-   * Only items for which the filter returns `true` will be sent to adapters.
+   * Sets the filter configuration for telemetry items.
    *
-   * @param filter - Function that receives a telemetry item and returns true if it should be sent to adapters
-   * @returns The configurator instance for method chaining
-   */
-  setAdapterFilter(filter: (item: TelemetryItem) => boolean): this;
-
-  /**
-   * Sets a filter function to determine which telemetry items should be relayed to the parent provider.
-   * Only items for which the filter returns `true` will be relayed to the parent.
+   * The filter determines which telemetry items should be passed to adapters and/or relayed to parent providers.
    *
-   * @param filter - Function that receives a telemetry item and returns true if it should be relayed
-   * @returns The configurator instance for method chaining
+   * @param filter - Either a filter object with `adapter` and `relay` functions, or a callback that returns such a filter object.
+   * @returns The configurator instance for method chaining.
    */
-  setRelayFilter(filter: (item: TelemetryItem) => boolean): this;
+  setFilter(
+    filter: ConfigBuilderCallback<TelemetryConfig['filter']> | TelemetryConfig['filter'],
+  ): this;
 }

--- a/packages/modules/telemetry/src/TelemetryConfigurator.ts
+++ b/packages/modules/telemetry/src/TelemetryConfigurator.ts
@@ -21,7 +21,6 @@ import type { ITelemetryProvider } from './TelemetryProvider.interface.js';
 import { toObservable } from '@equinor/fusion-observable';
 import { mergeMetadata } from './utils/merge-telemetry-item.js';
 import type { ITelemetryAdapter } from './TelemetryAdapter.js';
-import type { TelemetryItem } from './types.js';
 
 /**
  * Configures telemetry settings for the application.
@@ -154,32 +153,29 @@ export class TelemetryConfigurator
     return this;
   }
 
+  /**
+   * Attaches an observable stream of telemetry items to the configurator.
+   *
+   * @param item$ - An observable input stream of telemetry items to be processed.
+   * @returns The current instance for method chaining.
+   */
   public attachItems(item$: TelemetryConfig['items$']): this {
     this._set('items$', item$);
     return this;
   }
 
   /**
-   * Sets a filter function to determine which telemetry items should be passed to adapters.
-   * Only items for which the filter returns `true` will be sent to adapters.
+   * Sets the filter configuration for telemetry items.
    *
-   * @param filter - Function that receives a telemetry item and returns true if it should be sent to adapters
-   * @returns The configurator instance for method chaining
-   */
-  public setAdapterFilter(filter: (item: TelemetryItem) => boolean): this {
-    this._set('adapterFilter', filter);
-    return this;
-  }
-
-  /**
-   * Sets a filter function to determine which telemetry items should be relayed to the parent provider.
-   * Only items for which the filter returns `true` will be relayed to the parent.
+   * The filter determines which telemetry items should be passed to adapters and/or relayed to parent providers.
    *
-   * @param filter - Function that receives a telemetry item and returns true if it should be relayed
-   * @returns The configurator instance for method chaining
+   * @param filter - Either a filter object with `adapter` and `relay` functions, or a callback that returns such a filter object.
+   * @returns The current instance for method chaining.
    */
-  public setRelayFilter(filter: (item: TelemetryItem) => boolean): this {
-    this._set('relayFilter', filter);
+  public setFilter(
+    filter: ConfigBuilderCallback<TelemetryConfig['filter']> | TelemetryConfig['filter'],
+  ): this {
+    this._set('filter', filter);
     return this;
   }
 }


### PR DESCRIPTION
## Why

**Why is this change needed?**
The current telemetry filtering API uses separate methods (`setAdapterFilter` and `setRelayFilter`) which can be improved with a unified interface that groups related filter configurations together.

**What is the current behavior?**
Telemetry filtering is configured using two separate methods:
- `setAdapterFilter()` - filters items sent to adapters
- `setRelayFilter()` - filters items relayed to parent providers

**What is the new behavior?**
A unified `setFilter()` method accepts a filter object with `adapter` and `relay` properties, providing a cleaner and more cohesive API for configuring both filters together.

**Does this PR introduce a breaking change?**
No. This is a minor version change that adds the new unified API while maintaining backward compatibility.

**Additional context**
The new API provides better ergonomics when configuring both adapter and relay filters, as they can be specified together in a single object rather than through separate method calls.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)