### PR TITLE
chore: bump @azure/msal-node from 3.7.3 to 3.8.3 and @azure/msal-node-extensions from 1.5.11 to 1.5.25

### DIFF
--- a/.changeset/msal-node_update-azure-msal-node.md
+++ b/.changeset/msal-node_update-azure-msal-node.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-module-msal-node": patch
+---
+
+Update @azure/msal-node from 3.7.3 to 3.8.3 and @azure/msal-node-extensions from 1.5.11 to 1.5.25.
+
+This patch update includes bug fixes and improvements to the MSAL Node.js library, including enhanced logging to HttpClient and compatibility updates.
+
+Closes #3780
+Closes #3781
+

--- a/packages/modules/msal-node/package.json
+++ b/packages/modules/msal-node/package.json
@@ -37,8 +37,8 @@
     "directory": "packages/modules/msal-node"
   },
   "dependencies": {
-    "@azure/msal-node": "^3.7.3",
-    "@azure/msal-node-extensions": "^1.5.11",
+    "@azure/msal-node": "^3.8.3",
+    "@azure/msal-node-extensions": "^1.5.25",
     "@equinor/fusion-framework-module": "workspace:^",
     "open": "^10.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,11 +1277,11 @@ importers:
   packages/modules/msal-node:
     dependencies:
       '@azure/msal-node':
-        specifier: ^3.7.3
-        version: 3.8.1
+        specifier: ^3.8.3
+        version: 3.8.3
       '@azure/msal-node-extensions':
-        specifier: ^1.5.11
-        version: 1.5.23
+        specifier: ^1.5.25
+        version: 1.5.25
       '@equinor/fusion-framework-module':
         specifier: workspace:^
         version: link:../module
@@ -2205,23 +2205,19 @@ packages:
     resolution: {integrity: sha512-n278DdCXKeiWhLwhEL7/u9HRMyzhUXLefeajiknf6AmEedoiOiv2r5aRJ7LXdT3NGPyubkdIbthaJlVtmuEqvA==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.13.0':
-    resolution: {integrity: sha512-8oF6nj02qX7eE/6+wFT5NluXRHc05AgdCC3fJnkjiJooq8u7BcLmxaYYSwc2AfEkWRMRi6Eyvvbeqk4U4412Ag==}
+  '@azure/msal-common@15.13.2':
+    resolution: {integrity: sha512-cNwUoCk3FF8VQ7Ln/MdcJVIv3sF73/OT86cRH81ECsydh7F4CNfIo2OAx6Cegtg8Yv75x4506wN4q+Emo6erOA==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.13.1':
-    resolution: {integrity: sha512-vQYQcG4J43UWgo1lj7LcmdsGUKWYo28RfEvDQAEMmQIMjSFufvb+pS0FJ3KXmrPmnWlt1vHDl3oip6mIDUQ4uA==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-node-extensions@1.5.23':
-    resolution: {integrity: sha512-9i9GibDBxEUiYon/3Ecisde4SDFJD89nW+VCnvlzbFnVyo2TSaV047anLA/lk2ena52GSJvBGGdZLpAQqxwo3w==}
+  '@azure/msal-node-extensions@1.5.25':
+    resolution: {integrity: sha512-8UtOy6McoHQUbvi75Cx+ftpbTuOB471j4V4yZJmRM3KJ30bMO7forXrVV+/xArvWdgZ9VkBvq26OclFstJUo8Q==}
     engines: {node: '>=16'}
 
-  '@azure/msal-node-runtime@0.19.5':
-    resolution: {integrity: sha512-0oBQgCcgOb+VwQ5k8OXShbuXCBU8FKKhpwnqWSBzzYWSFoYAtyad2zggl26ME4IKzN9telaOJPEEcsQOf/+3Ug==}
+  '@azure/msal-node-runtime@0.20.1':
+    resolution: {integrity: sha512-WVbMedbJHjt9M+qeZMH/6U1UmjXsKaMB6fN8OZUtGY7UVNYofrowZNx4nVvWN/ajPKBQCEW4Rr/MwcRuA8HGcQ==}
 
-  '@azure/msal-node@3.8.1':
-    resolution: {integrity: sha512-HszfqoC+i2C9+BRDQfuNUGp15Re7menIhCEbFCQ49D3KaqEDrgZIgQ8zSct4T59jWeUIL9N/Dwiv4o2VueTdqQ==}
+  '@azure/msal-node@3.8.3':
+    resolution: {integrity: sha512-Ul7A4gwmaHzYWj2Z5xBDly/W8JSC1vnKgJ898zPMZr0oSf1ah0tiL15sytjycU/PMhDZAlkWtEL1+MzNMU6uww==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.27.1':
@@ -9384,21 +9380,19 @@ snapshots:
 
   '@azure/msal-common@13.3.3': {}
 
-  '@azure/msal-common@15.13.0': {}
+  '@azure/msal-common@15.13.2': {}
 
-  '@azure/msal-common@15.13.1': {}
-
-  '@azure/msal-node-extensions@1.5.23':
+  '@azure/msal-node-extensions@1.5.25':
     dependencies:
-      '@azure/msal-common': 15.13.0
-      '@azure/msal-node-runtime': 0.19.5
+      '@azure/msal-common': 15.13.2
+      '@azure/msal-node-runtime': 0.20.1
       keytar: 7.9.0
 
-  '@azure/msal-node-runtime@0.19.5': {}
+  '@azure/msal-node-runtime@0.20.1': {}
 
-  '@azure/msal-node@3.8.1':
+  '@azure/msal-node@3.8.3':
     dependencies:
-      '@azure/msal-common': 15.13.1
+      '@azure/msal-common': 15.13.2
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
 


### PR DESCRIPTION
## Why

**Why is this change needed?**
This PR consolidates the dependency updates from Dependabot PRs #3780 and #3781 by updating @azure/msal-node to version 3.8.3, the latest patch version.

**What is the current behavior?**
The @equinor/fusion-framework-module-msal-node package currently uses @azure/msal-node version 3.7.3 and @azure/msal-node-extensions version 1.5.11.

**What is the new behavior?**
The package will use @azure/msal-node version 3.8.3 and @azure/msal-node-extensions version 1.5.25, which include bug fixes and improvements such as enhanced logging to HttpClient and compatibility updates.

**Does this PR introduce a breaking change?**
No, this is a patch version update that maintains backward compatibility.

**Additional context**
This update consolidates two separate Dependabot PRs (#3780 and #3781) into a single update to the latest version 3.8.3.

**Related issues**
closes: #3780
closes: #3781

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

