### PR TITLE
hotfix: update msal acquire-token-request default

### DIFF
--- a/.changeset/fusion-framework-module-msal_acquire-token-request-default.md
+++ b/.changeset/fusion-framework-module-msal_acquire-token-request-default.md
@@ -1,0 +1,19 @@
+---
+"@equinor/fusion-framework-module-msal": patch
+---
+
+Ensure `acquireToken` normalizes legacy options when `request` is omitted by creating a default request object and applying active account fallback.
+
+Previously `{ scopes: ["User.Read"] }` could yield a request without `account`, relying on downstream resolution. The provider now explicitly supplies an empty request object, resolves `account` from the active session, and merges legacy `scopes` for clearer telemetry and safer behavior.
+
+Before:
+```typescript
+await provider.acquireToken({ scopes: ["User.Read"] }); // request undefined, account implicit
+```
+After (both forms valid, account resolved automatically):
+```typescript
+await provider.acquireToken({ scopes: ["User.Read"] });
+await provider.acquireToken({ request: { scopes: ["User.Read"] } });
+```
+
+Internal: improves stability of legacy usage without breaking API.

--- a/packages/modules/msal/src/MsalProvider.ts
+++ b/packages/modules/msal/src/MsalProvider.ts
@@ -13,6 +13,7 @@ import type { MsalConfig } from './MsalConfigurator';
 import type { AcquireTokenOptionsLegacy, IMsalProvider } from './MsalProvider.interface';
 import { createProxyProvider } from './create-proxy-provider';
 import type {
+  AcquireTokenOptions,
   AcquireTokenResult,
   IMsalClient,
   LoginOptions,
@@ -245,7 +246,12 @@ export class MsalProvider extends BaseModuleProvider<MsalConfig> implements IMsa
    * ```
    */
   async acquireToken(options: AcquireTokenOptionsLegacy): Promise<AcquireTokenResult> {
-    const { behavior = 'redirect', silent = true, request } = options;
+    const {
+      behavior = 'redirect',
+      silent = true,
+      request = {} as AcquireTokenOptions['request'],
+    } = options;
+
     const account = request.account ?? this.account ?? undefined;
     // Extract scopes from either new format (request.scopes) or legacy format (scopes)
     const scopes = options.request?.scopes ?? options?.scopes ?? [];


### PR DESCRIPTION
## Why

This PR updates the changeset for the MSAL acquire-token-request default behavior.

**Why is this change needed?**
The previous acquire-token-request default did not match legacy account handling requirements. This update ensures correct behavior for legacy accounts in MSAL integration.

**What is the current behavior?**
Legacy accounts may not be handled as expected when acquiring tokens, leading to authentication issues.

**What is the new behavior?**
Legacy account handling is now explicitly supported in the acquire-token-request default, improving authentication reliability.

**Does this PR introduce a breaking change?**
No breaking changes. This is a targeted hotfix for legacy account support.

**Additional context**
See .changeset/fusion-framework-module-msal_acquire-token-request-default.md for details.

**Related issues**
ref: #msal-legacy-account

### Checklist
- [x] Confirm completion of the self-review checklist
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))
- [x] Confirm adherence to code of conduct

