### PR TITLE
feat(analytics): add optional `data` to `trackFeature` hook

### DIFF
--- a/.changeset/seven-bobcats-open.md
+++ b/.changeset/seven-bobcats-open.md
@@ -1,0 +1,21 @@
+---
+"@equinor/fusion-framework-module-analytics": minor
+"@equinor/fusion-framework-react-app": minor
+---
+
+`trackFeature` now has an extra optional argument for passing additional analytics
+data.
+
+Example
+```typescript
+const trackFeature = useTrackFeature();
+
+// Without extra data
+trackFeature('SomeComponent:loaded');
+
+// Send additional data
+trackFeature('some:feature:happened', {
+  extra: 'data',
+  foo: 'bar',
+});
+```

--- a/.changeset/tidy-ads-melt.md
+++ b/.changeset/tidy-ads-melt.md
@@ -1,0 +1,5 @@
+---
+"portal-analytics": patch
+---
+
+Add example usage of `trackFeature` hook with optional `data`

--- a/cookbooks/portal-analytics/src/components/LogReader.tsx
+++ b/cookbooks/portal-analytics/src/components/LogReader.tsx
@@ -24,7 +24,9 @@ export const LogReader = () => {
    * Will fetch, parse and store the log file entries in entries state
    */
   const fetchLogs = useCallback(async () => {
-    trackFeature('cookbook:portal-analytics:logs:fetch');
+    trackFeature('cookbook:portal-analytics:logs:fetch', {
+      foo: 'bar',
+    });
 
     try {
       /**

--- a/packages/modules/analytics/src/index.ts
+++ b/packages/modules/analytics/src/index.ts
@@ -1,6 +1,6 @@
 export { module as analyticsModule, AnalyticsModule } from './module.js';
 
-export { AnalyticsEvent } from './types.js';
+export { AnalyticsEvent, AnyValue, AnyValueMap } from './types.js';
 
 export { AnalyticsProvider } from './AnalyticsProvider.js';
 export { IAnalyticsProvider } from './AnalyticsProvider.interface.js';

--- a/packages/react/app/src/analytics/README.md
+++ b/packages/react/app/src/analytics/README.md
@@ -28,6 +28,12 @@ const SomeComponent = () => {
   // Triggers when the component is loaded.
   useEffect(() => {
     trackFeature('SomeComponent loaded');
+
+    // Send additional data
+    trackFeature('some feature happened', {
+      extra: 'data',
+      foo: 'bar',
+    });
   }, [trackFeature]);
 
   return <button onClick={handleOnClick}>Click me</button>;

--- a/packages/react/app/src/analytics/useTrackFeature.ts
+++ b/packages/react/app/src/analytics/useTrackFeature.ts
@@ -1,6 +1,6 @@
 import { useFrameworkModule } from '@equinor/fusion-framework-react';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
-import type { AnalyticsModule } from '@equinor/fusion-framework-module-analytics';
+import type { AnalyticsModule, AnyValueMap } from '@equinor/fusion-framework-module-analytics';
 import { useCallback } from 'react';
 
 /**
@@ -18,9 +18,10 @@ export const useTrackFeature = () => {
    * Can be used both in useCallback or useEffects - see README.md for examples.
    *
    * @param name - The feature to track
+   * @param data - Optional map of additional key-value pairs to include with the analytics event
    */
   const trackFeature = useCallback(
-    (name: string) => {
+    (name: string, data?: AnyValueMap) => {
       if (!analyticsProvider) {
         telemetryProvider?.trackException({
           name: 'AnalyticsProviderNotFound',
@@ -32,6 +33,7 @@ export const useTrackFeature = () => {
         name: 'app-feature',
         value: {
           feature: name,
+          data,
         },
         attributes: {
           appKey: appProvider?.current?.appKey,


### PR DESCRIPTION
## Why

**Why is this change needed?**
App teams need the ability to pass additional contextual data when tracking features to enable more detailed analytics and statistics. Currently, the `trackFeature` hook only supports tracking a feature name, which limits the ability to capture rich analytics data that could be valuable for understanding feature usage patterns.

**What is the current behavior?**
The `useTrackFeature` hook only accepts a feature name (string) as a parameter. There is no way to attach additional data to analytics events.

**What is the new behavior?**
The `trackFeature` function now accepts an optional second parameter `data` of type `AnyValueMap`, allowing app teams to pass additional key-value pairs that will be included in the analytics event. The `AnyValueMap` and `AnyValue` types are now exported from the analytics module for use by consumers.

**Does this PR introduce a breaking change?**
No. The `data` parameter is optional, so existing code will continue to work without modification.

**Additional context**
- The `AnyValueMap` type is exported from `@equinor/fusion-framework-module-analytics` to enable type-safe usage
- Documentation and cookbook examples have been updated to demonstrate the new functionality
- The additional data is included in the `value` object of the analytics event alongside the feature name

**Related issues**
ref: [AB#66328](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/66328)

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
