### PR TITLE
chore(cli): update recommended Node.js version to 24.x LTS

### DIFF
--- a/.changeset/fusion-framework-cli_update-node-version-to-24.md
+++ b/.changeset/fusion-framework-cli_update-node-version-to-24.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Update recommended Node.js version from 22.x to 24.x (LTS).
+
+The CLI now recommends Node.js 24.x as the LTS version for best compatibility. This change updates the version check warning, build configuration, Dockerfile, and documentation examples to reflect Node.js 24 as the recommended version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=22
+ARG NODE_VERSION=24
 
 FROM myoung34/github-runner:ubuntu-noble AS base
 

--- a/packages/cli/docs/ai-commands.md
+++ b/packages/cli/docs/ai-commands.md
@@ -418,7 +418,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - run: pnpm install
 
@@ -461,7 +461,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/packages/cli/rollup.config.js
+++ b/packages/cli/rollup.config.js
@@ -15,7 +15,7 @@ const plugins = [
   replace({
     preventAssignment: true,
     'process.env.MINIMUM_NODE_VERSION': '20',
-    'process.env.RECOMMENDED_NODE_LTS': '22',
+    'process.env.RECOMMENDED_NODE_LTS': '24',
   }),
 ];
 const output = {

--- a/packages/cli/src/cli/main.ts
+++ b/packages/cli/src/cli/main.ts
@@ -12,7 +12,7 @@ import registerCommands from './commands/index.js';
 
 loadDotEnv();
 
-// Check Node.js version and recommend LTS (22.x)
+// Check Node.js version and recommend LTS (24.x)
 const MINIMUM_NODE_VERSION = process.env.MINIMUM_NODE_VERSION || '20';
 const [major] = process.versions.node.split('.').map(Number);
 if (major < Number(MINIMUM_NODE_VERSION)) {
@@ -23,7 +23,7 @@ if (major < Number(MINIMUM_NODE_VERSION)) {
   process.exit(1);
 }
 
-const RECOMMENDED_NODE_LTS = process.env.RECOMMENDED_NODE_LTS || '22';
+const RECOMMENDED_NODE_LTS = process.env.RECOMMENDED_NODE_LTS || '24';
 if (major !== Number(RECOMMENDED_NODE_LTS)) {
   console.warn(
     chalk.yellow('[WARNING]'),


### PR DESCRIPTION
**Why is this change needed?**
Update the recommended Node.js version from 22.x to 24.x (LTS) to align with the current Node.js LTS release and ensure users are using the recommended version for best compatibility.

**What is the current behavior?**
The CLI recommends Node.js 22.x as the LTS version, and the Dockerfile and build configuration use Node.js 22.

**What is the new behavior?**
The CLI now recommends Node.js 24.x as the LTS version. The version check warning, Dockerfile, build configuration (rollup.config.js), and documentation examples have been updated to reflect Node.js 24 as the recommended version.

**Does this PR introduce a breaking change?**
No. This is a configuration update that changes the recommended version but does not change any APIs or require consumers to upgrade immediately. The minimum Node.js version requirement (20) remains unchanged.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (changeset created)
- Consumer impact: Users will see a warning if they're using Node.js 22.x, recommending they upgrade to 24.x for best compatibility. No code changes required.
- Downstream impact: None - this only affects CLI configuration and documentation.

**Review guidance:**
- Verify that the CLI correctly shows the warning message for Node.js 24.x recommendation
- Check that the Dockerfile builds correctly with Node.js 24
- Confirm documentation examples are updated consistently
- Ensure the changeset is properly formatted

**Additional context**
- The GitHub Actions node-setup action already defaults to Node.js 24
- The package.json engines field supports both ^24 and ^22 for backward compatibility
- Build has been verified to complete successfully

**Related issues**
None