### PR TITLE
feat(dev-portal): add ConsoleAnalyticsAdapter when fusionLogAnalytics feature flag is enabled

### DIFF
--- a/.changeset/ten-ravens-take.md
+++ b/.changeset/ten-ravens-take.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-dev-portal": minor
+---
+
+Add feature flag `fusionLogAnalytics` to dev-portal in CLI.
+
+Add `ConsoleAnalyticsAdapter` Adapter to analytics module if the feature flag is
+enabled.
+
+By enabling this feature flag, analytics events will be logged out in the
+console. This is useful when you want to test events created by app teams (e.g.
+using `trackFeature` hook).

--- a/packages/dev-portal/package.json
+++ b/packages/dev-portal/package.json
@@ -30,6 +30,7 @@
     "@equinor/fusion-framework-app": "workspace:*",
     "@equinor/fusion-framework-dev-server": "workspace:*",
     "@equinor/fusion-framework-module-app": "workspace:*",
+    "@equinor/fusion-framework-module-analytics": "workspace:*",
     "@equinor/fusion-framework-module-bookmark": "workspace:*",
     "@equinor/fusion-framework-module-context": "workspace:*",
     "@equinor/fusion-framework-module-feature-flag": "workspace:*",

--- a/packages/dev-portal/src/config.ts
+++ b/packages/dev-portal/src/config.ts
@@ -1,6 +1,8 @@
 import { enableAppModule } from '@equinor/fusion-framework-module-app';
 import { enableBookmark } from '@equinor/fusion-framework-react-module-bookmark';
 import type { FrameworkConfigurator } from '@equinor/fusion-framework';
+import { enableAnalytics } from '@equinor/fusion-framework-module-analytics';
+import { ConsoleAnalyticsAdapter } from '@equinor/fusion-framework-module-analytics/adapters';
 import { enableNavigation } from '@equinor/fusion-framework-module-navigation';
 import { enableServices } from '@equinor/fusion-framework-module-services';
 import { enableFeatureFlagging } from '@equinor/fusion-framework-module-feature-flag';
@@ -52,6 +54,17 @@ export const configure = async (config: FrameworkConfigurator) => {
 
   enableServices(config);
 
+  enableAnalytics(config, (builder) => {
+    builder.setAdapter('console', async (args) => {
+      if (args.hasModule('featureFlag')) {
+        const featureFlagProvider = await args.requireInstance('featureFlag');
+        if (featureFlagProvider.getFeature('fusionLogAnalytics')?.enabled) {
+          return new ConsoleAnalyticsAdapter();
+        }
+      }
+    });
+  });
+
   // Configure bookmark functionality with CLI as the source system
   enableBookmark(config, (builder) => {
     // Identify bookmarks created in dev portal as coming from CLI system
@@ -71,6 +84,11 @@ export const configure = async (config: FrameworkConfigurator) => {
           key: 'fusionDebug',
           title: 'Fusion debug log',
           description: 'Show Fusion debug log in console',
+        },
+        {
+          key: 'fusionLogAnalytics',
+          title: 'Log Fusion Analytics',
+          description: 'Show Analytics events in console',
         },
         {
           key: 'pinkBg',

--- a/packages/dev-portal/tsconfig.json
+++ b/packages/dev-portal/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../modules/app"
     },
     {
+      "path": "../modules/analytics"
+    },
+    {
       "path": "../modules/context"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1137,6 +1137,9 @@ importers:
       '@equinor/fusion-framework-dev-server':
         specifier: workspace:*
         version: link:../dev-server
+      '@equinor/fusion-framework-module-analytics':
+        specifier: workspace:*
+        version: link:../modules/analytics
       '@equinor/fusion-framework-module-app':
         specifier: workspace:*
         version: link:../modules/app
@@ -9436,7 +9439,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -19043,7 +19045,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -20909,7 +20911,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.13.2):
+  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 


### PR DESCRIPTION
<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
By enabling this feature flag, analytics events will be logged out in the
console. This is useful when you want to test events created by app teams (e.g.
using `trackFeature` hook).

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
The dev-portal will not log any analytics events. To test analytics events now, the app teams needs to publish the app to the CI environment - which will log the events to the backend for retrieving events. 

**What is the new behavior?**
<!-- What will change after this PR is merged. -->
The new behavior lets the app teams enable the `fusionLogAnalytics` feature flag and see the analytics events in the console.

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
No

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref [AB#66328](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/66328)
Ref equinor/fusion-core-tasks#34

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

