### PR TITLE
feat(cli): add possibility to tag app/portal with a string

### DIFF
--- a/.changeset/true-jobs-lose.md
+++ b/.changeset/true-jobs-lose.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-cli": minor
+---
+
+Add support for custom tags when publishing apps and portals, expanding beyond
+the previous `latest` and `preview` options.
+
+Tags can now use any combination of alphanumeric characters, dots, and hyphens
+(`a–z`, `A–Z`, `0–9`, `.`, `-`), for example `latest`, `preview` or `pr-1234`.

--- a/packages/cli/src/bin/app-tag.ts
+++ b/packages/cli/src/bin/app-tag.ts
@@ -6,21 +6,6 @@ import type { FusionFramework } from '@equinor/fusion-framework-cli/bin';
 import { type ConsoleLogger, formatPath, chalk, defaultHeaders } from './utils/index.js';
 
 /**
- * Allowed tags for application versions in the app service.
- *
- * - `latest`: Marks the most recent stable version of the application.
- * - `preview`: Marks a pre-release or preview version for testing or review.
- *
- * Used by {@link tagApplication} to validate and apply version tags.
- *
- * @public
- */
-export enum AllowedTags {
-  Latest = 'latest',
-  Preview = 'preview',
-}
-
-/**
  * Options for tagging an application version in the app service.
  *
  * This interface defines the required and optional parameters for the
@@ -36,7 +21,7 @@ export enum AllowedTags {
  * @public
  */
 export type TagApplicationOptions = {
-  tag: AllowedTags;
+  tag: string;
   appKey: string;
   version: string;
   framework: FusionFramework;
@@ -44,7 +29,8 @@ export type TagApplicationOptions = {
 };
 
 /**
- * Tags an application version in the app service with a specified tag (e.g., 'latest' or 'preview').
+ * Tags an application version in the app service with a specified tag (e.g., 'latest', 'preview'
+ * or pr-1234).
  *
  * This function validates input, creates a client for the app service, and sends a tag request.
  * It provides detailed logging and error handling for common failure scenarios.
@@ -57,11 +43,18 @@ export type TagApplicationOptions = {
 export const tagApplication = async (options: TagApplicationOptions) => {
   const { tag, appKey, version, framework, log } = options;
 
-  // Validate tag value
-  if (!['latest', 'preview'].includes(tag)) {
-    log?.fail('🤪', 'Invalid tag. Use "latest" or "preview".');
+  // Validate tag value - ensure it's a non-empty string
+  if (!tag || typeof tag !== 'string' || tag.trim().length === 0) {
+    log?.fail('🤪', 'Tag must be a non-empty string.');
     process.exit(1);
   }
+
+  // Validate tag value - ensure only a-z, A-Z, 0-9, "." and "-"
+  if (!/^[a-zA-Z0-9.-]+$/.test(tag)) {
+    log?.fail('🤪', 'Invalid tag. Use "latest", "preview" or string [a-z, A-Z, 0-9, ".", "-"].');
+    process.exit(1);
+  }
+
   // Validate app key
   if (!appKey) {
     log?.fail('🤪', 'Application key is required.');

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -6,7 +6,7 @@ export { startAppDevServer } from './app-dev.js';
 export { checkApp } from './app-check.js';
 export { loadAppManifest } from './app-manifest.js';
 export { uploadApplication } from './app-upload.js';
-export { tagApplication, AllowedTags as AllowedAppTags } from './app-tag.js';
+export { tagApplication } from './app-tag.js';
 
 export { startPortalDevServer } from './portal-dev.js';
 export { buildPortal } from './portal-build.js';

--- a/packages/cli/src/bin/portal-tag.ts
+++ b/packages/cli/src/bin/portal-tag.ts
@@ -47,6 +47,13 @@ export const tagPortal = async (options: TagPortalOptions) => {
     log?.fail('🤪', 'Tag must be a non-empty string.');
     process.exit(1);
   }
+
+  // Validate tag value - ensure only a-z, A-Z, 0-9, "." and "-"
+  if (!/^[a-zA-Z0-9.-]+$/.test(tag)) {
+    log?.fail('🤪', 'Invalid tag. Use "latest", "preview" or string [a-z, A-Z, 0-9, ".", "-"].');
+    process.exit(1);
+  }
+
   // Validate portal name
   if (!name) {
     log?.fail('🤪', 'Portal name is required.');

--- a/packages/cli/src/cli/commands/app/publish.ts
+++ b/packages/cli/src/cli/commands/app/publish.ts
@@ -8,7 +8,6 @@ import {
   ConsoleLogger,
   uploadApplication,
   tagApplication,
-  AllowedAppTags,
   checkApp,
 } from '@equinor/fusion-framework-cli/bin';
 
@@ -36,7 +35,7 @@ import { createEnvOption } from '../../options/env.js';
  *   -d, --debug          Enable debug mode for verbose logging (default: false)
  *   -e, --env <env>      Target environment
  *   -m, --manifest       Manifest file to use for bundling (e.g., app.manifest.ts)
- *   -t, --tag            Tag to apply to the published app (latest | preview)
+ *   -t, --tag            Tag to apply to the published app (e.g. latest | preview | pr-1234)
  *
  * Example:
  *   $ ffc app publish
@@ -80,8 +79,8 @@ export const command = withAuthOptions(
     .option('-m, --manifest [string]', 'Manifest file to use for bundling (e.g., app.manifest.ts)')
     .option(
       '-t, --tag [string]',
-      `Tag to apply to the published app (${Object.values(AllowedAppTags).join(' | ')})`,
-      AllowedAppTags.Latest,
+      'Tag to apply to the published app (e.g. latest | preview | next | pr-1234). Alphanumeric, dots and dashes allowed.',
+      'latest',
     )
     .argument('[bundle]', 'Path to the app bundle to upload')
     .action(async (bundle, options) => {

--- a/packages/cli/src/cli/commands/app/tag.ts
+++ b/packages/cli/src/cli/commands/app/tag.ts
@@ -9,7 +9,6 @@ import {
   ConsoleLogger,
   loadAppManifest,
   tagApplication,
-  AllowedAppTags,
 } from '@equinor/fusion-framework-cli/bin';
 
 import { createEnvOption } from '../../options/env.js';
@@ -63,7 +62,7 @@ async function parseAppInfo(
  *   $ fusion tag <tag> [options]
  *
  * Arguments:
- *   <tag>                           Tag to apply (latest | preview)
+ *   <tag>                           Tag to apply (e.g. latest | preview | pr-1234)
  *
  * Options:
  *   -p, --package [package@version] Package to tag in format name@version (e.g., my-app@1.0.0). If not provided, loaded from manifest
@@ -76,6 +75,7 @@ async function parseAppInfo(
  *   $ ffc app tag latest
  *   $ ffc app tag preview --env prod --manifest app.manifest.prod.ts
  *   $ ffc app tag latest --package my-app@1.2.3
+ *   $ ffc app tag pr-1234 --package my-app@1.2.3
  *
  * @see tagApplication for implementation details
  */
@@ -93,6 +93,7 @@ export const command = withAuthOptions(
         '  $ ffc app tag preview --env prod --manifest app.manifest.prod.ts',
         '  $ ffc app tag stable --package my-app@1.2.3',
         '  $ ffc app tag latest --manifest app.manifest.custom.ts',
+        '  $ ffc app tag pr-1234 --package my-app@1.2.3',
       ].join('\n'),
     )
     .addOption(createEnvOption({ allowDev: false }))
@@ -106,7 +107,10 @@ export const command = withAuthOptions(
     )
     .option('--debug', 'Enable debug mode for verbose logging')
     .option('--silent', 'Silent mode, suppresses output except errors')
-    .argument('<tag>', `Tag to apply (${Object.values(AllowedAppTags).join(' | ')})`)
+    .argument(
+      '<tag>',
+      'Tag to apply (e.g. latest | preview | next | pr-1234). Alphanumeric, dots and dashes allowed.',
+    )
     .action(async (tag, options) => {
       const log = options.silent ? null : new ConsoleLogger('app:tag', { debug: options.debug });
 

--- a/packages/cli/src/cli/commands/portal/publish.ts
+++ b/packages/cli/src/cli/commands/portal/publish.ts
@@ -30,12 +30,13 @@ import {
  *   -d, --debug          Enable debug mode for verbose logging
  *   -e, --env <env>      Target environment
  *   -m, --manifest       Manifest file to use for bundling
- *   -t, --tag            Tag to apply to the published portal (any string value)
+ *   -t, --tag            Tag to apply to the published portal (e.g latest | preview | pr-1234)
  *
  * Example:
  *   $ ffc portal publish
  *   $ ffc portal publish --env prod --manifest portal.manifest.prod.ts
  *   $ ffc portal publish --tag preview
+ *   $ ffc portal publish --tag pr-1234
  *
  * @see uploadPortalBundle, tagPortal for implementation details
  */
@@ -56,6 +57,7 @@ export const command = withAuthOptions(
         '  $ ffc portal publish --env prod --manifest portal.manifest.prod.ts',
         '  $ ffc portal publish --tag preview',
         '  $ ffc portal publish --tag next',
+        '  $ ffc portal publish --tag pr-1234',
       ].join('\n'),
     )
     .option('-d, --debug', 'Enable debug mode for verbose logging', false)
@@ -67,7 +69,7 @@ export const command = withAuthOptions(
     .option('--schema [string]', 'Schema file to use for validation')
     .option(
       '-t, --tag [string]',
-      'Tag to apply to the published portal (e.g., latest, preview, next, or any string value)',
+      'Tag to apply to the published portal (e.g. latest | preview | next | pr-1234). Alphanumeric, dots and dashes allowed.',
       'latest',
     )
     .action(async (options) => {

--- a/packages/cli/src/cli/commands/portal/tag.ts
+++ b/packages/cli/src/cli/commands/portal/tag.ts
@@ -62,7 +62,7 @@ async function parsePortalInfo(
  *   $ ffc portal tag <tag> [options]
  *
  * Arguments:
- *   <tag>                  Tag to apply (e.g., latest, preview, next, or any string value)
+ *   <tag>                  Tag to apply (e.g., latest, preview, next, or string [a-z, A-Z, 0-9, ".", "-"])
  *
  * Options:
  *   -m, --manifest <file>  Manifest file to use (optional, defaults to portal.manifest.ts)
@@ -92,6 +92,7 @@ export const command = withAuthOptions(
         '  $ ffc portal tag preview --manifest ./portal.manifest.ts',
         '  $ ffc portal tag next --package my-portal@2.0.0-alpha',
         '  $ ffc portal tag stable --package my-portal@1.5.0',
+        '  $ ffc portal tag pr-1234 --package my-portal@2.0.0',
       ].join('\n'),
     )
     .addOption(createEnvOption({ allowDev: false }))
@@ -105,7 +106,10 @@ export const command = withAuthOptions(
     )
     .option('-d, --debug', 'Enable debug mode for verbose logging')
     .option('--silent', 'Silent mode, suppresses output except errors')
-    .argument('<tag>', 'Tag to apply (e.g., latest, preview, next, or any string value)')
+    .argument(
+      '<tag>',
+      'Tag to apply (e.g. latest | preview | next | pr-1234). Alphanumeric, dots and dashes allowed.',
+    )
     .action(async (tag, options) => {
       const log = options.silent ? null : new ConsoleLogger('app:tag', { debug: options.debug });
 


### PR DESCRIPTION
Also removed enum `AllowedAppTags`.

It is now allowed to use 'a-z', 'A-Z', '0-9', '.', '-' in tag.



<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
To allow us to tag app/portals with other tags than latest and preview. We will use this for 'pr-tags' (e.g. pr-1234)
<!-- Problem this solves or reason for change. Be specific. -->

**What is the current behavior?**
only latest and preview tag allowed
<!-- How things work currently, including any issues. -->

**What is the new behavior?**
allow tags containing chars: a-z, A-Z, 0-9, '.', '-'
<!-- What will change after this PR is merged. -->

**Does this PR introduce a breaking change?**
no
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#19

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

