### PR TITLE
feat(app): allow custom tags in build schema

### DIFF
--- a/.changeset/fusion-framework-module-app_allow-custom-tags.md
+++ b/.changeset/fusion-framework-module-app_allow-custom-tags.md
@@ -1,0 +1,27 @@
+---
+"@equinor/fusion-framework-module-app": minor
+---
+
+Allow custom string values for app build tags instead of restricting to 'latest' and 'preview'.
+
+The app module schema now accepts any string value for the `tag` field in `AppBuildManifest` and `ApiApplicationBuildSchema`. This enables using custom deployment tags like `dev`, `staging`, `v1.0`, or any other string value while maintaining backward compatibility with existing `latest` and `preview` tags.
+
+```typescript
+// Before: only 'latest' | 'preview' allowed
+const build: AppBuildManifest = {
+  version: '1.0.0',
+  entryPoint: 'index.js',
+  tag: 'latest' // or 'preview' only
+};
+
+// After: any string value allowed
+const build: AppBuildManifest = {
+  version: '1.0.0', 
+  entryPoint: 'index.js',
+  tag: 'dev' // or 'staging', 'v1.0', etc.
+};
+```
+
+This aligns the schema validation with the CLI's existing flexibility for custom tags.
+
+Fixes: https://github.com/equinor/fusion-core-tasks/issues/252

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -424,7 +424,7 @@ This command uploads and tags your app for deployment. If no bundle is provided,
 | `[bundle]`         | Path to the app bundle to upload. If omitted, the CLI will build and bundle your app automatically. When provided, app validation uses metadata from the bundle instead of local files. |                   |
 | `-e`, `--env`      | Target environment for deployment (e.g., `ci`, `fqa`, `fprd`).                                      |                   |
 | `-m`, `--manifest` | Manifest file to use for bundling (e.g., `app.manifest.ts`) (optional).                             | `app.manifest.ts` |
-| `-t`, `--tag`      | Tag to apply to the published app (`latest` \| `preview`).                                          | `latest`          |
+| `-t`, `--tag`      | Tag to apply to the published app (any string, commonly `latest` or `preview`).                    | `latest`          |
 | `-d`, `--debug`    | Enable debug mode for verbose logging.                                                              | `false`           |
 | `--token`          | Authentication token for Fusion.                                                                    |                   |
 | `--tenantId`       | Azure tenant ID for authentication.                                                                 |                   |
@@ -449,7 +449,7 @@ pnpm fusion-framework-cli publish --tag latest app-bundle.zip
 >
 > **Additional Notes**:
 > - **Artifact-based publishing**: When providing a bundle, the command extracts app metadata from `metadata.json` within the bundle, enabling publishing from any directory without requiring local project files.
-> - The `--tag` option lets you mark the published version (e.g., as `latest` or `preview`) for easier deployment targeting.
+> - The `--tag` option lets you mark the published version with any custom tag (e.g., `latest`, `preview`, `dev`, `staging`, `v1.0`) for easier deployment targeting.
 > - Authentication options (`--token`, `--tenantId`, `--clientId`) can be set via CLI flags or environment variables.
 > - If any step fails (build, upload, or tagging), an error will be logged and the process will exit with a non-zero code.
 
@@ -591,11 +591,11 @@ Tag a published application version in the Fusion app store (registry).
 
 Tag a specific version of your Fusion application in the Fusion app registry for release management.
 
-The `tag` command applies a tag (such as `latest`, `preview`, or `stable`) to a published application version. This helps you manage which version is considered the default for deployment or preview purposes.
+The `tag` command applies a tag (such as `latest`, `preview`, `dev`, `staging`, or any custom string) to a published application version. This helps you manage which version is considered the default for deployment or preview purposes.
 
 | Argument/Option           | Description                                                        | Default / Example |
 | ------------------------- | ------------------------------------------------------------------ | ----------------- |
-| `<tag>`                   | Tag to apply (`latest` \| `preview` \| `stable`).                  |                   |
+| `<tag>`                   | Tag to apply (any string, e.g., `latest`, `preview`, `dev`, `staging`).     |                   |
 | `-p, --package`           | Package to tag in format name@version.                              |                   |
 | `-m, --manifest <string>` | Manifest file to use for resolving app key and version.            | `app.manifest.ts` |
 | `--debug`                 | Enable debug mode for verbose logging.                             | `false`           |
@@ -621,7 +621,7 @@ pnpm fusion-framework-cli app tag latest --package my-app@1.2.3
 
 > [!NOTE]
 > - The `tag` command requires a published application version. You can specify the package name and version using `--package`, or let the CLI resolve them from your manifest file.
-> - Supported tags are: `latest` and `preview`.
+> - Tags can be any string value. Common examples include `latest`, `preview`, `dev`, `staging`, or version numbers like `v1.0`.
 > - Authentication options (`--token`, `--tenantId`, `--clientId`) can be set via CLI flags or environment variables.
 > - If tagging fails, an error will be logged and the process will exit with a non-zero code.
 

--- a/packages/cli/docs/portal.md
+++ b/packages/cli/docs/portal.md
@@ -159,7 +159,7 @@ pnpm fusion-framework-cli portal publish --tag preview --schema portal.schema.ts
 > **Building Behavior**: Unlike the app publish command—which only builds your app if a pre-built bundle is not provided—the portal publish command always builds your portal template before uploading and tagging. There is no option to provide a pre-built bundle.
 > 
 > **Additional Notes**:
-> - The `--tag` option lets you mark the published version (e.g., as `latest` or `preview`) for easier deployment targeting.
+> - The `--tag` option lets you mark the published version with any custom tag (e.g., `latest`, `preview`, `dev`, `staging`) for easier deployment targeting.
 > - Authentication options (`--token`, `--tenantId`, `--clientId`) can be set via CLI flags or environment variables.
 > - If any step fails (build, upload, or tagging), an error will be logged and the process will exit with a non-zero code.
 

--- a/packages/modules/app/src/schemas.ts
+++ b/packages/modules/app/src/schemas.ts
@@ -67,7 +67,7 @@ const ApiApplicationPersonSchema = z.object({
  * - `version`: The version of the application build.
  * - `entryPoint`: The entry point of the application.
  * - `tags`: An optional array of tags associated with the build.
- * - `tag`: An optional tag indicating the build type, either 'latest' or 'preview'.
+ * - `tag`: An optional tag indicating the build type (can be any string, commonly 'latest' or 'preview').
  * - `assetPath`: An optional path to the build assets.
  * - `configUrl`: An optional URL to the build configuration.
  * - `timestamp`: An optional timestamp of the build.
@@ -81,7 +81,7 @@ export const ApiApplicationBuildSchema = z.object({
   version: z.string(),
   entryPoint: z.string(),
   tags: z.array(z.string()).nullish(),
-  tag: z.enum(['latest', 'preview']).nullish(),
+  tag: z.string().nullish(),
   assetPath: z.string().nullish(),
   configUrl: z.string().nullish(),
   timestamp: z.string().nullish(),

--- a/packages/modules/app/src/types.ts
+++ b/packages/modules/app/src/types.ts
@@ -70,7 +70,7 @@ export type AppBuildManifest = {
   version: string;
   entryPoint: string;
   tags?: Nullable<string[]>;
-  tag?: Nullable<'latest' | 'preview'>;
+  tag?: Nullable<string>;
   assetPath?: Nullable<string>;
   configUrl?: Nullable<string>;
   timestamp?: Nullable<string>;


### PR DESCRIPTION
This PR addresses equinor/fusion-core-tasks#252 by allowing custom string values for app build tags instead of restricting them to only 'latest' and 'preview'.

## Changes Made

- Updated ApiApplicationBuildSchema to accept any string for the tag field
- Updated AppBuildManifest type to accept string instead of 'latest' | 'preview'
- Updated CLI documentation with custom tag examples  
- Added changeset for minor version bump

## Examples of Custom Tags Now Supported

- dev, staging, v1.0, feature-x, rc1, etc.

All requirements from the issue are met with full backward compatibility.