### PR TITLE
fix(cli): suppress dotenv stdout contamination in JSON output

### DIFF
--- a/.changeset/red-bees-nail.md
+++ b/.changeset/red-bees-nail.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fix CLI commands outputting invalid JSON due to dotenv messages appearing in stdout. Commands like `ffc app manifest` now produce clean JSON output suitable for automated tooling and CI/CD pipelines.

--- a/packages/cli/src/cli/main.ts
+++ b/packages/cli/src/cli/main.ts
@@ -10,7 +10,9 @@ import { readPackageUpSync } from 'read-package-up';
 
 import registerCommands from './commands/index.js';
 
-loadDotEnv();
+// Load environment variables from .env file without stdout contamination
+// Uses dotenv's quiet option to suppress informational messages that contaminate JSON output
+loadDotEnv({ quiet: true });
 
 // Check Node.js version and recommend LTS (24.x)
 const MINIMUM_NODE_VERSION = process.env.MINIMUM_NODE_VERSION || '20';


### PR DESCRIPTION
# Fix CLI JSON Output Contamination from dotenv Messages

## 🐛 Problem

CLI commands that output JSON (like `ffc app manifest > test.json`) were producing corrupted files due to dotenv informational messages being written to stdout. This broke automated tooling, CI/CD pipelines, and third-party integrations that expected clean JSON output.

**Example of the issue:**
```bash
$ ffc app manifest > test.json
$ head -1 test.json
[dotenv@17.2.3] injecting env (0) from .env -- tip: 🔐 encrypt with Dotenvx: https://dotenvx.com
```

**Expected:** File should start with `{` (clean JSON)  
**Actual:** File starts with dotenv debug message, making it invalid JSON

## 🔧 Solution

Uses dotenv's `quiet: true` option to suppress informational messages that contaminate stdout while preserving all environment variable loading functionality.

**Before:**
```typescript
import { config as loadDotEnv } from 'dotenv';
loadDotEnv();  // Prints messages to stdout
```

**After:**
```typescript
import { config as loadDotEnv } from 'dotenv';
loadDotEnv({ quiet: true });  // Clean stdout, no contamination
```

## 🎯 Impact

### Commands Fixed
- `ffc app manifest`
- `ffc app config` 
- `ffc portal manifest`
- All CLI commands that output structured data

### Benefits
- ✅ **Clean JSON Output:** Files now contain valid JSON without contamination
- ✅ **CI/CD Reliability:** Automated deployment scripts can parse CLI output correctly
- ✅ **Tool Integration:** Third-party tools can consume CLI output without preprocessing
- ✅ **Developer Experience:** Commands work consistently in terminal and scripts

## 🧪 Testing

**Validation Steps:**
1. **Clean JSON Output:** `ffc app manifest > test.json` produces valid JSON
2. **Environment Loading:** Variables from `.env` still loaded correctly
3. **Missing .env Handling:** CLI works when no `.env` file exists
4. **Stdout Preservation:** Other CLI output (warnings, errors) still work

**Before Fix:**
```bash
$ ffc app manifest > test.json
$ head -1 test.json
[dotenv@17.2.3] injecting env (0) from .env -- tip: 🔐 encrypt with Dotenvx
```

**After Fix:**
```bash
$ ffc app manifest > test.json
$ head -1 test.json
{
```

## 📋 Checklist

- [x] **Root Cause Analysis:** Identified dotenv@17.2.3 behavioral change
- [x] **Solution Research:** Analyzed 4 different approaches, selected optimal one
- [x] **Implementation:** Applied `quiet: true` option (simplest, most reliable)
- [x] **Testing:** Verified clean JSON output and maintained functionality
- [x] **Changeset:** Added proper versioning and changelog entry
- [x] **Documentation:** Updated code comments explaining the fix

## 🔄 Breaking Changes

**None** - This is a pure bug fix that maintains all existing functionality while fixing the stdout contamination issue.

## 📚 Technical Details

**Root Cause:** dotenv version 17.x introduced informational logging to stdout by default, different from 16.x behavior.

**Fix Approach:** Used dotenv's officially supported `quiet` option to suppress these messages while maintaining all other functionality.

**Alternative Approaches Considered:**
1. Direct `parse()` usage (more complex)
2. `@equinor/fusion-load-env` package (dependency change)
3. Console suppression (hacky, not recommended)

Selected the simplest, most reliable approach that doesn't rely on undocumented features or complex workarounds.

---

## 🎯 Ready to Merge

This fix resolves a critical issue affecting automated tooling and CI/CD pipelines. The solution is minimal, well-tested, and maintains backward compatibility while ensuring clean JSON output for programmatic consumption.

**Resolves:** JSON parsing failures in deployment scripts and third-party integrations
**Affects:** All users of CLI commands that output structured data

Closes: https://github.com/equinor/fusion-core-tasks/issues/254