### PR TITLE
fix(module-event): replace structuredClone with custom deepClone to handle functions

### DIFF
--- a/.changeset/module-event_fix-structuredclone-error.md
+++ b/.changeset/module-event_fix-structuredclone-error.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-event": patch
+---
+
+Fix `DataCloneError` when event details contain functions by replacing `structuredClone` with custom deep clone implementation that preserves class instances and handles non-serializable values.
+
+The custom deep clone function gracefully handles functions (preserving them as references), supports circular references, and maintains the prototype chain for class instances, preventing serialization errors while still providing a deep copy of event details.

--- a/packages/modules/event/src/deep-clone.ts
+++ b/packages/modules/event/src/deep-clone.ts
@@ -1,0 +1,51 @@
+/**
+ * Deep clones a value while preserving class instances and handling non-serializable values.
+ * Functions are preserved as references. Circular references are handled via WeakMap.
+ *
+ * @template T - The type of the value to clone
+ * @param value - The value to clone
+ * @param seen - WeakMap to track circular references (internal use)
+ * @returns A deep clone of the value
+ */
+export function deepClone<T>(value: T, seen = new WeakMap<object, object>()): T {
+  // Handle primitives and null
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  // Functions are not cloned, keep the reference
+  if (typeof value === 'function') {
+    return value;
+  }
+
+  // Handle circular references
+  if (seen.has(value)) {
+    return seen.get(value) as T;
+  }
+
+  // Handle Date
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  // Handle Array
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = [];
+    seen.set(value, cloned);
+    for (let i = 0; i < value.length; i++) {
+      cloned[i] = deepClone(value[i], seen);
+    }
+    return cloned as T;
+  }
+
+  // Handle plain objects and class instances
+  const cloned: Record<string, unknown> = Object.create(Object.getPrototypeOf(value));
+  seen.set(value, cloned);
+
+  for (const key of Object.keys(value)) {
+    const propValue = (value as Record<string, unknown>)[key];
+    cloned[key] = deepClone(propValue, seen);
+  }
+
+  return cloned as T;
+}

--- a/packages/modules/event/src/event.ts
+++ b/packages/modules/event/src/event.ts
@@ -1,5 +1,6 @@
 import type { ModuleInstance } from '@equinor/fusion-framework-module';
 import type { IEventModuleProvider } from './provider';
+import { deepClone } from './deep-clone';
 
 export declare interface FrameworkEventMap {
   onModulesLoaded: FrameworkEvent<FrameworkEventInit<ModuleInstance, IEventModuleProvider>>;
@@ -157,7 +158,7 @@ export class FrameworkEvent<
     args: TInit,
   ) {
     this.#detail = args.detail;
-    this.#originalDetail = structuredClone(args.detail);
+    this.#originalDetail = deepClone(args.detail);
     this.#mutableDetails = !!args.mutableDetails;
     this.#source = args.source;
     this.#cancelable = !!args.cancelable;


### PR DESCRIPTION
**Why is this change needed?**
The event module was throwing a `DataCloneError` when event details contained functions (such as event listeners). This occurred because `structuredClone` cannot serialize functions.

**What is the current behavior?**
When creating a `FrameworkEvent` with event details containing functions, the constructor calls `structuredClone(args.detail)` which throws:
```
DataCloneError: Failed to execute 'structuredClone' on 'Window': (i) => { ... } could not be cloned.
```

**What is the new behavior?**
The event constructor now uses a custom `deepClone` implementation that:
- Preserves class instances via prototype chain
- Handles functions by keeping them as references (not cloning)
- Supports circular references via WeakMap
- Deep clones Date, Array, and plain object structures

Events with function-containing details now work without throwing serialization errors.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (bug fix)
- Consumer impact: Fixes runtime error when event details contain functions
- Downstream impact: None - internal implementation change only

**Review guidance:**
- Verify the `deepClone` function correctly handles all object types (primitives, arrays, dates, objects, functions, class instances)
- Check that class instances preserve their prototype chain
- Ensure circular references don't cause infinite loops
- Consider testing with complex event payloads containing mixed types

**Additional context**
Created a separate `deep-clone.ts` utility file for better code organization and potential reuse.

**Related issues**
N/A

### Checklist

- [ ] Confirm completion of the self-review checklist
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR_
- [ ] Confirm adherence to code of conduct
