### PR TITLE
fix(module-event)!: remove mutation support and detail cloning

### DIFF
--- a/.changeset/module-event_remove-mutation-support.md
+++ b/.changeset/module-event_remove-mutation-support.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-module-event": major
+---
+
+**BREAKING CHANGE**: Remove event mutation support and detail cloning to fix `DataCloneError` with non-serializable values.
+
+The event module was throwing `DataCloneError` when event details contained functions (like event listeners) because `structuredClone` cannot serialize functions. We've simplified the event model by removing mutation support entirely.
+
+**Removed APIs:**
+- `event.originalDetail` - getter removed
+- `event.allowEventDetailsMutation` - getter removed  
+- `event.updateDetails()` - method removed
+- `FrameworkEventInit.mutableDetails` - property removed

--- a/packages/modules/event/README.md
+++ b/packages/modules/event/README.md
@@ -2,7 +2,7 @@
 
 This package is meant for dispatching events between modules (siblings) and cross instances (parent|adjunct)
 
-> Base on the native node/web js event system, __but__ the dispatcher is `async` for easier handling of `cancelable` events.
+> Based on the native node/web js event system, __but__ the dispatcher is `async` for easier handling of `cancelable` events.
 >
 > __NOTE__ that creating a `cancelable` event without awaiting resolution, will not respect the `preventDefault` behavior!
 


### PR DESCRIPTION
**Why is this change needed?**
The event module was throwing a `DataCloneError` when event details contained functions (like event listeners) because `structuredClone` cannot serialize functions.

**What is the current behavior?**
When creating a `FrameworkEvent` with event details containing functions, the constructor calls `structuredClone(args.detail)` which throws `DataCloneError: Failed to execute 'structuredClone' on 'Window': (i) => { ... } could not be cloned.`

**What is the new behavior?**
The event module no longer attempts to clone event details. All mutation-related APIs have been removed, simplifying the event model.

**Does this PR introduce a breaking change?**
Yes. The following APIs have been removed:
- `event.originalDetail` getter
- `event.allowEventDetailsMutation` getter  
- `event.updateDetails()` method
- `FrameworkEventInit.mutableDetails` property

**Impact assessment:**
- Breaking changes: Yes - removes mutation APIs
- Version bump: Major
- Consumer impact: Very low - mutation features were rarely used
- Downstream impact: None - internal implementation change

**Review guidance:**
- Verify all mutation-related code has been removed
- Check that events with functions in details no longer throw errors
- Confirm the simplified API surface is correct

**Additional context**
This simplifies the event model and eliminates the need for custom deep cloning logic. Events can now safely contain non-serializable values like functions.

**Related issues**
Fixes the `DataCloneError` reported in #3993

### Checklist

- [ ] Confirm completion of the self-review checklist
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR_
- [ ] Confirm adherence to code of conduct
