### PR TITLE
fix(service-discovery): add support for session based override of service-discovery endpoints

### DIFF
--- a/.changeset/thin-grapes-poke.md
+++ b/.changeset/thin-grapes-poke.md
@@ -1,0 +1,18 @@
+---
+"@equinor/fusion-framework-module-service-discovery": minor
+"@equinor/fusion-framework-app": minor
+---
+
+Add support for session overridden service discovery endpoints
+
+Checks `overriddenServiceDiscoveryUrls` in session storage.
+
+The serviceName is looked up in ServiceDiscovery.
+User can override url and scopes with session values.
+App can override url and scopes with app config.
+
+Priority:
+
+1. Session overrides
+2. AppConfig
+3. ServiceDiscovery

--- a/packages/modules/service-discovery/src/types.ts
+++ b/packages/modules/service-discovery/src/types.ts
@@ -5,6 +5,14 @@ export type Service = {
   id?: string;
   name?: string;
   tags?: string[];
+  /**
+   * Indicates whether this service configuration has been overridden via
+   * session storage.
+   *
+   * Used by the service override priority system to distinguish between
+   * persisted overrides and default configuration values.
+   */
+  overridden?: boolean;
 
   /**
    * @deprecated use scopes instead


### PR DESCRIPTION




<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
be able to override service-discovery with session values

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
you can't

**What is the new behavior?**
<!-- What will change after this PR is merged. -->
Checks `overriddenServiceDiscoveryUrls` in session storage.

The serviceName is looked up in ServiceDiscovery.
User can override url and scopes with session values. App can override url and scopes with app config.

Priority:

1. Session overrides
2. AppConfig
3. ServiceDiscovery

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
no

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#126

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

