### PR TITLE
feat(msal): add support for backend-issued auth code exchange

### DIFF
--- a/.changeset/msal-auth-code-exchange.md
+++ b/.changeset/msal-auth-code-exchange.md
@@ -1,0 +1,40 @@
+---
+"@equinor/fusion-framework-module-msal": minor
+---
+
+Add support for backend-issued auth code exchange in MSAL module
+
+Enable automatic sign-in using a backend-issued SPA authorization code without requiring interactive MSAL login flows. This eliminates double-login issues and provides seamless user experience when backend pre-authenticates users.
+
+**New API:**
+
+- `MsalConfigurator.setAuthCode(authCode: string)` - Configure backend auth code for token exchange
+- `IMsalClient.acquireTokenByCode(request)` - Exchange auth code for tokens (inherited from PublicClientApplication)
+
+**How it works:**
+
+1. Backend authenticates user and generates short-lived SPA auth code
+2. Frontend calls `builder.setAuthCode(authCode)` during MSAL configuration
+3. During `initialize()`, auth code is exchanged for tokens before `requiresAuth` check
+4. Tokens are cached by MSAL - user is automatically signed in
+5. Falls back to standard MSAL flows if exchange fails
+
+**Example:**
+
+```typescript
+enableMSAL(configurator, (builder) => {
+  builder.setClientConfig({
+    auth: { clientId: 'app-id', tenantId: 'tenant-id' }
+  });
+
+  // Backend injects auth code as window.MSAL_AUTH_CODE during initial first page load
+  if (typeof window !== 'undefined' && window.MSAL_AUTH_CODE) {
+    builder.setAuthCode(window.MSAL_AUTH_CODE);
+    delete (window as any).MSAL_AUTH_CODE; // Clear after consuming
+  }
+
+  builder.setRequiresAuth(true);
+});
+```
+
+Fixes: https://github.com/equinor/fusion-core-tasks/issues/271

--- a/.changeset/msal-docs-auth-code-flow.md
+++ b/.changeset/msal-docs-auth-code-flow.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Add documentation for backend-issued auth code flow in MSAL module
+
+Add comprehensive guide explaining the SPA Auth Code Flow pattern, including:
+- Overview and motivation for using backend-issued codes
+- Step-by-step usage instructions with code examples
+- API documentation for `setAuthCode()` method
+- Security considerations and best practices
+- Troubleshooting guide for common issues
+
+This enables developers to implement seamless authentication without double-login prompts.

--- a/packages/modules/msal/src/MsalClient.interface.ts
+++ b/packages/modules/msal/src/MsalClient.interface.ts
@@ -4,6 +4,7 @@ import type {
   AuthenticationResult,
   PopupRequest,
   RedirectRequest,
+  AuthorizationCodeRequest,
 } from '@azure/msal-browser';
 
 /**
@@ -118,4 +119,21 @@ export interface IMsalClient extends IPublicClientApplication {
    * @returns Promise resolving to authentication result or null/undefined
    */
   acquireToken(options: AcquireTokenOptions): Promise<AcquireTokenResult>;
+
+  /**
+   * Exchange a backend-issued authorization code for tokens (SPA Auth Code Flow).
+   *
+   * This method enables automatic sign-in using a backend-issued auth code without
+   * requiring interactive MSAL flows. Primarily used during module initialization.
+   *
+   * @param request - Authorization code request with code and scopes
+   * @returns Promise resolving to authentication result with tokens
+   *
+   * @remarks
+   * - Auth codes are single-use and short-lived (typically 5-10 minutes)
+   * - MSAL handles token validation, caching, and refresh token management
+   * - Follows Microsoft's standard SPA Auth Code Flow pattern
+   * - Inherited from PublicClientApplication (MSAL Browser v4+)
+   */
+  acquireTokenByCode(request: AuthorizationCodeRequest): Promise<AuthenticationResult>;
 }


### PR DESCRIPTION
**Why is this change needed?**

Enable automatic sign-in using backend-issued authorization codes without requiring interactive MSAL login flows. This solves the double-login problem where users must authenticate twice: once with the backend and once with MSAL. Backend pre-authentication with code exchange provides a seamless user experience.

**What is the current behavior?**

Users must authenticate twice:
1. Authenticate with the backend
2. Return to the frontend and trigger an interactive MSAL login flow

This results in a login prompt and potentially confusing user experience.

**What is the new behavior?**

- Backend generates a short-lived authorization code during user authentication
- Frontend configures MSAL with `builder.setAuthCode(authCode)` during setup
- During `initialize()`, the auth code is exchanged for tokens before the `requiresAuth` check
- Tokens are cached by MSAL and the user is automatically signed in
- If exchange fails, the provider falls back to standard MSAL authentication flows

**Does this PR introduce a breaking change?**

No. This is purely additive—existing code continues to work unchanged.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor (new feature)
- Consumer impact: Optional adoption—consumers can use backend auth codes or continue with existing authentication flows
- Downstream impact: Only affects `@equinor/fusion-framework-module-msal` package

**Review guidance:**

Key areas to verify:
1. **Auth code exchange logic**: Review the priority order (auth code → requiresAuth → fallback) in `MsalProvider.initialize()`
2. **Scope handling**: Auth codes are exchanged with `${clientId}/.default` scope—verify this works for target AAD configuration
3. **Error handling**: Confirm auth code failures are logged and gracefully fall back to standard flows
4. **API surface**: Check that `MsalConfigurator.setAuthCode()` and `IMsalClient.acquireTokenByCode()` are properly documented with TSDoc
5. **Documentation**: Verify README and examples clearly explain the SPA Auth Code Flow pattern and security considerations

**Additional context**

Implementation details:
- Auth code exchange happens as Priority 0 before requiresAuth check in `MsalProvider.initialize()`
- Auth codes are single-use and short-lived (typically 5-10 minutes)—cleared after exchange to prevent reuse
- MSAL handles token validation, caching, and refresh token management
- Follows Microsoft's standard SPA Auth Code Flow pattern (compatible with MSAL Browser v4+)
- Added comprehensive documentation in README with usage examples, security notes, and troubleshooting guide

New API methods:
- `MsalConfigurator.setAuthCode(authCode: string)` - Configure backend auth code for token exchange
- `IMsalClient.acquireTokenByCode(request: AuthorizationCodeRequest)` - Exchange auth code for tokens (inherited from PublicClientApplication)

**Related issues**

Fixes: https://github.com/equinor/fusion-core-tasks/issues/270

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)