### PR TITLE
fix(module-ag-grid): prevent mixed v34/v35 theme state crash

### DIFF
--- a/.changeset/module-ag-grid_fix-style-state-shim.md
+++ b/.changeset/module-ag-grid_fix-style-state-shim.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-module-ag-grid": patch
+---
+
+Fix AG Grid theme initialization crash in mixed v34/v35 runtime scenarios where shared style state can trigger `grids.add is not a function`.
+
+Adds compatibility shimming for the shared AG Grid style injection state so Set-like and Map-like access patterns can coexist when bundles from different AG Grid versions are loaded on the same page.
+
+Related: https://github.com/equinor/fusion-core-tasks/issues/388

--- a/packages/modules/ag-grid/src/AgGridProvider.ts
+++ b/packages/modules/ag-grid/src/AgGridProvider.ts
@@ -2,31 +2,7 @@ import { LicenseManager } from 'ag-grid-enterprise';
 import { ModuleRegistry, provideGlobalGridOptions, type Theme } from 'ag-grid-community';
 
 import type { AgGridConfig } from './AgGridConfigurator.interface';
-
-/**
- * Ensures "window.agStyleInjectionState" has the shape AG Grid v35+ expects.
- *
- * AG Grid changed "grids" from a "Set" (v34) to a "Map" (v35).
- * If the first bundle was v34, "grids" is a "Set" and v35 crashes
- * because it calls "Map" methods ("get", "set") on it.
- *
- * AG Grid captures a local reference to the state object at module
- * evaluation time, so replacing the global has no effect. Instead we
- * mutate the existing object in-place so all captured references see
- * the corrected "grids" property.
- */
-const ensureStyleInjectionState = (): void => {
-  if (typeof window !== 'object') return;
-  const state = (window as Window & { agStyleInjectionState?: Record<string, unknown> })
-    .agStyleInjectionState;
-  if (!state) return;
-  if (!(state.grids instanceof Map)) {
-    state.grids = new Map();
-  }
-  if (!(state.map instanceof WeakMap)) {
-    state.map = new WeakMap();
-  }
-};
+import { applyThemeShim } from './apply-theme-shim';
 
 export interface IAgGridProvider {
   readonly licenseKey?: string;
@@ -57,7 +33,7 @@ export class AgGridProvider implements IAgGridProvider {
   }
 
   protected _init(): void {
-    ensureStyleInjectionState();
+    applyThemeShim();
 
     if (this.licenseKey) {
       LicenseManager.setLicenseKey(this.licenseKey);

--- a/packages/modules/ag-grid/src/apply-theme-shim.ts
+++ b/packages/modules/ag-grid/src/apply-theme-shim.ts
@@ -1,0 +1,49 @@
+/**
+ * Extends a `Map` with an optional `add` API to support legacy Set-like usage.
+ */
+type MapWithAdd = Map<unknown, unknown> & {
+  add?: (key: unknown) => Map<unknown, unknown>;
+};
+
+/**
+ * Ensures `window.agStyleInjectionState` is shimmed for AG Grid compatibility.
+ *
+ * AG Grid has (at least) two observed shapes for `agStyleInjectionState.grids`:
+ * - `Set` (older) where code calls `grids.add(...)`
+ * - `Map` (newer, v35+) where code calls `grids.get/set/delete(...)`
+ *
+ * In setups with multiple bundles (for example module federation), both shapes can
+ * appear on the same page. To avoid runtime crashes, this shims the existing
+ * instance in-place so it supports both APIs.
+ */
+export const applyThemeShim = (): void => {
+  if (typeof window !== 'object') return;
+
+  const state = window.agStyleInjectionState;
+  if (!state) return;
+
+  if (state.grids instanceof Map) {
+    const grids = state.grids as MapWithAdd;
+
+    if (typeof grids.add !== 'function') {
+      grids.add = (key: unknown): Map<unknown, unknown> => {
+        // TODO: Add telemetry when available. This should log when `add` is missing
+        // and we patch Map-based grid state for legacy AG Grid assumptions (requested marker: ">35").
+        grids.set(key, true);
+        return grids;
+      };
+    }
+    if (!(state.map instanceof WeakMap)) {
+      state.map = new WeakMap();
+    }
+  }
+};
+
+declare global {
+  interface Window {
+    agStyleInjectionState?: {
+      grids?: Map<unknown, unknown> | Set<unknown>;
+      map?: unknown;
+    };
+  }
+}


### PR DESCRIPTION
**Why is this change needed?**
Mixed AG Grid runtime scenarios (host on v35, loaded app on v34) can crash during theme initialization with `TypeError: h3.grids.add is not a function`.

**What is the current behavior?**
`AgGridProvider` normalizes shared style state to `Map`/`WeakMap`, but this can still fail when mixed-version paths expect both Set-like `add(...)` and Map APIs on shared `agStyleInjectionState.grids`.

**What is the new behavior?**
A dedicated theme shim is applied before AG Grid initialization to support mixed API expectations on shared style state, preventing the runtime crash in mixed v34/v35 scenarios.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`@equinor/fusion-framework-module-ag-grid`)
- Consumer impact: Fixes runtime stability in mixed-version AG Grid environments
- Downstream impact: Affects AG Grid module consumers; no API contract change

**Review guidance:**
- Verify `applyThemeShim()` is invoked before AG Grid setup in `AgGridProvider`.
- Verify shim behavior in `themeShim.ts` for mixed Set-like and Map-like usage.
- Confirm changeset content and bump type are correct.

closes: https://github.com/equinor/fusion-core-tasks/issues/388

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
