### PR TITLE
feat(analytics)!: add appKey to ContextSelectedCollector's attributes

### DIFF
--- a/.changeset/rare-poets-send.md
+++ b/.changeset/rare-poets-send.md
@@ -1,0 +1,31 @@
+---
+"portal-analytics": minor
+"@equinor/fusion-framework-module-analytics": major
+---
+
+`ContextSelectedCollector` now accepts an `AppModuleProvider` as a second
+constructor argument and includes the currently active application key
+(`appKey`) in the event attributes.
+
+This allows analytics consumers to correlate context-change events with the app
+that was active when the context switch occurred.
+
+**Breaking change for direct users of `ContextSelectedCollector`:** the
+constructor now requires a second argument:
+
+```typescript
+// Before
+new ContextSelectedCollector(contextProvider);
+// After
+new ContextSelectedCollector(contextProvider, appProvider);
+```
+
+The emitted event attributes schema is extended accordingly:
+
+```typescript
+// attributes shape
+{
+  previous: ContextMetadata | null | undefined;
+  appKey?: string; // newly added — the appKey of the active app at the time of the context change
+}
+```

--- a/cookbooks/portal-analytics/src/framworkConfig.ts
+++ b/cookbooks/portal-analytics/src/framworkConfig.ts
@@ -83,7 +83,8 @@ export const frameworkConfig: PortalModuleInitiator = (configurator) => {
 
     builder.setCollector('context-selected', async (args) => {
       const contextProvider = await args.requireInstance('context');
-      return new ContextSelectedCollector(contextProvider);
+      const appProvider = await args.requireInstance('app');
+      return new ContextSelectedCollector(contextProvider, appProvider);
     });
 
     builder.setCollector('app-selected', async (args) => {

--- a/packages/modules/analytics/README.md
+++ b/packages/modules/analytics/README.md
@@ -25,7 +25,8 @@ const configure = (configurator: IModulesConfigurator<any, any>) => {
 
     builder.setCollector('context-selected', async (args) => {
       const contextProvider = await args.requireInstance('context');
-      return new ContextSelectedCollector(contextProvider);
+      const appProvider = await args.requireInstance('app');
+      return new ContextSelectedCollector(contextProvider, appProvider);
     });
   });
 }
@@ -180,7 +181,8 @@ const configure = (configurator: IModulesConfigurator<any, any>) => {
   enableAnalytics(configurator, (builder) => {
     builder.setCollector('context-selected', async (args) => {
       const contextProvider = await args.requireInstance('context');
-      return new ContextSelectedCollector(contextProvider);
+      const appProvider = await args.requireInstance('app');
+      return new ContextSelectedCollector(contextProvider, appProvider);
     });
   });
 }
@@ -210,7 +212,8 @@ const configure = (configurator: IModulesConfigurator<any, any>) => {
   enableAnalytics(configurator, (builder) => {
     builder.setCollector('context-selected', async (args) => {
       const contextProvider = await args.requireInstance('context');
-      return new ContextSelectedCollector(contextProvider);
+      const appProvider = await args.requireInstance('app');
+      return new ContextSelectedCollector(contextProvider, appProvider);
     });
   });
 }

--- a/packages/modules/analytics/src/collectors/ContextSelectedCollector.ts
+++ b/packages/modules/analytics/src/collectors/ContextSelectedCollector.ts
@@ -1,6 +1,7 @@
 import { distinctUntilChanged, map, type ObservableInput, pairwise } from 'rxjs';
 import type { IAnalyticsCollector } from './AnalyticsCollector.interface.js';
 import type { IContextProvider } from '@equinor/fusion-framework-module-context';
+import type { AppModuleProvider } from '@equinor/fusion-framework-module-app';
 import { z } from 'zod';
 import { BaseCollector, createSchema } from './BaseCollector.js';
 import {
@@ -12,26 +13,31 @@ import {
 /**
  * The schema of the data to be sent.
  */
-const eventSchema = createSchema(contextSchema, z.object({ previous: contextSchema }));
+const eventSchema = createSchema(
+  contextSchema,
+  z.object({ previous: contextSchema, appKey: z.string().optional() }),
+);
 
 /**
  * Collector to listen for context changes and add values and attributes for
  * further processing by adapters.
  */
 export class ContextSelectedCollector
-  extends BaseCollector<ContextItemType, { previous?: ContextItemType }>
+  extends BaseCollector<ContextItemType, { previous?: ContextItemType; appKey?: string }>
   implements IAnalyticsCollector
 {
   #contextProvider: IContextProvider;
+  #appProvider: AppModuleProvider;
 
-  constructor(contextProvider: IContextProvider) {
+  constructor(contextProvider: IContextProvider, appProvider: AppModuleProvider) {
     super('context-selected', eventSchema);
     this.#contextProvider = contextProvider;
+    this.#appProvider = appProvider;
   }
 
   _initialize(): ObservableInput<{
     value: ContextItemType;
-    attributes: { previous?: ContextItemType };
+    attributes: { previous?: ContextItemType; appKey?: string };
   }> {
     const contextSelected$ = this.#contextProvider.currentContext$.pipe(
       // Only emit when an actual change has happened.
@@ -46,6 +52,7 @@ export class ContextSelectedCollector
           value: next && extractContextMetadata(next),
           attributes: {
             previous: prev && extractContextMetadata(prev),
+            appKey: this.#appProvider.current?.appKey,
           },
         };
       }),


### PR DESCRIPTION

<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
Allows analytics consumers to correlate context-change events with the app that was active when the context switch occurred.

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
We don't send appKey

**What is the new behavior?**
<!-- What will change after this PR is merged. -->
Add appKey to event's parameters

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
Yes. 
The constructor of ContextSelectedCollector now requires a
second argument: appProvider.

```typescript
// Before
new ContextSelectedCollector(contextProvider);
// After
new ContextSelectedCollector(contextProvider, appProvider);
```

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->
The fusion-portal is the consumer. A new PR will get created there to rectify the breaking change. 

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#427

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

