### PR TITLE
fix(analytics): fix extractContextMetadata to comply with Zod context schema

### DIFF
--- a/.changeset/public-sheep-report.md
+++ b/.changeset/public-sheep-report.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-analytics": patch
+---
+
+Fix `extractContextMetadata` to use nullish coalescing (`?? undefined`) for
+optional fields (`externalId`, `title`, `source`), ensuring `null` values from
+`ContextItem` are coerced to `undefined` to comply with the Zod context schema.

--- a/packages/modules/analytics/src/collectors/utils/extractContextMetadata.ts
+++ b/packages/modules/analytics/src/collectors/utils/extractContextMetadata.ts
@@ -19,9 +19,9 @@ export type ContextItemType = z.infer<typeof contextSchema>;
 export const extractContextMetadata = (context: ContextItem): z.input<typeof contextSchema> => {
   return {
     id: context.id,
-    externalId: context.externalId,
-    title: context.title,
+    externalId: context.externalId ?? undefined,
+    title: context.title ?? undefined,
     type: context.type.id,
-    source: context.source,
+    source: context.source ?? undefined,
   };
 };


### PR DESCRIPTION




<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
to comply with the Zod context schema.

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
We get a zod error while trying to report context-change if the optional values are sent in as null (not complying with the ContextItem type)

**What is the new behavior?**
<!-- What will change after this PR is merged. -->
Fix `extractContextMetadata` to use nullish coalescing (`?? undefined`) for optional fields (`externalId`, `title`, `source`), ensuring `null` values from `ContextItem` are coerced to `undefined` to comply with the Zod context schema.

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
no

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#482


### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

