### PR TITLE
fix(cli): allow nullish portal manifest annotations

### DIFF
--- a/.changeset/fusion-framework-cli_portal-manifest-docs.md
+++ b/.changeset/fusion-framework-cli_portal-manifest-docs.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Internal: update portal manifest build annotation validation to accept `null` values (`string | null | undefined`) and document the nullish handling behavior.

--- a/packages/cli/src/lib/portal/portal-manifest.schema.ts
+++ b/packages/cli/src/lib/portal/portal-manifest.schema.ts
@@ -36,10 +36,10 @@ export const PortalManifestBuildSchema = z.object({
   // Current git commit SHA (required)
   commitSha: z.string({ message: 'commitSha must be a string' }).describe('Current git commit SHA'),
   // Optional build annotations (key-value pairs)
-  // Accepts Record<string, string | undefined> but transforms to Record<string, string>
-  // by filtering out undefined values to preserve the manifest contract
+  // Accepts Record<string, string | null | undefined> and removes undefined values
+  // while preserving explicit null values from input
   annotations: z
-    .record(z.string(), z.string().optional())
+    .record(z.string(), z.string().nullish())
     .optional()
     .transform((rec) => {
       if (!rec) {


### PR DESCRIPTION
**Why is this change needed?**
Portal manifest build annotations may include nullish values in generated or user-provided metadata. The schema previously rejected null values even though downstream handling already supports filtering undefined values.

**What is the current behavior?**
`build.annotations` accepts `string | undefined` values only. If a value is `null`, validation fails.

**What is the new behavior?**
`build.annotations` now accepts `string | null | undefined` via `z.string().nullish()`. The transform still removes `undefined` entries and preserves explicit `null` values. Inline comments and schema docs are updated to match behavior.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Consumers can provide `null` annotation values without schema validation failure.
- Downstream impact: Limited to CLI portal manifest schema validation.

**Review guidance:**
- Confirm schema definition changed from `.optional()` to `.nullish()` for annotation values.
- Confirm changeset bump is patch for `@equinor/fusion-framework-cli`.
- Validate transform behavior still filters only `undefined` values.

**Additional context**
Test command attempted: `pnpm -C packages/cli test --run` (failed in this environment because `vitest` was not found).

**Related issues**
None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
