### PR TITLE
fix: update routes to include PeopleConceptPage and ensure proper export

### DIFF
--- a/cookbooks/app-react-people/src/pages/PeopleConceptPage.tsx
+++ b/cookbooks/app-react-people/src/pages/PeopleConceptPage.tsx
@@ -100,3 +100,5 @@ export const PeopleConceptPage = () => {
     </div>
   );
 };
+
+export default PeopleConceptPage;

--- a/cookbooks/app-react-people/src/routes.tsx
+++ b/cookbooks/app-react-people/src/routes.tsx
@@ -1,13 +1,12 @@
 import { layout, index, route } from '@equinor/fusion-framework-react-router/routes';
 
-// TODO
-// route('people-concepts', './pages/PeopleConceptPage.tsx'),
 export const routes = layout('./pages/Navigation.tsx', [
   index('./pages/HomePage.tsx'),
   route('avatar/*', './pages/AvatarPage.tsx'),
   route('card/*', './pages/CardPage.tsx'),
   route('list-item/*', './pages/ListItemPage.tsx'),
   route('selector/*', './pages/SelectorPage.tsx'),
+  route('people-concepts/*', './pages/PeopleConceptPage.tsx'),
 ]);
 
 export default routes;


### PR DESCRIPTION
**Why is this change needed?**
The app-react-people cookbook on the react-19 branch is missing the people-concepts route even though the page exists. The page module also needs a default export so the route file can resolve it correctly.

**What is the current behavior?**
The people-concepts route is commented out in the cookbook routes, so the page is not reachable through navigation. In addition, PeopleConceptPage is only exported as a named export, which can cause route module resolution problems for the file-based router.

**What is the new behavior?**
The cookbook now registers the people-concepts/* route and PeopleConceptPage also exports a default component. This makes the page reachable and ensures the route module exports match the router expectations.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No.
- Version bump: None expected. This is a cookbook-only fix.
- Consumer impact: Limited to the app-react-people cookbook example on the react-19 branch.
- Downstream impact: No package API changes and no expected downstream monorepo impact.

**Review guidance:**
- Verify that the people-concepts page is reachable in the app-react-people cookbook.
- Confirm the route resolves without module export issues after adding the default export.
- Focus review on the route registration and page export shape.

**Additional context**
This PR is intentionally small and only updates the app-react-people cookbook routing for React 19.

Changes included in this PR:
- Re-enabled the people-concepts/* route in the cookbook route definition.
- Added a default export for PeopleConceptPage so the route module resolves correctly.

**Related issues**
ref: equinor/fusion-core-tasks#531
ref: equinor/fusion-core-tasks#451

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)