### PR TITLE
feat: automate Fusion skills sync with scheduled workflow

### DIFF
--- a/.github/workflows/skills-update.yml
+++ b/.github/workflows/skills-update.yml
@@ -1,0 +1,14 @@
+name: Upgrade Agent Skills
+
+on:
+  schedule:
+    - cron: '0 8 * * 1-5'      # Weekdays at 8 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    uses: equinor/fusion-skills/.github/workflows/skills-update.yml@main


### PR DESCRIPTION
**Why is this change needed?**

The repository needs one consistent home for installed and repo-owned skills. On `main`, the newer Fusion skills catalog is not present under `.agents/skills`, older repository skill content still lives under the deprecated `.github/skills` location, and there is no lock file or scheduled workflow to keep installed Fusion skills synchronized. This branch consolidates the skill layout, imports the Fusion skills catalog, and adds the automation and repo instructions needed to maintain it.

**What is the current behavior?**

- `main` does not include the imported Fusion skills catalog under `.agents/skills`
- Repository skill content still exists under `.github/skills`, including `dependabot-pr-handler`, `make-skill-template`, `npm-research`, `pnpm-dependency-analysis`, and the older `rebase` entry
- There is no `skills-lock.json` recording the installed Fusion skill set
- There is no scheduled workflow for keeping installed Fusion skills synchronized
- Dependabot and instruction wiring still references the older skill layout in places

**What is the new behavior?**

- Adds the Fusion skills catalog under `.agents/skills`, including dependency review, issue authoring, MCP, skill authoring, and review-resolution workflows
- Adds `skills-lock.json` to record the installed Fusion skills set for the repository
- Adds a scheduled GitHub Actions workflow in `.github/workflows/skills-update.yml` to keep installed skills synchronized
- Removes the remaining `.github/skills` entries and consolidates repo-owned skill content under `.agents/skills`
- Migrates the repo-specific rebase workflow to `.agents/skills/custom-rebase`
- Keeps generic dependency-review behavior in the imported Fusion skill catalog instead of carrying separate local `npm-research` or `pnpm-dependency-analysis` skills
- Adds repo-specific instruction overlays for workflow contributions, skill-catalog handling, and Dependabot PR handling
- Updates the Dependabot agent and instruction indexes to the current skill layout

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: None
- Consumer impact: None for published packages; this PR only changes repository automation, internal skill catalog content, and AI workflow guidance
- Downstream impact: Affects repository automation, local skill discovery/update flows, and internal Copilot or MCP-assisted workflows only

**Review guidance:**

- Verify `.github/workflows/skills-update.yml` is the intended scheduled sync workflow
- Verify the imported Fusion skills under `.agents/skills` are the intended catalog contents for this repository
- Verify `skills-lock.json` matches the installed Fusion skill set introduced by this branch
- Verify repo-owned skills now live under `.agents/skills` and `.github/skills` is fully removed
- Verify `.agents/skills/custom-rebase` is the correct home for the repo-specific rebase workflow and scripts
- Verify the new instruction files align with the existing Fusion skill catalog instead of trying to replace it
- Verify `.github/agents/dependabot.agent.md` now points to the current Dependabot workflow sources

**Additional context**

This branch includes three layers of work against `main`:

- importing the Fusion skills catalog into `.agents/skills`
- adding the lock file and scheduled sync workflow needed to keep that catalog current
- cleaning up the deprecated `.github/skills` layout and updating repo-specific instructions and agent wiring

No changeset was added because this PR only changes repository workflow files, agent instructions, and internal skill-catalog organization; it does not change a published package or consumer-facing documentation set.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
