### PR TITLE
fix(cli): tighten simple-git minimum to 3.32.3

### DIFF
--- a/.changeset/cli_secure-simple-git-range.md
+++ b/.changeset/cli_secure-simple-git-range.md
@@ -1,0 +1,8 @@
+---
+"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-cli-plugin-ai-index": patch
+---
+
+Require `simple-git` 3.32.3 or newer in published package manifests to align installs with the upstream fix for CVE-2026-28292.
+
+This does not change the CLI API. It tightens the minimum allowed dependency version so fresh installs and manifest-based scanners resolve the first safe `simple-git` release.

--- a/packages/cli-plugins/ai-index/package.json
+++ b/packages/cli-plugins/ai-index/package.json
@@ -58,7 +58,7 @@
     "multimatch": "^8.0.0",
     "read-package-up": "^12.0.0",
     "rxjs": "^7.8.1",
-    "simple-git": "^3.28.0",
+    "simple-git": "^3.32.3",
     "tree-sitter": "^0.25.0",
     "tree-sitter-typescript": "^0.23.2",
     "ts-morph": "^27.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -118,7 +118,7 @@
     "ora": "^9.0.0",
     "read-package-up": "^12.0.0",
     "semver": "^7.6.0",
-    "simple-git": "^3.28.0",
+    "simple-git": "^3.32.3",
     "vite": "^7.1.12",
     "vite-tsconfig-paths": "^6.0.4",
     "zod": "^4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,7 +856,7 @@ importers:
         specifier: ^7.6.0
         version: 7.7.4
       simple-git:
-        specifier: ^3.28.0
+        specifier: ^3.32.3
         version: 3.32.3
       vite:
         specifier: ^7.1.12
@@ -1051,7 +1051,7 @@ importers:
         specifier: ^7.8.1
         version: 7.8.2
       simple-git:
-        specifier: ^3.28.0
+        specifier: ^3.32.3
         version: 3.32.3
       tree-sitter:
         specifier: ^0.25.0


### PR DESCRIPTION
**Why is this change needed?**
The CLI and AI index plugin were already resolving `simple-git` 3.32.3 through the workspace lockfile, which is the first fixed version for CVE-2026-28292. However, both published package manifests still declared `^3.28.0`, which could allow vulnerable installs outside this workspace context and makes manifest-based security scanners report unnecessary risk.

**What is the current behavior?**
Within this repository, installs already resolve `simple-git` 3.32.3, so `main` is effectively using a fixed version. The mismatch is in the published manifest ranges: consumers and scanners inspecting `package.json` still see a range that includes versions affected by CVE-2026-28292.

The practical runtime exposure in the CLI also appears limited. The create flow clones the fixed `equinor/fusion-app-template` repository and passes fixed clone flags rather than attacker-controlled `customArgs`.

**What is the new behavior?**
This change tightens the declared `simple-git` dependency range from `^3.28.0` to `^3.32.3` in the published CLI and AI index plugin manifests and aligns the lockfile importer metadata.

Fresh installs now resolve the first safe upstream release by declaration, and manifest-based scanners no longer need to infer safety from the workspace lockfile alone.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Consumers get an explicit safe minimum for `simple-git` in published manifests; no CLI API or behavior changes
- Downstream impact: Affects `@equinor/fusion-framework-cli` and `@equinor/fusion-framework-cli-plugin-ai-index` release metadata only

**Review guidance:**
- Confirm the dependency range is tightened to `^3.32.3` in the two published package manifests
- Confirm the lockfile importer specifiers match the manifest change
- Confirm the changeset text clearly explains that this is a manifest tightening, not a new runtime feature or API change
- Confirm the risk framing is accurate: already effectively fixed on `main`, but not clearly expressed in published manifests

**Additional context**
The CVE record lists `simple-git` versions `< 3.32.3` as affected. This repository had already picked up 3.32.3 in the lockfile and changelog, but the manifest ranges were not updated at the same time.

Targeted validation run for this change:
- `pnpm install --frozen-lockfile`
- `pnpm changeset status`

Not run as part of this small dependency metadata update:
- `pnpm test`
- `pnpm build`
- `pnpm -w check`

**Related issues**
ref: CVE-2026-28292

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

## Release note wording

Require `simple-git` 3.32.3 or newer in the CLI and AI index plugin package manifests to align published installs with the upstream fix for CVE-2026-28292.

This patch does not change the CLI API or runtime behavior on `main`. It tightens the declared minimum dependency version so consumers and security scanners resolve the first safe `simple-git` release directly from package metadata.