### PR TITLE
docs: simplify eval format, add judge sub-agent, fix lifecycle finding

### DIFF
--- a/.agents/skills/custom-index-eval/SKILL.md
+++ b/.agents/skills/custom-index-eval/SKILL.md
@@ -4,7 +4,7 @@ description: 'Iterative evaluation of Fusion Framework MCP search quality agains
 license: MIT
 compatibility: Requires Fusion MCP access via `mcp_fusion_search` or `mcp_fusion_search_framework`. Works in any runtime that can read local files and call MCP tools.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
   status: experimental
   owner: "@equinor/fusion-core"
   tags:
@@ -58,53 +58,41 @@ If the user says only `eval` with no domain, ask which domain to evaluate or whe
 
 1. If the target is a specific domain (e.g., `core`), read `eval/index/<domain>.md`
 2. If the target is `all`, list all `.md` files in `eval/index/` except `README.md` and process each one sequentially
-3. If the file does not exist or has no `## Pattern:` sections, report it as empty and skip
+3. If the file does not exist or has no `##` query sections, report it as empty and skip
 
-### Step 2 — Parse patterns from the domain file
+### Step 2 — Parse the domain file
 
-For each domain file, extract every `## Pattern:` section. Each pattern contains:
+Domain files have a simple structure:
 
-- **Pattern name**: the heading text after `## Pattern:`
-- **Requirement level**: `must` or `should` from the `**Requirement:**` line
-- **Description**: the prose explaining the pattern
-- **Code examples**: TypeScript codeblocks showing canonical usage
-- **File references**: real monorepo file paths
-- **Notes**: constraints, edge cases, related patterns
+- `# Domain Name` — the domain heading
+- Paragraph below `#` — **judgement instructions** for how to evaluate results across all queries in this domain
+- `## <query>` — each `##` heading is a search query to run against MCP
+- `- must ...` / `- should ...` — expectations for each query's results
 
-Build a list of patterns to evaluate. Track the requirement level for each.
+Extract the judgement instructions once (use them as context when evaluating every query). Then build a list of queries, each with its `must` and `should` expectations.
 
-### Step 3 — Query Fusion MCP for each pattern
+### Step 3 — Evaluate each query via judge sub-agent
 
-For each pattern, construct a search query and call Fusion MCP:
+For each `##` heading, spin up a **query-judge** sub-agent (see `agents/query-judge.md`). Pass it:
 
-1. Use the pattern name as the primary search query
-   - Example: for `## Pattern: Initialize framework with FrameworkConfigurator and init`, search for `"Initialize framework with FrameworkConfigurator and init"`
-2. Call `mcp_fusion_search_framework` (preferred) or `mcp_fusion_search` with the query
-3. Collect the top results returned by MCP
+- The heading text (search query)
+- The `must` and `should` bullets for that query
+- The domain-level judgement instructions
 
-### Step 4 — Validate results against the pattern
+The judge sub-agent will:
+1. Search MCP using the heading text
+2. Check results against each expectation
+3. Return a verdict (`pass` / `partial` / `fail`) with counts and explanation
 
-For each pattern, evaluate whether the MCP results satisfy the documented expectations:
+If the runtime does not support sub-agents, follow the same workflow inline:
+1. Use the heading text as the search query
+2. Call `mcp_fusion_search_framework` (preferred) or `mcp_fusion_search`
+3. Check results against each `must` / `should` bullet
+4. Record verdict with explanation
 
-**Pass criteria:**
-- At least one result references the same package, API, or concept described in the pattern
-- Key exported symbols mentioned in the pattern appear in the returned content
-- The returned guidance is consistent with (not contradicting) the pattern's must/should statements
+Collect all verdicts before producing the report.
 
-**Fail criteria:**
-- No results returned for the query
-- Results reference unrelated packages or concepts
-- Results contradict the documented must/should requirements
-- Key symbols or file paths from the pattern are absent from all returned results
-
-**Partial criteria:**
-- Results cover the concept but miss specific details (e.g., returns the package but not the specific API pattern)
-- Results are correct but outdated compared to the documented pattern
-- Only some of the key symbols appear in results
-
-Record the verdict as `pass`, `partial`, or `fail` with a brief explanation.
-
-### Step 5 — Generate the evaluation report
+### Step 4 — Generate the evaluation report
 
 Produce a report following the template in `assets/report-template.md`. The report includes:
 
@@ -113,7 +101,7 @@ Produce a report following the template in `assets/report-template.md`. The repo
 3. **Summary statistics**: total patterns, pass/partial/fail counts, pass rate
 4. **Recommendations**: actionable next steps for failed or partial patterns
 
-### Step 6 — Present results
+### Step 5 — Present results
 
 - Print the full report to the conversation
 - For `eval all`, present a per-domain summary first, then offer to show detailed results for any domain
@@ -134,11 +122,10 @@ A structured evaluation report containing:
 
 **Workflow:**
 1. Read `eval/index/core.md`
-2. Extract 5 patterns: "Initialize framework with FrameworkConfigurator and init", "Define a module with the Module interface", "Module lifecycle phases", "Configure application modules with AppModuleInitiator", "Listen to framework events with addEventListener"
-3. For each pattern, search Fusion MCP:
-   - Search: `"Initialize framework with FrameworkConfigurator and init"`
-   - Evaluate: Do results mention `FrameworkConfigurator`, `init`, `@equinor/fusion-framework`?
-4. Produce report:
+2. Note judgement instructions: "Results should reference `@equinor/fusion-framework` and `@equinor/fusion-framework-module`..."
+3. Extract 5 queries from `##` headings
+4. For each, search MCP and check `must`/`should` bullets
+5. Produce report:
 
 ```
 ## Evaluation Report: core
@@ -147,24 +134,21 @@ Date: 2026-03-14
 Strictness: full
 Domain: eval/index/core.md
 
-| # | Pattern | Req | Verdict | Explanation |
-|---|---------|-----|---------|-------------|
-| 1 | Initialize framework with FrameworkConfigurator and init | must | pass | Results include @equinor/fusion-framework README with FrameworkConfigurator and init examples |
-| 2 | Define a module with the Module interface | must | pass | Results cover Module type from @equinor/fusion-framework-module |
-| 3 | Module lifecycle phases | should | partial | Lifecycle mentioned but postConfigure/postInitialize hooks not detailed |
-| 4 | Configure application modules with AppModuleInitiator | must | fail | No results reference AppModuleInitiator or app-level configuration |
-| 5 | Listen to framework events with addEventListener | must | pass | Event module documentation returned with addEventListener examples |
+| # | Query | Verdict | Explanation |
+|---|-------|---------|-------------|
+| 1 | How to initialize Fusion Framework | pass | Results mention FrameworkConfigurator, init, configureMsal |
+| 2 | How to create a custom module | pass | Module interface, BaseConfigBuilder, BaseModuleProvider all covered |
+| 3 | Module lifecycle phases | partial | Lifecycle order shown but postConfigure/postInitialize hooks not detailed |
+| 4 | How to configure an app with AppModuleInitiator | fail | No results reference AppModuleInitiator |
+| 5 | How to listen to framework events | pass | addEventListener, dispatchEvent, event module all returned |
 
 ### Summary
-- Total: 5 patterns
-- Pass: 3 (60%)
-- Partial: 1 (20%)
-- Fail: 1 (20%)
-- Must pass rate: 3/4 (75%)
+- Queries: 5 | Pass: 3 | Partial: 1 | Fail: 1
+- Must expectations met: 14/17 (82%)
 
 ### Recommendations
-1. **[CRITICAL]** Pattern 4 — AppModuleInitiator: Re-index `packages/app/src/types.ts` and `cookbooks/app-react/src/config.ts` to cover app configuration patterns
-2. **[IMPROVE]** Pattern 3 — Lifecycle phases: Enrich `packages/modules/module/README.md` lifecycle section with postConfigure and postInitialize examples
+1. **[CRITICAL]** Query 4: Re-index `packages/app/src/types.ts` and `cookbooks/app-react/src/config.ts`
+2. **[IMPROVE]** Query 3: Enrich lifecycle section in `packages/modules/module/README.md`
 ```
 
 ## Safety & constraints

--- a/.agents/skills/custom-index-eval/agents/query-judge.md
+++ b/.agents/skills/custom-index-eval/agents/query-judge.md
@@ -1,0 +1,40 @@
+# Query Judge
+
+Evaluates a single MCP search query against documented expectations from a domain file.
+
+## Role
+
+You are a strict evaluator. Given a search query, its must/should expectations, domain-level judgement instructions, and MCP search results, determine whether the results satisfy the expectations. Return a verdict only — do not fix, edit, or suggest changes to the index.
+
+## Inputs
+
+- **Query**: the `##` heading text from the domain file (used as the search query)
+- **Expectations**: the `- must ...` and `- should ...` bullets for this query
+- **Judgement instructions**: the domain-level preamble (below the `#` heading)
+- **MCP results**: the search results returned by `mcp_fusion_search_framework` or `mcp_fusion_search`
+
+## Workflow
+
+1. Read the domain-level judgement instructions. These apply to every query in the domain.
+2. Search MCP using the query heading text via `mcp_fusion_search_framework` (preferred) or `mcp_fusion_search`.
+3. For each `must` expectation, check whether any returned result satisfies it. Be precise — the expectation names specific symbols, packages, or concepts.
+4. For each `should` expectation, check the same way but with lighter weight.
+5. Apply the domain-level judgement instructions as a cross-cutting filter (e.g., reject results with relative imports if the domain instructions say so).
+6. Produce a verdict.
+
+## Verdict scale
+
+- **pass** — all `must` expectations met, most `should` expectations met
+- **partial** — all `must` met but `should` largely missing, OR some `must` missed but results are relevant
+- **fail** — critical `must` expectations not met, or no relevant results returned
+
+## Output contract
+
+Return exactly:
+
+- **Query**: the heading text
+- **Verdict**: `pass`, `partial`, or `fail`
+- **Must met**: count of must expectations satisfied / total must expectations
+- **Should met**: count of should expectations satisfied / total should expectations
+- **Explanation**: one sentence noting which key expectations were met or missed
+- **Remediation** (only for `partial` or `fail`): one sentence describing what would fix the gap

--- a/.agents/skills/custom-index-eval/assets/report-template.md
+++ b/.agents/skills/custom-index-eval/assets/report-template.md
@@ -10,27 +10,21 @@ Use this template when producing evaluation reports.
 **Strictness:** {full | strict}
 **Domain file:** `eval/index/{domain}.md`
 
-### Pattern Results
+### Results
 
-| # | Pattern | Req | Verdict | Explanation |
-|---|---------|-----|---------|-------------|
-| {n} | {pattern name} | {must\|should} | {pass\|partial\|fail} | {brief explanation of what MCP returned vs what was expected} |
+| # | Query | Verdict | Explanation |
+|---|-------|---------|-------------|
+| {n} | {## heading text} | {pass\|partial\|fail} | {which must/should expectations were met or missed} |
 
 ### Summary
 
-- **Total patterns:** {count}
-- **Pass:** {count} ({percent}%)
-- **Partial:** {count} ({percent}%)
-- **Fail:** {count} ({percent}%)
-- **Must pass rate:** {must_pass}/{must_total} ({percent}%)
-- **Should pass rate:** {should_pass}/{should_total} ({percent}%)
+- **Queries:** {count} | **Pass:** {count} | **Partial:** {count} | **Fail:** {count}
+- **Must expectations met:** {met}/{total} ({percent}%)
 
 ### Recommendations
 
-List recommendations in priority order. Use `[CRITICAL]` for `must` failures, `[IMPROVE]` for `should` failures or partials:
-
-1. **[CRITICAL]** Pattern {n} — {name}: {concrete action to fix the gap}
-2. **[IMPROVE]** Pattern {n} — {name}: {concrete action to improve coverage}
+1. **[CRITICAL]** Query {n}: {concrete action to fix the gap}
+2. **[IMPROVE]** Query {n}: {concrete action to improve coverage}
 
 ### Notes
 

--- a/eval/index/README.md
+++ b/eval/index/README.md
@@ -1,143 +1,78 @@
 # Fusion Framework Evaluation Index
 
-Shared evaluation infrastructure for validating Fusion Framework MCP search retrieval quality. Domain files in this directory define expected coding patterns, conventions, and usage guidance that the search index must surface accurately.
-
-## Purpose
-
-The evaluation index exists to:
-
-- Define authoritative framework patterns that retrieval must return correctly
-- Provide structured test material for validating index freshness and accuracy
-- Give contributors a clear format for documenting patterns that drive evaluation
-- Support automated evaluation workflows that compare retrieval results against expected patterns
+Shared evaluation infrastructure for validating Fusion Framework MCP search retrieval quality. Domain files in this directory define expected search queries and what the index should return for each.
 
 ## How it works
 
-Each **domain file** describes a set of patterns for a specific area of Fusion Framework. When the search index is evaluated, queries derived from these patterns are run against the index, and the results are checked for accuracy and completeness.
-
-A pattern represents a single coding convention, API usage rule, or architectural requirement. Each pattern includes:
-
-- A descriptive name
-- A requirement level (`must` or `should`)
-- Canonical code examples or file references showing the correct approach
-- Context explaining when and why the pattern applies
+Each **domain file** lists search queries as `##` headings. Under each heading, bullet points describe what the index **must** or **should** return. When evaluating, run the heading as a search query and check results against the expectations.
 
 ## Directory structure
 
 ```
 eval/
   index/
-    README.md            # This file — framework overview and contribution guide
-    core.md              # Core framework patterns (modules, providers, initialization)
-    state-data.md        # State management and data flow patterns
-    http-services.md     # HTTP client and service layer patterns
-    auth.md              # Authentication and authorization patterns
-    ui-components.md     # React components and UI patterns
-    features.md          # Feature flags, bookmarks, and app-level features
-    utilities.md         # Shared utilities and helper patterns
+    README.md            # This file
+    core.md              # Modules, providers, initialization, events
+    state-data.md        # State management and data flow
+    http-services.md     # HTTP clients and service layer
+    auth.md              # Authentication and authorization
+    ui-components.md     # React components and UI
+    features.md          # Feature flags, bookmarks, app features
+    utilities.md         # Shared utilities and helpers
 ```
 
-## Domain file template
+## Format
 
-Every domain file follows the same markdown structure. Use this template when adding new patterns to a domain file.
-
-### File header
-
-Each domain file starts with a title and a one-line summary of what the domain covers:
+Each domain file follows this structure:
 
 ```markdown
 # Domain Name
 
-Brief description of which part of Fusion Framework this domain covers and what kinds of patterns belong here.
+Judgement instructions for this domain — directed at you, the evaluator.
+Ensure results reference the right packages. Verify symbols are real exports.
+Reject results that contradict documented patterns.
+
+## Search query as a natural question
+
+- must mention X from `@equinor/fusion-framework-*`
+- must show Y pattern or API
+- should reference Z as related concept
 ```
 
-### Pattern format
-
-Each pattern is a level-2 heading followed by structured sections:
-
-```markdown
-## Pattern: Descriptive Pattern Name
-
-**Requirement:** `must` | `should`
-
-Brief explanation of what this pattern requires and why it matters for Fusion Framework consumers.
-
-### Example
-
-\`\`\`typescript
-// Canonical code example showing the correct approach
-import { something } from '@equinor/fusion-framework-module-something';
-
-const result = something.doTheRightThing();
-\`\`\`
-
-### File references
-
-- `packages/modules/something/src/provider.ts` — where the pattern is implemented
-- `cookbooks/app-react/src/App.tsx` — cookbook example demonstrating usage
-
-### Notes
-
-- Any constraints, edge cases, or related patterns worth mentioning
-- Links to related patterns in other domain files when relevant
-```
+The `#` heading names the domain. The paragraph below it tells the evaluator
+how to judge results across all queries in that domain.
+Each `##` heading is a search query. Bullets are expectations.
 
 ### Requirement levels
 
-- **`must`** — A hard requirement. Code that violates this pattern is incorrect or will break. The search index must surface this pattern accurately for relevant queries.
-- **`should`** — A strong recommendation. Code that follows this pattern is idiomatic and maintainable. The search index should surface this pattern for relevant queries but it is not a correctness issue if missed.
-
-### Complete single-pattern example
-
-Below is a fully populated example pattern showing the expected format:
-
-```markdown
-## Pattern: Use scoped package imports
-
-**Requirement:** `must`
-
-Always import from scoped `@equinor/fusion-framework-*` package names. Never use relative imports to reach into other monorepo packages. Scoped imports ensure correct dependency resolution and allow each package to be versioned and published independently.
+- **`must`** — the index must surface this for the query; absence means a gap
+- **`should`** — the index should ideally surface this; absence is not critical
 
 ### Example
 
-\`\`\`typescript
-// Correct — scoped package import
-import { useFramework } from '@equinor/fusion-framework-react';
+```markdown
+# HTTP & Services
 
-// Incorrect — relative cross-package import
-import { useFramework } from '../../react/src/useFramework';
-\`\`\`
+Ensure results reference `@equinor/fusion-framework-module-http` or
+`@equinor/fusion-framework-module-service-discovery`. Verify that
+package names, configuration helpers, and code examples are real.
 
-### File references
+## How to configure a named HTTP client
 
-- `packages/react/src/useFramework.ts` — hook implementation
-- `.github/instructions/monorepo-structure.instructions.md` — import rules
-
-### Notes
-
-- This applies to all source code, tests, and cookbooks
-- The `workspace:^` protocol is used in `package.json` but never in source imports
+- must mention `configureHttpClient` from `@equinor/fusion-framework-module-http`
+- must show `baseUri` and client name as parameters
+- should mention default headers configuration
+- should reference service discovery as an alternative
 ```
 
 ## How to contribute
 
-1. Identify which domain file your pattern belongs to
-2. Add a new `## Pattern:` section following the template above
-3. Choose the correct requirement level (`must` or `should`)
-4. Include at least one code example showing the correct approach
-5. Add file references pointing to real files in the repository
-6. Submit a PR with the pattern addition
-
-### Guidelines
-
-- One pattern per `## Pattern:` section — keep patterns focused and atomic
-- Use real package names, exported symbols, and file paths from the repository
-- Keep code examples minimal but realistic enough to be unambiguous
-- Prefer showing both correct and incorrect approaches when the distinction matters
-- Cross-reference related patterns in other domain files using relative links
+1. Pick the right domain file
+2. Add a `##` heading phrased as a natural question developers would search for
+3. Add `must` and `should` bullets for what the index should return
+4. Use real package names, exported symbols, and API names
+5. Submit a PR
 
 ## Related
-
-- **Parent issue:** [equinor/fusion-core-tasks#599](https://github.com/equinor/fusion-core-tasks/issues/599) — Fusion Framework documentation index freshness
-- **Evaluation automation:** Covered in separate follow-up issues
+- **Evaluation skill:** `.agents/skills/custom-index-eval/` — run `eval core` or `eval all`
 - **Framework instructions:** `.github/instructions/` — source-of-truth rules for code generation

--- a/eval/index/core.md
+++ b/eval/index/core.md
@@ -1,274 +1,49 @@
 # Core
 
-Core framework patterns covering module system architecture, provider initialization, configuration, and the fundamental building blocks that all Fusion Framework applications depend on.
-
-## Pattern: Initialize framework with FrameworkConfigurator and init
-
-**Requirement:** `must`
-
-Portal shells and standalone application hosts must use `FrameworkConfigurator` to collect module configuration and `init` to bootstrap the framework. The `init` function resolves all modules, assigns the result to `window.Fusion`, and dispatches the `onFrameworkLoaded` event. Micro-frontend apps running inside an already-initialized portal should use `@equinor/fusion-framework-react-app` instead.
-
-### Example
-
-```typescript
-import { FrameworkConfigurator, init } from '@equinor/fusion-framework';
-
-const configurator = new FrameworkConfigurator();
-configurator.configureMsal({
-  clientId: '<your-client-id>',
-  authority: 'https://login.microsoftonline.com/<your-tenant-id>',
-});
-configurator.configureServiceDiscovery({
-  client: { baseUri: 'https://service-registry.example.com' },
-});
-
-const fusion = await init(configurator);
-console.log(fusion.modules); // fully initialized module instances
-```
-
-### File references
-
-- `packages/framework/src/FrameworkConfigurator.ts` — configurator class with typed helpers (`configureMsal`, `configureHttp`, `configureHttpClient`, `configureServiceDiscovery`)
-- `packages/framework/src/init.ts` — async `init` function that bootstraps the framework
-- `packages/framework/src/types.ts` — `FusionModules`, `Fusion`, and `FusionModulesInstance` type definitions
-
-### Notes
-
-- `FusionConfigurator` is deprecated — always use `FrameworkConfigurator`
-- `init` sets `window.Fusion` globally so portal shells and widgets can access the running instance
-- The configurator registers the built-in module set: event, MSAL, HTTP, service-discovery, services, context, and telemetry
-
-## Pattern: Define a module with the Module interface
-
-**Requirement:** `must`
-
-Every Fusion Framework module must be a plain object satisfying the `Module<TKey, TType, TConfig, TDeps>` interface from `@equinor/fusion-framework-module`. A module declares a unique `name`, an optional `configure` factory that creates a config builder, and a required `initialize` method that returns the runtime provider instance.
-
-### Example
-
-```typescript
-import {
-  type Module,
-  BaseConfigBuilder,
-  type ConfigBuilderCallback,
-} from '@equinor/fusion-framework-module';
-import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
-
-// 1. Configuration shape
-interface GreeterConfig {
-  greeting: string;
-}
-
-// 2. Config builder with typed setters
-class GreeterConfigurator extends BaseConfigBuilder<GreeterConfig> {
-  setGreeting(cb: ConfigBuilderCallback<string>) {
-    this._set('greeting', cb);
-  }
-}
-
-// 3. Runtime provider
-class GreeterProvider extends BaseModuleProvider<GreeterConfig> {
-  #config: GreeterConfig;
-
-  greet(name: string): string {
-    return `${this.#config.greeting}, ${name}!`;
-  }
-
-  constructor(args: { version: string; config: GreeterConfig }) {
-    super(args);
-    this.#config = args.config;
-  }
-}
-
-// 4. Module definition
-export const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurator> = {
-  name: 'greeter',
-  configure: () => new GreeterConfigurator(),
-  initialize: async ({ config }) => {
-    const resolved = await config.createConfigAsync({
-      config: {},
-      hasModule: () => false,
-      requireInstance: () => Promise.reject('no modules'),
-    });
-    return new GreeterProvider({ version: '1.0.0', config: resolved });
-  },
-};
-```
-
-### File references
-
-- `packages/modules/module/src/types.ts` — `Module`, `AnyModule`, `ModuleInitializerArgs` type definitions
-- `packages/modules/module/src/BaseConfigBuilder.ts` — abstract config builder base class
-- `packages/modules/module/src/lib/provider/BaseModuleProvider.ts` — abstract base class for module providers
-- `packages/modules/module/src/lib/provider/IModuleProvider.ts` — provider interface contract
-
-### Notes
-
-- The `name` field must be unique across all registered modules — it becomes the property key on the resolved `ModulesInstance`
-- Extend `BaseConfigBuilder` for declarative config with dot-path targeting; extend `BaseModuleProvider` for automatic subscription teardown and version tracking
-- `ModuleConfigBuilder` is deprecated — use `BaseConfigBuilder` instead
-
-## Pattern: Module lifecycle phases
-
-**Requirement:** `should`
-
-Module authors should understand and use the full lifecycle managed by `ModulesConfigurator`: configure → postConfigure → initialize → postInitialize → dispose. Each phase enables specific setup and teardown behaviors.
-
-### Example
-
-```typescript
-import type { Module } from '@equinor/fusion-framework-module';
-
-export const myModule: Module<'my', MyProvider, MyConfigurator> = {
-  name: 'my',
-
-  // Phase 1: Create configurator
-  configure: () => new MyConfigurator(),
-
-  // Phase 2: React to completed configuration (all modules configured)
-  postConfigure: (config) => {
-    console.log('All module configs ready:', Object.keys(config));
-  },
-
-  // Phase 3: Create provider instance (can require other module instances)
-  initialize: async ({ config, requireInstance, hasModule }) => {
-    // Use requireInstance to depend on another module
-    if (hasModule('event')) {
-      const event = await requireInstance('event');
-      // use event module during initialization
-    }
-    return new MyProvider(config);
-  },
-
-  // Phase 4: Post-initialization (all modules instantiated)
-  postInitialize: async ({ instance, modules }) => {
-    console.log('Module ready, all modules available:', Object.keys(modules));
-  },
-
-  // Phase 5: Cleanup
-  dispose: ({ instance }) => {
-    instance.teardown();
-  },
-};
-```
-
-### File references
-
-- `packages/modules/module/src/configurator.ts` — `ModulesConfigurator` orchestration logic
-- `packages/modules/module/src/types.ts` — `Module` interface with all lifecycle hooks
-- `packages/modules/module/README.md` — lifecycle phase diagram
-
-### Notes
-
-- `configure` and `initialize` are the two essential hooks; `postConfigure`, `postInitialize`, and `dispose` are optional
-- Use `requireInstance(name, timeout?)` in `initialize` to depend on another module — modules initialize concurrently and `requireInstance` waits for the dependency
-- `postInitialize` receives the full `modules` map, making it the right place for cross-module wiring after all modules are ready
-
-## Pattern: Configure application modules with AppModuleInitiator
-
-**Requirement:** `must`
-
-Micro-frontend applications running inside a Fusion portal must export a configuration callback of type `AppModuleInitiator` from `@equinor/fusion-framework-react-app`. This callback receives the app-level `configurator` and environment object. Use `onConfigured` and `onInitialized` hooks from the configurator to react to lifecycle transitions.
-
-### Example
-
-```typescript
-import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
-
-export const configure: AppModuleInitiator = (configurator, env) => {
-  console.log('configuring application', env);
-
-  // React when all module configurations are built
-  configurator.onConfigured((config) => {
-    console.log('application config created', config);
-  });
-
-  // React when all application modules are initialized
-  configurator.onInitialized((instance) => {
-    console.log('application modules initialized', instance);
-  });
-};
-
-export default configure;
-```
-
-### File references
-
-- `cookbooks/app-react/src/config.ts` — canonical cookbook example of app configuration
-- `packages/app/src/types.ts` — `AppModuleInitiator` type definition (re-exported from `@equinor/fusion-framework-react-app`)
-
-### Notes
-
-- The `env` parameter provides the render environment (manifest, basename, etc.)
-- `onConfigured` fires after all module configs are resolved but before initialization
-- `onInitialized` fires after all module providers are created — use it for post-setup logging or cross-module wiring
-
-## Pattern: Listen to framework events with addEventListener
-
-**Requirement:** `must`
-
-Modules and applications must use `addEventListener` on the event module to listen for framework events. Listeners for `cancelable` events must be registered before the event is dispatched. When dispatching a cancelable event, the `dispatchEvent` call must be `await`ed — firing without `await` means `preventDefault()` calls from listeners will not be respected.
-
-### Example
-
-```typescript
-// Listen to a framework event
-const teardown = modules.event.addEventListener('onModulesLoaded', (event) => {
-  console.log('All modules loaded:', event.detail);
-});
-// Remove the listener when no longer needed
-teardown();
-
-// Dispatch a cancelable event — must await
-const event = await modules.event.dispatchEvent('myEvent', {
-  detail: { id: 42 },
-  cancelable: true,
-});
-if (event.canceled) {
-  // A listener called event.preventDefault()
-  return;
-}
-```
-
-**Requirement:** `should`
-
-Module authors should register custom event types via TypeScript declaration merging on `FrameworkEventMap` for type-safe `addEventListener` and `dispatchEvent` calls.
-
-### Example
-
-```typescript
-import type {
-  FrameworkEvent,
-  FrameworkEventInit,
-} from '@equinor/fusion-framework-module-event';
-
-interface MyPayload {
-  id: string;
-  value: number;
-}
-
-declare module '@equinor/fusion-framework-module-event' {
-  interface FrameworkEventMap {
-    myFeature: FrameworkEvent<FrameworkEventInit<MyPayload>>;
-  }
-}
-
-// Now type-safe
-modules.event.addEventListener('myFeature', (event) => {
-  console.log(event.detail.id); // typed as string
-});
-```
-
-### File references
-
-- `packages/modules/event/src/provider.ts` — `EventModuleProvider` with `addEventListener`, `dispatchEvent`, and `event$`
-- `packages/modules/event/src/event.ts` — `FrameworkEvent` base class
-- `packages/modules/event/src/filter-event.ts` — `filterEvent` RxJS operator for narrowing `event$`
-- `packages/modules/event/README.md` — event lifecycle, cancelable events, and bubbling documentation
-
-### Notes
-
-- `addEventListener` returns a teardown function — call it to unsubscribe
-- The `event$` observable emits events after dispatch and cannot call `preventDefault` or `stopPropagation`; use `addEventListener` for side-effect-capable handling
-- Events bubble to parent providers by default (`canBubble: true`); call `event.stopPropagation()` to prevent it
-- Use `filterEvent` from `@equinor/fusion-framework-module-event` to narrow `event$` to a specific event type
+Ensure results reference `@equinor/fusion-framework` or `@equinor/fusion-framework-module` packages.
+Verify that returned symbols, configuration helpers, and lifecycle hooks are real exports.
+Reject results that use relative cross-package imports instead of scoped `@equinor/` imports.
+
+## How to initialize Fusion Framework
+
+- must mention `FrameworkConfigurator` from `@equinor/fusion-framework`
+- must mention `init` function that bootstraps the framework
+- must show `configureMsal` and `configureServiceDiscovery` as configuration helpers
+- should mention `window.Fusion` assignment and `onFrameworkLoaded` event
+- should note that `FusionConfigurator` is deprecated in favor of `FrameworkConfigurator`
+- should mention apps inside a portal use `@equinor/fusion-framework-react-app` instead
+
+## How to create a custom module
+
+- must reference `Module` interface from `@equinor/fusion-framework-module`
+- must show a module with `name`, `configure`, and `initialize` properties
+- must mention `BaseConfigBuilder` for declarative config builders
+- must mention `BaseModuleProvider` from `@equinor/fusion-framework-module/provider`
+- should show `ConfigBuilderCallback` type for typed setters
+- should note `ModuleConfigBuilder` is deprecated — use `BaseConfigBuilder`
+
+## Module lifecycle phases
+
+- must describe the lifecycle order: configure → postConfigure → initialize → postInitialize → dispose
+- must mention `ModulesConfigurator` as the orchestrator
+- must explain `requireInstance` for cross-module dependencies during initialization
+- should note `configure` and `initialize` are required; other hooks are optional
+- should mention `postInitialize` receives the full `modules` map
+
+## How to configure an app with AppModuleInitiator
+
+- must reference `AppModuleInitiator` type from `@equinor/fusion-framework-react-app`
+- must show the callback receiving `configurator` and `env` parameters
+- must mention `onConfigured` and `onInitialized` hooks
+- should reference `cookbooks/app-react/src/config.ts` as canonical example
+- should note `env` provides render environment (manifest, basename, etc.)
+
+## How to listen to framework events
+
+- must mention `addEventListener` on the event module
+- must mention `dispatchEvent` with `cancelable: true` requires `await`
+- must reference `@equinor/fusion-framework-module-event` package
+- should show `FrameworkEventMap` declaration merging for custom event types
+- should mention `addEventListener` returns a teardown function
+- should mention `event$` observable and `filterEvent` operator
+- should note events bubble to parent providers by default


### PR DESCRIPTION
## Changes

- **Simplified eval/index format**: Replaced verbose `## Pattern:` sections with concise `## <query>` headings + `- must/should` bullet expectations
- **Directive judge preambles**: Rewrote domain-level preambles as imperative judge instructions ("Ensure…", "Verify…", "Reject…")
- **Query-judge sub-agent** (`agents/query-judge.md`): Each query now spins up its own judge sub-agent for isolated evaluation. SKILL.md bumped to v0.2.0
- **Module README lifecycle fix**: Enriched the lifecycle section in `packages/modules/module/README.md` with `requireInstance` usage and `postInitialize` details, co-locating them with the lifecycle diagram so MCP retrieval returns them in a single chunk

### Eval finding addressed

Query "Module lifecycle phases" scored **partial** because `requireInstance` and `postInitialize` details were in separate README chunks from the lifecycle diagram. Fixed by adding inline prose and examples directly after the ASCII table.