### PR TITLE
docs(module): enrich lifecycle section with requireInstance and postInitialize details

### DIFF
--- a/packages/modules/module/README.md
+++ b/packages/modules/module/README.md
@@ -132,6 +132,35 @@ export const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurat
 └──────────┴──────────────────────────┴────────────────┘
 ```
 
+### Cross-module dependencies with requireInstance
+
+Modules initialize concurrently. Use `requireInstance(name, timeout?)` inside `initialize` to wait for a dependency:
+
+```typescript
+initialize: async ({ config, requireInstance, hasModule }) => {
+  // Wait for the event module (with optional timeout in ms)
+  const event = await requireInstance('event', 5000);
+  return new MyProvider(config, event);
+},
+```
+
+`requireInstance` returns a promise that resolves when the requested module finishes initializing. If the module is not registered, the promise rejects.
+
+### postInitialize and the full modules map
+
+`postInitialize` runs after **all** modules are initialized. It receives the full `modules` map, making it the right place for cross-module wiring that depends on every module being ready:
+
+```typescript
+postInitialize: async ({ instance, modules }) => {
+  // All modules are available here
+  modules.event.addEventListener('onContextChanged', (e) => {
+    instance.handleContextChange(e.detail);
+  });
+},
+```
+
+`configure` and `initialize` are the two required hooks. `postConfigure`, `postInitialize`, and `dispose` are optional.
+
 Events are emitted on `configurator.event$` throughout the lifecycle for telemetry and debugging.
 
 ## Related Packages


### PR DESCRIPTION
## Changes

Enriches the `## Module Lifecycle` section in `packages/modules/module/README.md` with:

- **`requireInstance(name, timeout?)`** — how modules wait for dependencies during concurrent initialization
- **`postInitialize` and the full modules map** — explains that `postInitialize` runs after all modules are ready and receives the complete `modules` map for cross-module wiring

### Why

The eval run for query "Module lifecycle phases" scored **partial** because `requireInstance` details and `postInitialize` receiving the full `modules` map were in separate README chunks from the lifecycle diagram. Co-locating this information ensures MCP search returns it as a single retrieval chunk.