### PR TITLE
docs: add context.md eval domain, remove context from state-data.md

### DIFF
--- a/eval/index/context.md
+++ b/eval/index/context.md
@@ -1,0 +1,63 @@
+# Context
+
+Ensure results reference `@equinor/fusion-framework-module-context` or its subpath exports (`/utils`, `/errors.js`).
+Verify that builder methods, provider methods, event names, and hook signatures match real exports.
+Reject results that confuse the Fusion context module with React's built-in `useContext` or other unrelated context APIs.
+
+## How to enable and configure the context module
+
+- must mention `enableContext` from `@equinor/fusion-framework-module-context`
+- must show `ContextConfigBuilder` with `setContextType` for restricting accepted context types
+- must show the builder callback pattern: `enableContext(configurator, (builder) => { ... })`
+- should mention `setContextFilter` for post-query filtering of results
+- should mention `setContextParameterFn` for custom search API parameter mapping
+- should mention `setValidateContext` for custom validation logic
+
+## How to set and read the active context
+
+- must show `currentContext$` observable for subscribing to context changes
+- must mention `setCurrentContextAsync` for setting context by item
+- must mention `clearCurrentContext` for removing the active context
+- should mention `setCurrentContextByIdAsync` for setting context by ID string
+- should mention `queryContextAsync` for searching available context items
+
+## How to configure context resolution and validation
+
+- must mention `setResolveContext` builder method for custom context resolution
+- must explain that resolution triggers when a context item's type is not in the configured types
+- must show `setValidateContext` receiving a function where `this` is the provider
+- should mention `onSetContextResolve` and `onSetContextResolved` events
+- should mention `onSetContextValidationFailed` and `onSetContextResolveFailed` events
+
+## How to resolve initial context from URL
+
+- must mention `resolveInitialContext` from `@equinor/fusion-framework-module-context/utils`
+- must mention `extractContextIdFromPath` for extracting a GUID from the URL path
+- must mention `setResolveInitialContext` builder method for overriding the default resolver
+- should mention `resolveContextFromPath` for creating a resolver function
+- should mention `setContextPathExtractor` and `setContextPathGenerator` for URL ↔ context mapping
+
+## How to sync context between portal and app
+
+- must mention `connectParentContext` builder method
+- must explain bi-directional synchronization between parent portal and child app
+- must mention `onParentContextChanged` event for intercepting parent changes
+- should note `connectParentContext(false)` to opt out of parent sync
+- should mention `setContextClient` for providing a fully custom get/query/related client
+
+## How to use context React hooks
+
+- must mention `useCurrentContext` from `@equinor/fusion-framework-react-app/context`
+- must show the hook returning `{ currentContext, setCurrentContext }`
+- must mention `useModuleCurrentContext` from `@equinor/fusion-framework-react-module-context`
+- should mention `useQueryContext` returning `{ value, querying, query }` with default 500ms debounce
+- should mention `useModuleQueryContext` variant
+- should mention `useFrameworkCurrentContext` for accessing the portal-level context from within an app
+
+## How to handle context events and errors
+
+- must mention `onCurrentContextChange` (cancelable, before) and `onCurrentContextChanged` (after) events
+- must show the event detail containing `previous` and `next` context values
+- must mention `FusionContextSearchError` from `@equinor/fusion-framework-module-context/errors.js`
+- should mention events are dispatched through `@equinor/fusion-framework-module-event`
+- should mention `onSetContextResolve`, `onSetContextResolved`, `onSetContextValidationFailed`, `onSetContextResolveFailed`

--- a/eval/index/state-data.md
+++ b/eval/index/state-data.md
@@ -1,8 +1,8 @@
 # State & Data
 
-Ensure results reference `@equinor/fusion-observable`, `@equinor/fusion-query`, `@equinor/fusion-framework-module-context`, or `@equinor/fusion-framework-module-feature-flag` packages.
+Ensure results reference `@equinor/fusion-observable`, `@equinor/fusion-query`, or `@equinor/fusion-framework-module-feature-flag` packages.
 Verify that returned symbols, operators, and configuration helpers are real exports from these packages.
-Reject results that confuse framework-level context with React component context or mix up query cache vs HTTP cache.
+Reject results that mix up query cache vs HTTP cache or confuse FlowSubject with plain RxJS subjects.
 
 ## How to manage observable state with FlowSubject
 
@@ -12,16 +12,6 @@ Reject results that confuse framework-level context with React component context
 - should mention `createAsyncAction` for actions with request/success/failure lifecycle
 - should mention Immer-powered draft mutations inside reducer cases
 - should show `useObservableState` from `@equinor/fusion-observable/react` for subscribing in React
-
-## How to select and change the active context
-
-- must mention `enableContext` from `@equinor/fusion-framework-module-context`
-- must show `currentContext$` observable for subscribing to context changes
-- must mention `setCurrentContextAsync` for changing the active context
-- must mention `queryContextAsync` for searching available context items
-- should mention `clearCurrentContext` method
-- should mention `resolveInitialContext` utility for resolving context from URL path
-- should mention `connectParentContext` for syncing context between portal and app
 
 ## How to fetch and cache data with Query
 


### PR DESCRIPTION
## Changes

Creates a dedicated `eval/index/context.md` domain file with 7 evaluation queries covering the full context module surface:

1. **Module configuration** — `enableContext`, `ContextConfigBuilder`, `setContextType`, `setContextFilter`, `setContextParameterFn`
2. **Active context management** — `currentContext$`, `setCurrentContextAsync`, `clearCurrentContext`, `setCurrentContextByIdAsync`
3. **Resolution and validation** — `setResolveContext`, `setValidateContext`, resolution events
4. **URL path resolution** — `resolveInitialContext`, `extractContextIdFromPath`, `setContextPathExtractor`/`Generator`
5. **Portal ↔ app sync** — `connectParentContext`, `onParentContextChanged`, `setContextClient`
6. **React hooks** — `useCurrentContext`, `useModuleCurrentContext`, `useQueryContext`, `useFrameworkCurrentContext`
7. **Events and errors** — `onCurrentContextChange`/`Changed`, `FusionContextSearchError`

Also removes the single context query from `state-data.md` (context is too large for a single query in another domain).

Closes equinor/fusion-core-tasks#703