### PR TITLE
docs(context): co-locate URL utils and parent event in configuration section

### DIFF
--- a/packages/modules/context/README.md
+++ b/packages/modules/context/README.md
@@ -93,9 +93,12 @@ enableContext(configurator, (builder) => {
   });
 
   // connect (or disconnect) from parent context
+  // when enabled (default), onParentContextChanged fires before mirroring the parent's context locally
   builder.connectParentContext(false);
 
   // path ↔ context integration
+  // the default resolver uses extractContextIdFromPath to pull a GUID from the URL,
+  // then fetches the matching context item — see resolveInitialContext in utils
   builder.setContextPathExtractor((path) => path.split('/')[2]);
   builder.setContextPathGenerator((ctx, path) =>
     path.replace(/\/context\/[^/]+/, `/context/${ctx.id}`),
@@ -118,10 +121,10 @@ enableContext(configurator, (builder) => {
 | `setContextParameterFn(fn)` | Maps search + type to API query params |
 | `setValidateContext(fn)` | Custom validation (`this` = provider) |
 | `setResolveContext(fn)` | Custom resolution (`this` = provider) |
-| `connectParentContext(bool)` | Enable/disable parent context sync |
+| `connectParentContext(bool)` | Enable/disable parent context sync (fires `onParentContextChanged` on change) |
 | `setContextPathExtractor(fn)` | Extract context ID from URL path |
 | `setContextPathGenerator(fn)` | Generate URL path from context item |
-| `setResolveInitialContext(fn)` | Override initial context resolution |
+| `setResolveInitialContext(fn)` | Override initial context resolution (default uses `extractContextIdFromPath` → `resolveContextFromPath`) |
 | `setContextClient(client)` | Custom get/query/related clients |
 
 ## Events


### PR DESCRIPTION
## Changes

Enriches the context module README Configuration section to co-locate related information for better MCP search recall:

- **`connectParentContext`** — added inline note that `onParentContextChanged` fires before mirroring parent context locally
- **Path integration** — added comment referencing `extractContextIdFromPath` and `resolveInitialContext` from utils
- **Config reference table** — expanded `connectParentContext` description to mention `onParentContextChanged` event; expanded `setResolveInitialContext` to mention `extractContextIdFromPath` → `resolveContextFromPath` default chain

### Eval findings addressed

- Q4 "resolve initial context from URL" scored **partial** — `extractContextIdFromPath` and `resolveContextFromPath` were only in the Utilities chunk, not in the Configuration chunk
- Q5 "sync context between portal and app" scored **partial** — `onParentContextChanged` was only in the Events chunk, not near `connectParentContext`