### PR TITLE
docs(dev-server): co-locate retrieval targets for eval gaps

### DIFF
--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -46,6 +46,8 @@ await devServer.listen();
 devServer.printUrls();
 ```
 
+If you only need the Vite configuration object without starting the server, use `createDevServerConfig(options, overrides?)` instead. This returns a `UserConfig` that you can pass to Vite directly or merge with other configurations.
+
 ## Configuration
 
 The dev server accepts a configuration object with the following structure:
@@ -66,7 +68,10 @@ Configure the Single Page Application environment and template generation:
       // Application title
       title: 'My Application',
 
-      // Service discovery settings
+      // Service discovery settings (SPA-side — tells the browser where to find services)
+      // The API-side counterpart is `api.serviceDiscoveryUrl` which sets up server-side proxying.
+      // During development you can redirect individual services to local URLs by storing
+      // overrides in sessionStorage under the key "overriddenServiceDiscoveryUrls".
       serviceDiscovery: {
         url: 'https://service-discovery.example.com',
         scopes: ['scope1', 'scope2'],
@@ -111,6 +116,8 @@ Configure API proxying and service discovery:
     serviceDiscoveryUrl: 'https://service-discovery.example.com',
 
     // Optional: Custom service processing
+    // Takes an array of FusionService objects ({ key, uri, name }) from discovery
+    // and returns { data: FusionService[], routes: ApiRoute[] } with proxy routes.
     processServices: (services, route) => {
       // Process and return services with routes
       return processServices(services, route);


### PR DESCRIPTION
## Summary

Fixes 3 should-level eval gaps found in the dev-server domain eval pass:

1. **Q1 gap** — `createDevServerConfig` not surfaced: Added mention near Quick Start so both server entry points (`createDevServer` and `createDevServerConfig`) appear in the same retrieval chunk.

2. **Q3 gap** — `FusionService` type not retrieved for proxying query: Added inline reference to `FusionService` (`{ key, uri, name }`) in the API config `processServices` comment so it co-locates with proxying documentation.

3. **Q4 gap** — `sessionStorage` overrides not cross-referenced with dev-server: Added tip about `overriddenServiceDiscoveryUrls` in the SPA service discovery config comment, linking the runtime override mechanism to the dev-server context.