### PR TITLE
docs(msal-node): co-locate error classes in troubleshooting section

### DIFF
--- a/packages/modules/msal-node/README.md
+++ b/packages/modules/msal-node/README.md
@@ -186,13 +186,35 @@ interface IAuthProvider {
 
 ### Common Issues
 
-| Issue | Solution |
-|-------|----------|
-| **Invalid client/tenant ID** | Verify your Azure AD app registration settings |
-| **Port already in use** | Change the `serverPort` or kill the process using the port |
-| **Silent auth fails** | Ensure you've logged in interactively first to cache credentials |
-| **Token expired** | The module handles refresh automatically; check your scopes |
-| **Credential storage errors** | See our [credential storage guide](docs/libsecret.md) |
+| Issue | Error Class | Solution |
+|-------|------------|----------|
+| **No cached session** | `NoAccountsError` | Run interactive login first to cache credentials, then retry with silent mode |
+| **Silent auth fails** | `SilentTokenAcquisitionError` | Cached session may have expired or network is unavailable; fall back to interactive login |
+| **Callback server fails** | `AuthServerError` | Check that the callback server port is not in use and the browser can reach it |
+| **Callback server timeout** | `AuthServerTimeoutError` | The browser did not complete login within the timeout (default 5 min); retry or check network |
+| **Invalid client/tenant ID** | — | Verify your Azure AD app registration settings |
+| **Port already in use** | — | Change the `serverPort` or kill the process using the port |
+| **Token expired** | — | The module handles refresh automatically; check your scopes |
+| **Credential storage errors** | — | See our [credential storage guide](docs/libsecret.md) |
+
+All error classes are exported from `@equinor/fusion-framework-module-msal-node/error`. A common pattern is to attempt silent token acquisition first and fall back to interactive login on failure:
+
+```typescript
+import { NoAccountsError, SilentTokenAcquisitionError } from '@equinor/fusion-framework-module-msal-node/error';
+
+try {
+  const token = await modules.auth.acquireAccessToken({
+    request: { scopes: ['api://my-api/.default'] },
+  });
+} catch (error) {
+  if (error instanceof NoAccountsError || error instanceof SilentTokenAcquisitionError) {
+    // Fall back to interactive login
+    await modules.auth.login({ request: { scopes: ['api://my-api/.default'] } });
+  } else {
+    throw error;
+  }
+}
+```
 
 ### Getting Help
 


### PR DESCRIPTION
## Summary

Fixes Q4 eval failure ("How to handle authentication errors" — 1/3 must met) by co-locating error classes and usage patterns in the Troubleshooting section.

### Problem

The msal-node README has an Error Handling section with `NoAccountsError` and try/catch examples, but it lives in a separate retrieval chunk from the Troubleshooting section. When MCP search returns results for "How to handle authentication errors", the Troubleshooting table dominates but lacks error class references.

### Fix

- Enriched the Troubleshooting table with error class names (`NoAccountsError`, `SilentTokenAcquisitionError`, `AuthServerError`, `AuthServerTimeoutError`)
- Added inline try/catch fallback pattern showing silent-to-interactive recovery
- Referenced `@equinor/fusion-framework-module-msal-node/error` import path

This co-locates error handling patterns with troubleshooting content so both appear in the same retrieval chunk.