### PR TITLE
docs(eval): split CLI into own domain file

### DIFF
--- a/eval/index/README.md
+++ b/eval/index/README.md
@@ -19,8 +19,9 @@ eval/
     dev-server.md        # Development server, mocking, proxying
     auth.md              # Authentication and authorization
     react-app.md         # React app bootstrap, hooks, sub-path APIs
-    features.md          # Feature flags, bookmarks, app features
-    utilities.md         # CLI, observable state, events, Vite plugin
+    features.md          # Bookmarks, navigation, app loading, observability
+    cli.md               # CLI commands, auth, deployment, portal templates
+    utilities.md         # Observable state, event bus, Vite plugin
 ```
 
 ## Format

--- a/eval/index/cli.md
+++ b/eval/index/cli.md
@@ -1,0 +1,52 @@
+# CLI
+
+These queries cover the `@equinor/fusion-framework-cli` (`ffc`) tool that
+developers use to create, develop, build, deploy, and authenticate Fusion
+applications and portal templates.
+
+When judging results, verify that:
+- Commands use the correct binary name (`fusion-framework-cli` or `ffc`) and
+  follow the `ffc <category> <command>` pattern (e.g., `ffc app dev`,
+  `ffc auth login`). Reject results that invent commands or confuse the
+  Fusion CLI with generic Vite/npm scripts.
+- Configuration files reference the correct names (`app.manifest.ts`,
+  `app.config.ts`, `dev-server.config.ts`) and show the matching
+  `define*` helper from the right sub-path import.
+- Authentication results distinguish **interactive login** (browser prompt)
+  from **CI/CD token mode** (`FUSION_TOKEN` env var). A result that only
+  shows one without acknowledging the other is incomplete.
+- Deployment results show the correct command sequence — build/pack first,
+  then upload/publish with environment and tag options. Reject results that
+  skip the build step or confuse `publish` with `upload`.
+
+## How to develop and build a Fusion application locally
+
+- must mention `ffc app dev` for starting a local dev server with hot reload
+- must mention `ffc app build` for creating a production bundle
+- must mention `app.manifest.ts` and `app.config.ts` as the two configuration files
+- should mention `defineAppManifest` and `defineAppConfig` from `@equinor/fusion-framework-cli/app`
+- should mention that the `main` or `module` field in `package.json` determines the build output path
+
+## How to authenticate the Fusion CLI for deployment
+
+- must mention `ffc auth login` for interactive browser-based authentication
+- must mention `FUSION_TOKEN` environment variable for CI/CD token-based authentication
+- must mention `ffc auth token` for retrieving a token after login
+- should mention `FUSION_TENANT_ID` and `FUSION_CLIENT_ID` as optional Azure AD overrides
+- should mention the `--token` flag available on all commands as an inline alternative
+
+## How to publish and tag a Fusion application
+
+- must mention `ffc app publish` for building, uploading, and tagging in one step
+- must mention `ffc app pack` for creating a distributable bundle archive
+- must mention `ffc app tag` for tagging an existing published version
+- should mention `--env` flag for environment-specific config and `--tag` for version tagging
+- should mention `ffc app config --publish` for publishing config separately from the bundle
+
+## How to develop and publish a Fusion portal template
+
+- must mention `ffc portal dev` for local portal development
+- must mention `ffc portal build` and `ffc portal publish` for building and deploying portal templates
+- must mention `portal.manifest.ts` as the required portal manifest file
+- should mention `definePortalManifest` from `@equinor/fusion-framework-cli/portal`
+- should mention `portal.schema.ts` for defining the portal configuration schema

--- a/eval/index/utilities.md
+++ b/eval/index/utilities.md
@@ -1,14 +1,10 @@
 # Utilities & Tooling
 
-These queries cover the shared infrastructure that Fusion developers interact
-with outside of application code: the CLI workflow, the Vite build plugin,
-the observable state primitives, and the cross-module event system.
+These queries cover shared infrastructure primitives that Fusion modules and
+apps build on: the observable state system, the cross-module event bus, and
+the Vite build plugin for local development.
 
 When judging results, verify that:
-- CLI results describe **real commands** (`ffc app dev`, `ffc app build`, etc.)
-  and reference the correct binary name (`fusion-framework-cli` / `ffc`). Reject
-  results that invent sub-commands or confuse the Fusion CLI with generic Vite
-  or Node tooling.
 - Observable results distinguish the **`@equinor/fusion-observable`** utility
   package from RxJS itself. The package wraps RxJS with action-driven state
   (`FlowSubject`, `createReducer`, `createAction`) — results that only mention
@@ -22,14 +18,6 @@ When judging results, verify that:
   explain both the plugin factory (`fusionSpaPlugin`) and the template
   environment shape. Reject results that confuse build-time config with runtime
   framework init.
-
-## How to build and develop Fusion apps with the CLI
-
-- must mention `fusion-framework-cli` or `ffc` as the CLI binary name
-- must mention `app dev` for starting a local dev server and `app build` for production bundles
-- must mention `app.manifest.ts` as the application manifest configuration file
-- should mention `defineAppManifest` and `defineAppConfig` from `@equinor/fusion-framework-cli/app`
-- should mention `auth login` for authenticating against Azure AD before deployment
 
 ## How to manage observable state with FlowSubject and actions
 


### PR DESCRIPTION
Split the CLI query out of `utilities.md` into a dedicated `cli.md` domain file.

The CLI is its own developer workflow — mixing it with observable state and
event bus primitives made no sense.

**cli.md** — 4 queries:
1. **Local dev/build** — `ffc app dev`, `ffc app build`, `app.manifest.ts`, `defineAppManifest`
2. **Authentication** — `ffc auth login`, `FUSION_TOKEN`, `ffc auth token`, tenant/client overrides
3. **Publishing** — `ffc app publish`, `ffc app pack`, `ffc app tag`, env/tag flags
4. **Portal templates** — `ffc portal dev/build/publish`, `portal.manifest.ts`, `definePortalManifest`

**utilities.md** — trimmed to 3 queries (observable state, event bus, Vite plugin)

Updated README directory listing.