### PR TITLE
docs(cli): add ffc short alias examples to CLI documentation

### DIFF
--- a/eval/index/cli.md
+++ b/eval/index/cli.md
@@ -21,32 +21,32 @@ When judging results, verify that:
 
 ## How to develop and build a Fusion application locally
 
-- must mention `ffc app dev` for starting a local dev server with hot reload
-- must mention `ffc app build` for creating a production bundle
+- must mention `ffc app dev` or `fusion-framework-cli dev` for starting a local dev server with hot reload
+- must mention `ffc app build` or `fusion-framework-cli build` for creating a production bundle
 - must mention `app.manifest.ts` and `app.config.ts` as the two configuration files
 - should mention `defineAppManifest` and `defineAppConfig` from `@equinor/fusion-framework-cli/app`
 - should mention that the `main` or `module` field in `package.json` determines the build output path
 
 ## How to authenticate the Fusion CLI for deployment
 
-- must mention `ffc auth login` for interactive browser-based authentication
+- must mention `ffc auth login` or `fusion-framework-cli auth login` for interactive browser-based authentication
 - must mention `FUSION_TOKEN` environment variable for CI/CD token-based authentication
-- must mention `ffc auth token` for retrieving a token after login
+- must mention `ffc auth token` or `fusion-framework-cli auth token` for retrieving a token after login
 - should mention `FUSION_TENANT_ID` and `FUSION_CLIENT_ID` as optional Azure AD overrides
 - should mention the `--token` flag available on all commands as an inline alternative
 
 ## How to publish and tag a Fusion application
 
-- must mention `ffc app publish` for building, uploading, and tagging in one step
-- must mention `ffc app pack` for creating a distributable bundle archive
-- must mention `ffc app tag` for tagging an existing published version
+- must mention `ffc app publish` or `fusion-framework-cli publish` for building, uploading, and tagging in one step
+- must mention `ffc app pack` or `fusion-framework-cli pack` for creating a distributable bundle archive
+- must mention `ffc app tag` or `fusion-framework-cli app tag` for tagging an existing published version
 - should mention `--env` flag for environment-specific config and `--tag` for version tagging
-- should mention `ffc app config --publish` for publishing config separately from the bundle
+- should mention `ffc app config --publish` or `fusion-framework-cli app config --publish` for publishing config separately from the bundle
 
 ## How to develop and publish a Fusion portal template
 
-- must mention `ffc portal dev` for local portal development
-- must mention `ffc portal build` and `ffc portal publish` for building and deploying portal templates
+- must mention `ffc portal dev` or `fusion-framework-cli portal dev` for local portal development
+- must mention `ffc portal build` or `fusion-framework-cli portal build` and `ffc portal publish` or `fusion-framework-cli portal publish` for building and deploying portal templates
 - must mention `portal.manifest.ts` as the required portal manifest file
 - should mention `definePortalManifest` from `@equinor/fusion-framework-cli/portal`
 - should mention `portal.schema.ts` for defining the portal configuration schema

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -2,6 +2,9 @@ The Fusion Framework CLI empowers you to rapidly build, configure, and deploy mo
 
 This guide will help you get set up, understand the most important commands, and follow best practices for configuration and CI/CD. Let’s get started building robust, scalable apps with Fusion Framework!
 
+> [!TIP]
+> The CLI exposes two binary aliases: `fusion-framework-cli` and `ffc`. All examples below use the long form, but you can substitute `ffc` anywhere — e.g. `ffc app dev`, `ffc app build`, `ffc app publish`.
+
 ## Getting Started
 
 ### Install the CLI
@@ -83,6 +86,8 @@ export default defineAppConfig((env, args) => ({
 
 ```sh
 pnpm fusion-framework-cli dev
+# or using the short alias
+ffc app dev
 ```
 
 ### Log in to Fusion Framework (if needed)
@@ -105,6 +110,8 @@ pnpm fusion-framework-cli auth login
 ```sh
 # Publish and upload config in one command
 pnpm fusion-framework-cli publish --env <environment> --config
+# or using the short alias
+ffc app publish --env <environment> --config
 
 # Or separately
 pnpm fusion-framework-cli publish --env <environment>
@@ -405,11 +412,13 @@ Start your application in development mode with hot reloading and environment-sp
 **Usage:**
 ```sh
 pnpm fusion-framework-cli dev [options]
+# or: ffc app dev [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli dev
+ffc app dev
 pnpm fusion-framework-cli dev --port 4000
 pnpm fusion-framework-cli dev --manifest ./app.manifest.local.ts --config ./app.config.ts
 ```
@@ -472,11 +481,13 @@ This command uploads and tags your app for deployment. If no bundle is provided,
 **Usage:**
 ```sh
 pnpm fusion-framework-cli publish [bundle] [options]
+# or: ffc app publish [bundle] [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli publish
+ffc app publish
 pnpm fusion-framework-cli publish --env prod --manifest app.manifest.prod.ts
 pnpm fusion-framework-cli publish --tag latest app-bundle.zip
 pnpm fusion-framework-cli publish --config --env prod
@@ -518,6 +529,7 @@ The `config` command allows you to generate your app's configuration and either 
 **Usage:**
 ```sh
 pnpm fusion-framework-cli app config [config] [options]
+# or: ffc app config [config] [options]
 ```
 
 **Examples:**
@@ -552,11 +564,13 @@ Build your application and generate the necessary artifacts for deployment:
 **Usage:**
 ```sh
 pnpm fusion-framework-cli build [manifest] [options]
+# or: ffc app build [manifest] [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli build
+ffc app build
 pnpm fusion-framework-cli build app.manifest.dev.ts --debug
 ```
 
@@ -582,11 +596,13 @@ Build a distributable app bundle archive for deployment.
 **Usage:**
 ```sh
 pnpm fusion-framework-cli pack [manifest] [options]
+# or: ffc app pack [manifest] [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli pack
+ffc app pack
 pnpm fusion-framework-cli pack app.manifest.dev.ts --archive my-app.zip --output ./dist
 ```
 
@@ -649,11 +665,13 @@ The `tag` command applies a tag (such as `latest`, `preview`, `dev`, `staging`, 
 **Usage:**
 ```sh
 pnpm fusion-framework-cli app tag <tag> [options]
+# or: ffc app tag <tag> [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli app tag latest
+ffc app tag latest
 pnpm fusion-framework-cli app tag preview --env prod --manifest app.manifest.prod.ts
 pnpm fusion-framework-cli app tag latest --package my-app@1.2.3
 ```

--- a/packages/cli/docs/auth.md
+++ b/packages/cli/docs/auth.md
@@ -2,6 +2,9 @@ The Fusion Framework CLI provides secure, robust authentication for both automat
 
 For detailed information about the underlying authentication module, see the [MSAL Node Module documentation](https://equinor.github.io/fusion-framework/modules/auth/msal-node/).
 
+> [!TIP]
+> The CLI exposes two binary aliases: `fusion-framework-cli` and `ffc`. All examples below use the long form, but you can substitute `ffc` anywhere — e.g. `ffc auth login`, `ffc auth token`.
+
 ## Key features
 - **Multiple authentication modes:**
   - `token_only`: Use a pre-provided token (e.g., for CI/CD and automation).
@@ -42,6 +45,8 @@ To log in, run:
 
 ```sh
 fusion-framework-cli auth login
+# or using the short alias
+ffc auth login
 ```
 
 - This will open a browser window for you to complete the Azure AD sign-in process.
@@ -52,6 +57,7 @@ If you ever need to clear your cached credentials, you can run:
 
 ```sh
 fusion-framework-cli auth logout
+# or: ffc auth logout
 ```
 
 This will remove your stored tokens and require you to log in again for future CLI operations.
@@ -78,12 +84,15 @@ The `auth token` command is designed to show your access token for the current u
 
 ```sh
 fusion-framework-cli auth token
+# or using the short alias
+ffc auth token
 ```
 
 > [!TIP]
 > The `--silent` flag outputs only the token (no extra logging), which is useful for exporting the token as an environment variable or saving it to a file for local testing or scripting:
 > ```sh
 > export FUSION_TOKEN=$(fusion-framework-cli auth token --silent)
+> # or: export FUSION_TOKEN=$(ffc auth token --silent)
 > ```
 
 > [!Note] This command requires an interactive user context and MSAL Node. It is not suitable for CI/CD environments, as there is no user available in those scenarios. Use it for local development, testing, or whenever you need to preserve a Fusion token for your own scripts or tools.

--- a/packages/cli/docs/portal.md
+++ b/packages/cli/docs/portal.md
@@ -8,6 +8,9 @@ The Fusion Framework CLI enables you to build, configure, and deploy **portal te
 
 This guide covers the essential commands and best practices for developing and managing portal templates. For information on registering and configuring portals, see the Portal Admin documentation.
 
+> [!TIP]
+> The CLI exposes two binary aliases: `fusion-framework-cli` and `ffc`. All examples below use the long form, but you can substitute `ffc` anywhere — e.g. `ffc portal dev`, `ffc portal build`, `ffc portal publish`.
+
 ## Getting Started
 
 ### Install the CLI
@@ -37,6 +40,16 @@ pnpm init
 ## Portal Manifest
 
 The portal manifest (`portal.manifest.ts`) describes your portal's metadata, configuration, and capabilities. It is required for all portal templates. You may also define a schema file for advanced configuration validation.
+
+```ts
+import { definePortalManifest } from '@equinor/fusion-framework-cli/portal';
+
+export default definePortalManifest((env, { base }) => ({
+  ...base,
+  name: 'my-portal',
+  // Add more manifest fields as needed
+}));
+```
 
 ---
 
@@ -71,11 +84,13 @@ Start the portal development server for local development and testing.
 **Usage:**
 ```sh
 pnpm fusion-framework-cli portal dev [options]
+# or: ffc portal dev [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli portal dev
+ffc portal dev
 pnpm fusion-framework-cli portal dev --port 4001 --manifest ./portal.manifest.ts
 ```
 
@@ -93,11 +108,13 @@ Build your portal template using Vite.
 **Usage:**
 ```sh
 pnpm fusion-framework-cli portal build [options]
+# or: ffc portal build [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli portal build
+ffc portal build
 pnpm fusion-framework-cli portal build --manifest ./portal.manifest.ts --env ci
 ```
 
@@ -116,6 +133,7 @@ Bundle your portal into a distributable archive for deployment.
 **Usage:**
 ```sh
 pnpm fusion-framework-cli portal pack [options]
+# or: ffc portal pack [options]
 ```
 
 **Examples:**
@@ -146,11 +164,13 @@ This command builds your portal template, uploads it to the Fusion portal regist
 **Usage:**
 ```sh
 pnpm fusion-framework-cli portal publish [options]
+# or: ffc portal publish [options]
 ```
 
 **Examples:**
 ```sh
 pnpm fusion-framework-cli portal publish
+ffc portal publish
 pnpm fusion-framework-cli portal publish --env prod --manifest portal.manifest.prod.ts
 pnpm fusion-framework-cli portal publish --tag preview --schema portal.schema.ts
 ```


### PR DESCRIPTION
## Summary

Add `ffc` short alias examples alongside `fusion-framework-cli` long form in CLI documentation so indexed chunks surface both binary names for MCP search queries.

## Changes

- **application.md**: Added tip box about `ffc` alias, added `ffc` examples for `dev`, `build`, `publish`, `pack`, `tag`, `config` commands
- **auth.md**: Added tip box about `ffc` alias, added `ffc` examples for `auth login`, `auth logout`, `auth token`
- **portal.md**: Added tip box about `ffc` alias, added `ffc` examples for `portal dev`, `portal build`, `portal pack`, `portal publish`. Added `definePortalManifest` code example
- **eval/index/cli.md**: Updated must-have expectations to accept both `ffc` and `fusion-framework-cli` forms

## Motivation

The CLI docs used `fusion-framework-cli` (68 occurrences in application.md vs 1 for `ffc`). Search queries using the `ffc` short name failed to find relevant results because the indexed chunks didn't contain the short alias.