### PR TITLE
fix(docs): register pnpm security patch for min-document

### DIFF
--- a/.changeset/docs_storybook-min-document-patch.md
+++ b/.changeset/docs_storybook-min-document-patch.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+fix: register pnpm security patch for min-document prototype pollution vulnerability
+
+Properly register the min-document security patch with pnpm to ensure the prototype pollution vulnerability fix is applied during installation. This ensures Storybook and other dependencies using min-document are protected against prototype chain manipulation attacks.
+
+- Register `min-document@2.19.2.patch` in `pnpm.patchedDependencies`
+- Update SECURITY.md to document the active patch registration
+- Patch applies automatically during `pnpm install`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,12 +23,13 @@ We prefer all communications to be in English.
 
 **Impact**: Low - This vulnerability only affects development environments since `min-document` is used by Storybook (via EDS Core React dev dependencies). Production builds are not affected.
 
-**Status**: Mitigated locally with a security patch.
+**Status**: Mitigated with a registered pnpm security patch.
 
-**Mitigation Applied**: A local patch has been applied to `min-document@2.19.0` that prevents access to dangerous prototype properties. The patch adds validation to reject operations on `__proto__`, `constructor`, and `prototype` namespace values.
+**Mitigation Applied**: A local security patch has been registered with pnpm for `min-document@2.19.2` that prevents access to dangerous prototype properties. The patch adds a validation function `isSafeProperty()` that rejects operations on `__proto__`, `constructor`, and `prototype` namespace values in the `setAttributeNS`, `getAttributeNS`, `removeAttributeNS`, and `hasAttributeNS` methods.
 
 **Files**:
-- `patches/min-document@2.19.0.patch` - The security patch
-- Applied to `node_modules/.pnpm/min-document@2.19.0/node_modules/min-document/dom-element.js`
+- `patches/min-document@2.19.2.patch` - The active security patch
+- Registered in `package.json` under `pnpm.patchedDependencies`
+- Applied automatically during `pnpm install`
 
 **Recommendation**: Monitor for updates to `min-document` or consider replacing it with a maintained alternative if the dependency chain allows.

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
       "axios@>=1.0.0 <=1.13.4": "1.13.6",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
       "minimatch@<3.1.3": "3.1.5"
+    },
+    "patchedDependencies": {
+      "min-document@2.19.2": "patches/min-document@2.19.2.patch"
     }
   },
   "dependencies": {

--- a/patches/min-document@2.19.2.patch
+++ b/patches/min-document@2.19.2.patch
@@ -1,0 +1,55 @@
+diff --git a/dom-element.js b/dom-element.js
+index 48783264a104365648a79a9fc38fbba3bd5950ad..550007897efedf2a75d37f243066383cf62a931b 100644
+--- a/dom-element.js
++++ b/dom-element.js
+@@ -6,6 +6,11 @@ var serializeNode = require("./serialize.js")
+ 
+ var htmlns = "http://www.w3.org/1999/xhtml"
+ 
++// Security fix: Prevent prototype pollution
++function isSafeProperty(prop) {
++    return prop !== '__proto__' && prop !== 'constructor' && prop !== 'prototype';
++}
++
+ module.exports = DOMElement
+ 
+ function DOMElement(tagName, owner, namespace) {
+@@ -97,6 +102,7 @@ DOMElement.prototype.insertBefore =
+ 
+ DOMElement.prototype.setAttributeNS =
+     function _Element_setAttributeNS(namespace, name, value) {
++        if (!isSafeProperty(namespace)) return; // Security fix
+         var prefix = null
+         var localName = name
+         var colonPosition = name.indexOf(":")
+@@ -115,6 +121,7 @@ DOMElement.prototype.setAttributeNS =
+ 
+ DOMElement.prototype.getAttributeNS =
+     function _Element_getAttributeNS(namespace, name) {
++        if (!isSafeProperty(namespace)) return null; // Security fix
+         var attributes = this._attributes[namespace];
+         var value = attributes && attributes[name] && attributes[name].value
+         if (this.tagName === 'INPUT' && name === 'type') {
+@@ -128,18 +135,16 @@ DOMElement.prototype.getAttributeNS =
+ 
+ DOMElement.prototype.removeAttributeNS =
+     function _Element_removeAttributeNS(namespace, name) {
+-        // Prevent prototype pollution by checking if namespace is a direct property
+-        if (!Object.prototype.hasOwnProperty.call(this._attributes, namespace)) {
+-            return;
+-        }
++        if (!isSafeProperty(namespace)) return; // Security fix
+         var attributes = this._attributes[namespace];
+-        if (attributes && Object.prototype.hasOwnProperty.call(attributes, name)) {
+-            delete attributes[name];
++        if (attributes) {
++            delete attributes[name]
+         }
+     }
+ 
+ DOMElement.prototype.hasAttributeNS =
+     function _Element_hasAttributeNS(namespace, name) {
++        if (!isSafeProperty(namespace)) return false; // Security fix
+         var attributes = this._attributes[namespace]
+         return !!attributes && name in attributes;
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,11 @@ overrides:
   minimatch@>=9.0.0 <9.0.7: 9.0.7
   minimatch@<3.1.3: 3.1.5
 
+patchedDependencies:
+  min-document@2.19.2:
+    hash: 2d552c3e457f83ee369adad1f28e44ce46d10d38127681328091787e4a2ed1b0
+    path: patches/min-document@2.19.2.patch
+
 importers:
 
   .:
@@ -17009,7 +17014,7 @@ snapshots:
 
   global@4.4.0:
     dependencies:
-      min-document: 2.19.2
+      min-document: 2.19.2(patch_hash=2d552c3e457f83ee369adad1f28e44ce46d10d38127681328091787e4a2ed1b0)
       process: 0.11.10
 
   globby@11.1.0:
@@ -17903,7 +17908,7 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  min-document@2.19.2:
+  min-document@2.19.2(patch_hash=2d552c3e457f83ee369adad1f28e44ce46d10d38127681328091787e4a2ed1b0):
     dependencies:
       dom-walk: 0.1.2
 


### PR DESCRIPTION
## Storybook Security Fix: min-document Prototype Pollution Vulnerability

Registers a local security patch for `min-document@2.19.2` to mitigate a prototype pollution vulnerability in development dependencies (Storybook via EDS Core React).

### Changes

- **patches/min-document@2.19.2.patch**: Adds a security validation function to prevent namespace-based prototype chain manipulation in `setAttributeNS`, `getAttributeNS`, `removeAttributeNS`, and `hasAttributeNS` methods
- **package.json**: Registers the patch in `pnpm.patchedDependencies` for automatic application during installation
- **SECURITY.md**: Documents the vulnerability, mitigation strategy, and patch registration details

### Impact

- **Development Only**: Affects only development environments (Storybook and dev dependencies)
- **Production Unaffected**: Production builds do not use min-document
- **Automatic Protection**: Patch is applied automatically during `pnpm install`

### Vulnerability Details

The min-document package contained a prototype pollution vulnerability allowing attackers to manipulate JavaScript object prototype chains by passing `__proto__` or `constructor` as namespace parameters. This patch prevents access to dangerous prototype properties.
