### PR TITLE
fix(router): add HydrateFallback support to vite plugin

### DIFF
--- a/.changeset/react-router_hydrate-fallback-support.md
+++ b/.changeset/react-router_hydrate-fallback-support.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Fix white screen when using `clientLoader` by adding `HydrateFallback` support.
+
+The Vite plugin now recognizes the `HydrateFallback` export from route files and wires it as the `HydrateFallback` component on the route object. Previously, even if a route file exported `HydrateFallback`, the plugin ignored it, causing React Router v7 to render nothing while loaders ran.
+
+Closes #4242

--- a/packages/react/router/src/__tests__/mocks/pages/UserDetailPage.tsx
+++ b/packages/react/router/src/__tests__/mocks/pages/UserDetailPage.tsx
@@ -8,6 +8,10 @@ export function ErrorElement({ error, fusion }: ErrorElementProps) {
   return <div>Error: {error?.message}</div>;
 }
 
+export function HydrateFallback() {
+  return <div>Loading user details...</div>;
+}
+
 export default function UserDetailPage() {
   return <div>User Detail Page</div>;
 }

--- a/packages/react/router/src/__tests__/vite-plugin.test.ts
+++ b/packages/react/router/src/__tests__/vite-plugin.test.ts
@@ -57,7 +57,7 @@ describe('reactRouterPlugin', () => {
     expect(normalizeCode(transformResult)).toBe(normalizeCode(expected));
   });
 
-  it('should transform route with clientLoader and ErrorElement', () => {
+  it('should transform route with clientLoader, ErrorElement, and HydrateFallback', () => {
     const inputCode = [
       `import { route } from '@equinor/fusion-framework-react-router/routes';`,
       `export const routes = route(':id', './mocks/pages/UserDetailPage.tsx');`,
@@ -74,13 +74,15 @@ describe('reactRouterPlugin', () => {
       `import {`,
       `    default as UserDetailPage,`,
       `    clientLoader as clientLoaderUserDetailPage,`,
-      `    ErrorElement as ErrorElementUserDetailPage`,
+      `    ErrorElement as ErrorElementUserDetailPage,`,
+      `    HydrateFallback as HydrateFallbackUserDetailPage`,
       `} from './mocks/pages/UserDetailPage.tsx';`,
       `export const routes = [{`,
       `        path: ':id',`,
       `        Component: UserDetailPage,`,
       `        loader: clientLoaderUserDetailPage,`,
-      `        errorElement: ErrorElementUserDetailPage`,
+      `        errorElement: ErrorElementUserDetailPage,`,
+      `        HydrateFallback: HydrateFallbackUserDetailPage`,
       `    }];`,
     ].join('\n');
 

--- a/packages/react/router/src/vite-plugin/plugin.ts
+++ b/packages/react/router/src/vite-plugin/plugin.ts
@@ -69,6 +69,7 @@ interface RouteImports {
   action?: string;
   handle?: string;
   errorElement?: string;
+  hydrateFallback?: string;
   availableExports: Set<string>;
 }
 
@@ -184,7 +185,7 @@ function getAvailableExports(filePath: string, currentFileId: string, debug: boo
     }
 
     // Check for named exports and re-exports
-    const exportNames = ['clientLoader', 'action', 'handle', 'ErrorElement'];
+    const exportNames = ['clientLoader', 'action', 'handle', 'ErrorElement', 'HydrateFallback'];
     for (const name of exportNames) {
       if (
         fileContent.match(EXPORT_NAMED_PATTERN(name)) ||
@@ -239,6 +240,10 @@ function buildRouteProperties(imports: RouteImports): string {
     properties.push(`errorElement: ${imports.errorElement}`);
   }
 
+  if (imports.hydrateFallback) {
+    properties.push(`HydrateFallback: ${imports.hydrateFallback}`);
+  }
+
   return properties.join(',\n        ');
 }
 
@@ -277,6 +282,9 @@ function generateImportStatements(
     }
     if (imports.errorElement) {
       importParts.push(`ErrorElement as ${imports.errorElement}`);
+    }
+    if (imports.hydrateFallback) {
+      importParts.push(`HydrateFallback as ${imports.hydrateFallback}`);
     }
 
     if (importParts.length > 0) {
@@ -584,6 +592,9 @@ export const reactRouterPlugin = (options: ReactRouterPluginOptions = {}): Plugi
             handle: availableExports.has('handle') ? `handle${componentName}` : undefined,
             errorElement: availableExports.has('ErrorElement')
               ? `ErrorElement${componentName}`
+              : undefined,
+            hydrateFallback: availableExports.has('HydrateFallback')
+              ? `HydrateFallback${componentName}`
               : undefined,
             availableExports,
           });


### PR DESCRIPTION
**Why is this change needed?**
Applications using `clientLoader` in route files get a white screen during initial load because React Router v7 has nothing to render while loaders run.

**What is the current behavior?**
The Vite plugin recognizes `clientLoader`, `action`, `handle`, and `ErrorElement` exports from route files, but ignores `HydrateFallback`. Even if a route module exports `HydrateFallback`, it is never wired into the route object, so React Router v7 renders nothing while a `clientLoader` runs — resulting in a blank page.

**What is the new behavior?**
The Vite plugin now recognizes the `HydrateFallback` export and wires it as the `HydrateFallback` component on the generated route object. React Router v7 uses this to render a fallback UI while `clientLoader` executes, eliminating the white screen.

**What is the intended behavior or invariant?**
Any named export from a route file that React Router v7 uses for data-route features (`clientLoader`, `action`, `handle`, `ErrorElement`, `HydrateFallback`) must be detected by the Vite plugin and wired onto the corresponding route object property.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Route files that export `HydrateFallback` will now correctly display a fallback while loaders run. No consumer code changes needed.
- Downstream impact: None — change is isolated to `@equinor/fusion-framework-react-router`.

**Review guidance:**
Focus on the `getAvailableExports` function in `plugin.ts` where `'HydrateFallback'` is added to the recognized exports list, and `buildRouteProperties` / `generateImportStatements` where it is wired through. The test mock page now exports `HydrateFallback` and the test validates the full import + route property generation.

**Additional context**
React Router v7 removed `fallbackElement` from `RouterProvider`. The per-route `HydrateFallback` component is the correct mechanism. The `Router.tsx` component does not need changes since the route object already flows through `mapRouteProperties` correctly with any standard React Router route properties.

**Related issues**
Closes #4242

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)