### PR TITLE
Fix/react/router/export navigate from react router

### DIFF
--- a/.changeset/fusion-framework-react-router_export-navigate.md
+++ b/.changeset/fusion-framework-react-router_export-navigate.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": minor
+---
+
+Export `Navigate` from the package root so consumers can import router primitives directly from `@equinor/fusion-framework-react-router`.

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -24,6 +24,7 @@ export {
   Form,
   Link,
   NavLink,
+  Navigate,
   Outlet,
   redirect,
   RouterProvider,


### PR DESCRIPTION
Export `Navigate` from the package root so consumers can import router primitives directly from `@equinor/fusion-framework-react-router`.
