### PR TITLE
fix(dev-portal): resolve pre-existing TypeScript errors

### DIFF
--- a/packages/cli-plugins/copilot/src/commands/app/session-logger.ts
+++ b/packages/cli-plugins/copilot/src/commands/app/session-logger.ts
@@ -126,9 +126,7 @@ export function attachSessionLogger(
         }
         break;
       }
-      // @ts-expect-error - missing case types in SDK typings
       case 'session.tools_updated': {
-        // @ts-expect-error - model property missing in SDK typings
         const negotiatedModel = event.data.model as string | undefined;
         if (negotiatedModel) {
           console.log(chalk.dim(`💾  ${negotiatedModel}`));

--- a/packages/dev-portal/src/PersonSideSheet/sheets/FeatureSheetContent.tsx
+++ b/packages/dev-portal/src/PersonSideSheet/sheets/FeatureSheetContent.tsx
@@ -32,7 +32,7 @@ export const FeatureSheetContent = ({ navigate }: SheetContentProps) => {
       </div>
       <Divider />
       <div>
-        <Tabs activeTab={tab} onChange={(index) => setTab(index)}>
+        <Tabs activeTab={tab} onChange={(index) => setTab(Number(index))}>
           <Tabs.List>
             <Tabs.Tab>App features</Tabs.Tab>
             <Tabs.Tab>Portal features</Tabs.Tab>

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -87,7 +87,5 @@ export const Router = () => {
   const [router] = useState(() => navigation.createRouter(routes));
   // observe the context changes and navigate when the context changes
   useAppContextNavigation();
-  return (
-    <RouterProvider router={router as unknown as RouterProviderProps['router']} />
-  );
+  return <RouterProvider router={router as unknown as RouterProviderProps['router']} />;
 };

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -88,9 +88,6 @@ export const Router = () => {
   // observe the context changes and navigate when the context changes
   useAppContextNavigation();
   return (
-    <RouterProvider
-      router={router as unknown as RouterProviderProps['router']}
-      fallbackElement={<p>wooot</p>}
-    />
+    <RouterProvider router={router as unknown as RouterProviderProps['router']} />
   );
 };

--- a/packages/dev-portal/src/globals.d.ts
+++ b/packages/dev-portal/src/globals.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Ambient JSX type declarations for Lit/WCEV web components used by dev-portal.
+ *
+ * `@types/react@19` removed the global `JSX` namespace — augmentations must
+ * target the `react` module's `JSX` namespace instead.
+ *
+ * The `@equinor/fusion-wc-person` package still uses the old `global JSX` pattern
+ * with computed-property keys so its declarations are not picked up by the compiler.
+ * This file re-declares the elements with string-literal keys in the correct location.
+ */
+export {};
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'fwc-person-avatar': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          azureId?: string;
+          size?: string;
+          clickable?: boolean;
+        },
+        HTMLElement
+      >;
+      'fwc-person-list-item': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          azureId?: string;
+        },
+        HTMLElement
+      >;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes four pre-existing TypeScript errors in `packages/dev-portal` that were already present on `main` (surfaced by the CI run on #4296).

### Changes

**`src/globals.d.ts`** (new)
Adds ambient JSX type declarations for `fwc-person-avatar` and `fwc-person-list-item`.
`@equinor/fusion-wc-person` augments `JSX.IntrinsicElements` using computed property keys (`[tag]`) in the global `JSX` namespace — a pattern that `@types/react@19` no longer supports (global `JSX` was removed). The fix augments `declare module 'react' { namespace JSX }` with explicit string-literal keys instead.

**`src/PersonSideSheet/sheets/FeatureSheetContent.tsx`**
Wraps the `Tabs` `onChange` index in `Number(...)` so it satisfies `setTab<number>` — the EDS `Tabs` callback types the index as `string | number`.

**`src/Router.tsx`**
Removes the `fallbackElement` prop from `RouterProvider`, which was removed in react-router-dom v7.