### PR TITLE
Fix/router/export linkprops

### DIFF
--- a/.changeset/react-router_export-link-props.md
+++ b/.changeset/react-router_export-link-props.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": minor
+---
+
+Export `LinkProps` from the package root so consumers can type link wrappers and related helpers without importing directly from `react-router`.

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -23,6 +23,7 @@ export type {
 export {
   Form,
   Link,
+  type LinkProps,
   NavLink,
   Navigate,
   Outlet,


### PR DESCRIPTION
Export `LinkProps` from the package root so consumers can type link wrappers and related helpers without importing directly from `react-router`.