### PR TITLE
feat(cli): add portal serve command

### DIFF
--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -20,6 +20,7 @@ export { uploadApplication } from './app-upload.js';
 export { tagApplication } from './app-tag.js';
 
 export { startPortalDevServer } from './portal-dev.js';
+export { servePortal, type ServePortalOptions } from './portal-serve.js';
 export { buildPortal } from './portal-build.js';
 export { bundlePortal } from './portal-pack.js';
 export { loadPortalManifest } from './portal-manifest.js';

--- a/packages/cli/src/bin/portal-serve.ts
+++ b/packages/cli/src/bin/portal-serve.ts
@@ -1,0 +1,164 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { mergeConfig as mergeConfigVite } from 'vite';
+
+import type { RuntimeEnv } from '@equinor/fusion-framework-cli/lib';
+
+import { createDevServer, type CreateDevServerOptions, type ConsoleLogger } from './utils/index.js';
+
+import { resolveProjectPackage } from './helpers/resolve-project-package.js';
+import { resolvePortalManifest } from './helpers/resolve-portal-manifest.js';
+import { resolvePortalConfig } from './helpers/resolve-portal-config.js';
+import { loadViteConfig } from './helpers/load-vite-config.js';
+
+/**
+ * Options for serving a built portal.
+ * @public
+ */
+export interface ServePortalOptions {
+  /**
+   * Path to the portal manifest file.
+   */
+  manifest?: string;
+  /**
+   * Path to the portal config file.
+   */
+  config?: string;
+  /**
+   * Directory to serve (optional, will detect from build config if not provided).
+   */
+  dir?: string;
+  /**
+   * Port for the preview server (optional, defaults to 4173).
+   */
+  port?: number;
+  /**
+   * Host for the preview server (optional, defaults to 'localhost').
+   */
+  host?: string;
+  /**
+   * Logger instance for outputting progress and debug information (optional).
+   */
+  log?: ConsoleLogger | null;
+  /**
+   * Enable debug mode for verbose logging.
+   */
+  debug?: boolean;
+}
+
+/**
+ * Serves a built portal using the dev server in preview mode.
+ *
+ * This function loads the portal manifest and Vite configuration to determine
+ * the build output directory, then starts a dev server to serve the built
+ * portal files in a production-like environment.
+ *
+ * @param options - Options for serving the portal including port, host, and logger.
+ * @returns A promise that resolves with the dev server instance.
+ * @throws Will throw if the build directory doesn't exist or if serving fails.
+ * @public
+ */
+export const servePortal = async (options?: ServePortalOptions) => {
+  const { log, dir: customDir, port = 4173, host = 'localhost' } = options ?? {};
+
+  log?.log('Starting to serve portal');
+
+  // Resolve the portal's package.json for root and metadata
+  const pkg = await resolveProjectPackage(log);
+
+  log?.start('Loading Vite config...');
+  // Load Vite configuration to determine build output directory
+  const viteConfig = await loadViteConfig(
+    { root: pkg.root, command: 'build', mode: 'production' },
+    pkg,
+  );
+  log?.succeed('Vite config loaded');
+
+  // Determine the directory to serve (relative to root)
+  const outDirRelative = customDir ? customDir : viteConfig.build?.outDir || 'dist';
+  const outDirAbsolute = resolve(pkg.root, outDirRelative);
+
+  // Setup the runtime environment for the serve server
+  const env: RuntimeEnv = {
+    root: pkg.root,
+    environment: 'local',
+    mode: 'production',
+    command: 'serve',
+    isPreview: true,
+  };
+
+  // Resolve the portal manifest using the environment and manifest path
+  const portalManifest = await resolvePortalManifest(env, pkg, {
+    log,
+    manifestPath: options?.manifest,
+  });
+
+  // Resolve the portal config
+  const portalConfig = await resolvePortalConfig(env, { log, config: options?.config });
+
+  log?.debug('Output directory:', outDirAbsolute);
+
+  // Check if the build directory exists
+  if (!existsSync(outDirAbsolute)) {
+    throw new Error(
+      `Build directory does not exist: ${outDirAbsolute}\n` +
+        'Please build the portal first using `ffc portal build`',
+    );
+  }
+
+  // In preview mode, serve built files directly from Vite's root instead of
+  // using the /@fs/ dev-only filesystem handler. Clear assetPath and prefix
+  // templateEntry with '/' so the browser resolves it as an absolute URL path.
+  portalManifest.build.assetPath = undefined;
+  portalManifest.build.templateEntry = `/${portalManifest.build.templateEntry}`;
+
+  const localViteConfig = await loadViteConfig(env, pkg);
+
+  // Configure Vite server settings
+  const viteConfigOverride = mergeConfigVite(localViteConfig, {
+    server: {
+      port,
+      host: host || localViteConfig.server?.host || 'localhost',
+      fs: {
+        allow: [pkg.root, outDirAbsolute],
+      },
+    },
+  });
+
+  const devServerConfig: CreateDevServerOptions = {
+    template: {
+      portal: {
+        id: portalManifest.name,
+      },
+    },
+    portal: {
+      manifest: portalManifest,
+      config: portalConfig,
+    },
+  };
+
+  log?.debug('vite config:', viteConfigOverride);
+  log?.debug('dev server config:', devServerConfig);
+
+  log?.start('Starting preview server...');
+
+  try {
+    const devServer = await createDevServer(env, devServerConfig, {
+      overrides: viteConfigOverride,
+      log,
+    });
+
+    await devServer.listen();
+
+    log?.succeed('Preview server started successfully');
+    const protocol = devServer.config.server?.https ? 'https' : 'http';
+    const serverHost = devServer.config.server?.host || host;
+    const serverPort = devServer.config.server?.port || port;
+    log?.info(`Preview server is running at: ${protocol}://${serverHost}:${serverPort}`);
+
+    return devServer;
+  } catch (error) {
+    log?.fail('Failed to start preview server');
+    throw error;
+  }
+};

--- a/packages/cli/src/cli/commands/portal/index.ts
+++ b/packages/cli/src/cli/commands/portal/index.ts
@@ -1,6 +1,7 @@
 import { createCommand } from 'commander';
 
 import devCommand from './dev.js';
+import serveCommand from './serve.js';
 import manifestCommand from './manifest.js';
 import schemaCommand from './schema.js';
 import buildCommand from './build.js';
@@ -13,6 +14,7 @@ import configCommand from './config.js';
 export const command = createCommand('portal')
   .description('Develop and deploy portal templates')
   .addCommand(devCommand)
+  .addCommand(serveCommand)
   .addCommand(manifestCommand)
   .addCommand(schemaCommand)
   .addCommand(buildCommand)

--- a/packages/cli/src/cli/commands/portal/serve.ts
+++ b/packages/cli/src/cli/commands/portal/serve.ts
@@ -1,0 +1,82 @@
+import { createCommand } from 'commander';
+
+import { ConsoleLogger, servePortal } from '@equinor/fusion-framework-cli/bin';
+
+/**
+ * CLI command: `serve`
+ *
+ * Serves a built portal template using the dev server in preview mode.
+ *
+ * Features:
+ * - Serves the built portal through the dev server.
+ * - Automatically detects the build directory from Vite configuration.
+ * - Supports custom port, host, directory, manifest, and config options.
+ * - Provides a debug mode for verbose logging.
+ *
+ * Usage:
+ *   $ ffc portal serve
+ *   $ ffc portal serve --port 5000
+ *   $ ffc portal serve --dir ./dist --host 0.0.0.0
+ *
+ * Options:
+ *   --port <port>        Port for the preview server (default: 4173)
+ *   --host <host>        Host for the preview server (default: localhost)
+ *   --dir <directory>    Directory to serve (default: detected from build config)
+ *   --manifest <path>    Path to the portal manifest file
+ *   --config <path>      Path to the portal config file
+ *   -d, --debug          Enable debug mode for verbose logging
+ *
+ * Example:
+ *   $ ffc portal serve
+ *   $ ffc portal serve --port 5000 --host 0.0.0.0
+ *   $ ffc portal serve --dir ./dist
+ *
+ * @see servePortal for implementation details
+ */
+export const command = createCommand('serve')
+  .description('Serve a built portal template')
+  .addHelpText(
+    'after',
+    [
+      '',
+      'Serves the built portal through the dev server, providing a production-like',
+      'preview environment.',
+      '',
+      'The build directory is automatically detected from your Vite configuration.',
+      'If you need to serve a different directory, use the --dir option.',
+      '',
+      'NOTE: The portal must be built first using `ffc portal build`.',
+      '',
+      'Examples:',
+      '  $ ffc portal serve',
+      '  $ ffc portal serve --port 5000',
+      '  $ ffc portal serve --dir ./dist --host 0.0.0.0',
+    ].join('\n'),
+  )
+  .option('--port <port>', 'Port for the preview server', '4173')
+  .option('--host <host>', 'Host for the preview server', 'localhost')
+  .option('--dir <directory>', 'Directory to serve (default: detected from build config)')
+  .option('--manifest <path>', 'Path to the portal manifest file')
+  .option('--config <path>', 'Path to the portal config file')
+  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .action(async (options) => {
+    const log = new ConsoleLogger('portal:serve', { debug: options.debug });
+
+    const port = options.port ? parseInt(options.port, 10) : undefined;
+    if (port && (Number.isNaN(port) || port < 1 || port > 65535)) {
+      log.fail('Invalid port number. Port must be between 1 and 65535.');
+      process.exit(1);
+    }
+
+    await servePortal({
+      log,
+      manifest: options.manifest,
+      config: options.config,
+      dir: options.dir,
+      port,
+      host: options.host,
+      debug: options.debug,
+    });
+  });
+
+export default command;


### PR DESCRIPTION
**Why is this change needed?**

There is currently no way to preview a built portal locally without manually configuring a static server. A `portal serve` command provides a quick production-like preview using the existing dev server infrastructure.

**What is the current behavior?**

After running `ffc portal build`, there is no built-in CLI command to serve the output. Users must set up their own static server or re-run `ffc portal dev`.

**What is the new behavior?**

A new `ffc portal serve` command starts a preview server for the built portal output. It auto-detects the build directory from Vite configuration and supports `--port`, `--host`, `--dir`, `--manifest`, `--config`, and `--debug` options.

**What is the intended behavior or invariant?**

The serve command must locate the build output directory (from Vite config or `--dir` flag), verify it exists, and start the dev server pointing at that directory. It should fail clearly if the build directory is missing.

**Does this PR introduce a breaking change?**

No. This is a new additive command.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-cli`)
- Consumer impact: New `ffc portal serve` command available
- Downstream impact: None

**Review guidance:**

Focus on the `portal-serve.ts` implementation and the `serve.ts` command wiring. The `index.ts` changes are minimal re-exports and command registration.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)