### PR TITLE
fix(cli): add direct /@fusion-api/apps service worker resource for app bundle auth

### DIFF
--- a/.changeset/fusion-framework-cli_fix-sw-auth-app-bundles.md
+++ b/.changeset/fusion-framework-cli_fix-sw-auth-app-bundles.md
@@ -1,5 +1,6 @@
 ---
 "@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-dev-portal": patch
 ---
 
 Add `/@fusion-api/apps` as a direct service worker resource so auth tokens are injected for app bundle chunk requests in portal mode.

--- a/.changeset/fusion-framework-cli_fix-sw-auth-app-bundles.md
+++ b/.changeset/fusion-framework-cli_fix-sw-auth-app-bundles.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Add `/@fusion-api/apps` as a direct service worker resource so auth tokens are injected for app bundle chunk requests in portal mode.
+
+Previously, only `/apps-proxy` was registered. When the browser resolved relative chunk imports (e.g. `lib-*.js`) against the rewritten `/@fusion-api/apps/` origin, the service worker did not match the URL and the request was sent without an Authorization header, resulting in 401 errors.

--- a/packages/cli/src/bin/utils/create-dev-server.ts
+++ b/packages/cli/src/bin/utils/create-dev-server.ts
@@ -104,6 +104,10 @@ const createDevServerTemplate = (
         scopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
       },
       {
+        url: '/@fusion-api/apps',
+        scopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
+      },
+      {
         url: '/help-proxy',
         rewrite: '/@fusion-api/help',
         scopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],

--- a/packages/dev-portal/dev-server.ts
+++ b/packages/dev-portal/dev-server.ts
@@ -49,6 +49,10 @@ if (serviceScopes.length === 0) {
               scopes: serviceScopes,
             },
             {
+              url: '/@fusion-api/apps',
+              scopes: serviceScopes,
+            },
+            {
               url: '/help-proxy',
               rewrite: '/@fusion-api/help',
               scopes: serviceScopes,


### PR DESCRIPTION
**Why is this change needed?**

In portal mode, app bundle chunks (e.g. `lib-*.js`) loaded via dynamic `import()` fail with 401 Unauthorized because the service worker does not inject an auth token for requests to `/@fusion-api/apps/...`.

**What is the current behavior?**

The service worker resource configuration only registers `/apps-proxy` with a rewrite to `/@fusion-api/apps`. When the browser resolves relative chunk imports inside an app's `index.js`, the chunk URL is resolved against the final (rewritten) origin `/@fusion-api/apps/bundles/...`. This URL does not match any service worker resource pattern, so no Bearer token is added and the request returns 401.

**What is the new behavior?**

A new service worker resource entry `{ url: '/@fusion-api/apps', scopes }` (without rewrite) is added in both the CLI defaults and the dev-portal config. This ensures the service worker matches and injects auth tokens for any browser-side fetch to `/@fusion-api/apps/...`, including lazy-loaded bundle chunks.

**What is the intended behavior or invariant?**

All browser-side requests to Fusion API endpoints under `/@fusion-api/apps/` must receive a Bearer token via the service worker, regardless of whether they originate from `/apps-proxy` rewrites or direct URL resolution.

**Does this PR introduce a breaking change?**

No. The existing `/apps-proxy` entry is unchanged and matched first by `Array.find()`. The new entry only adds token injection for previously-unmatched URLs — it performs no URL rewriting.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: Portal-mode users no longer see 401 errors on app bundle chunk loads
- Downstream impact: None — app mode serves bundles locally and is unaffected

**Review guidance:**

The fix is minimal: one new resource object in each of the two config files. Verify that the new entry has no `rewrite` property so it only adds auth without altering URL routing.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)