### PR TITLE
fix(cli): include empty endpoints in fallback app config

### DIFF
--- a/.changeset/fifty-oranges-cheat.md
+++ b/.changeset/fifty-oranges-cheat.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Add missing empty `endpoints` field in default fallback for app config

--- a/packages/cli/src/bin/helpers/resolve-app-config.ts
+++ b/packages/cli/src/bin/helpers/resolve-app-config.ts
@@ -44,7 +44,7 @@ export const resolveAppConfig = async (
       } else {
         // Fallback to built-in config if no local config is present
         log?.succeed(chalk.dim('⚙️ no local application config applied, using built-in'));
-        return { environment: {} };
+        return { environment: {}, endpoints: {} };
       }
     }
     // Log failure and debug information for other errors


### PR DESCRIPTION

<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
If a local app is ahead of the published app, and don't have a app-config override, the default will be used.
This default doesn't have `endpoints` prop.

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
This default doesn't have `endpoints` prop.


**What is the new behavior?**
<!-- What will change after this PR is merged. -->
Add empty `endpoints` prop.

**What is the intended behavior or invariant?**
<!-- Explain the contract this change introduces or preserves. State the non-obvious rule, threshold, lifecycle expectation, stream behavior, or render assumption reviewers should protect. -->

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
should not break anything - as far as i know

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#1015


### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

