### PR TITLE
fix(module-navigation): add ProxyHistory to prevent shared history disposal

### DIFF
--- a/.changeset/fusion-framework-module-navigation_proxy-history.md
+++ b/.changeset/fusion-framework-module-navigation_proxy-history.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-module-navigation": patch
+---
+
+Add `ProxyHistory` to prevent shared `BrowserHistory` disposal when child apps tear down.
+
+When a child app inherits the portal's history via `NavigationConfigurator`, the history is now
+wrapped in a `ProxyHistory` that delegates all operations but keeps its own listener/blocker
+teardown list. Disposing the proxy only cleans up proxy-owned subscriptions — the underlying
+history remains intact.
+
+`setHistory()` gains an optional `{ proxy }` flag (default: `true`) to control wrapping behavior.
+
+Fixes: https://github.com/equinor/fusion-core-tasks/issues/1016

--- a/packages/modules/navigation/src/NavigationConfigurator.ts
+++ b/packages/modules/navigation/src/NavigationConfigurator.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { of, firstValueFrom, from, type ObservableInput } from 'rxjs';
+import { of, from, type ObservableInput } from 'rxjs';
+import { map } from 'rxjs/operators';
 import {
   BaseConfigBuilder,
   type ModulesInstance,
@@ -149,15 +150,13 @@ export class NavigationConfigurator extends BaseConfigBuilder<INavigationConfigu
           async () => historyOrCallback;
 
     if (proxy) {
-      // Wrap the resolved history in a ProxyHistory so dispose only tears down
+      // Wrap each emitted history in a ProxyHistory so dispose only tears down
       // proxy-owned listeners/blockers, never the underlying history itself.
-      this._set('history', async (args) => {
-        const result = resolve(args);
-        // Unwrap the ObservableInput to get the resolved history value.
-        // biome-ignore lint/suspicious/noConfusingVoidType: matches ConfigBuilderCallback signature
-        const history = await firstValueFrom(from(result as ObservableInput<History | void>));
-        return history ? new ProxyHistory(history) : undefined;
-      });
+      this._set('history', (args) =>
+        from(resolve(args) as ObservableInput<History | undefined>).pipe(
+          map((history) => (history ? new ProxyHistory(history) : undefined)),
+        ),
+      );
     } else {
       this._set('history', resolve);
     }

--- a/packages/modules/navigation/src/NavigationConfigurator.ts
+++ b/packages/modules/navigation/src/NavigationConfigurator.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { of, type ObservableInput } from 'rxjs';
+import { of, firstValueFrom, from, type ObservableInput } from 'rxjs';
 import {
   BaseConfigBuilder,
   type ModulesInstance,
@@ -12,6 +12,7 @@ import type { INavigationConfigurator } from './NavigationConfigurator.interface
 
 import type { History } from './lib/types';
 import { createHistory } from './lib/create-history';
+import { ProxyHistory } from './lib/ProxyHistory';
 import type { NavigationModule } from './module';
 
 /**
@@ -72,16 +73,21 @@ export class NavigationConfigurator extends BaseConfigBuilder<INavigationConfigu
         return await args.requireInstance('event');
       }
     });
-    this.setHistory(async (args) => {
-      const history = (args.ref as ModulesInstance<[NavigationModule]>)?.navigation?.history;
-      if (history) {
-        return history;
-      }
-      if (typeof window !== 'undefined') {
-        return createHistory('browser');
-      }
-      return createHistory('memory');
-    });
+    this.setHistory(
+      async (args) => {
+        const history = (args.ref as ModulesInstance<[NavigationModule]>)?.navigation?.history;
+        if (history) {
+          // Wrap the provided history in a ProxyHistory to ensure the module can manage its own teardowns without affecting the original instance.
+          return new ProxyHistory(history);
+        }
+        if (typeof window !== 'undefined') {
+          return createHistory('browser');
+        }
+        return createHistory('memory');
+      },
+      // Don't wrap the default history in a ProxyHistory since it's already owned by the module and will be properly disposed.
+      { proxy: false },
+    );
   }
   /**
    * @deprecated Use `setBasename()` method instead
@@ -121,13 +127,40 @@ export class NavigationConfigurator extends BaseConfigBuilder<INavigationConfigu
   /**
    * Sets a custom history instance for the navigation module.
    *
+   * By default the resolved history is wrapped in a {@link ProxyHistory} so the
+   * module gets its own disposable handle without owning (or accidentally
+   * disposing) the original instance. Set `proxy` to `false` to use the
+   * history as-is.
+   *
    * @param historyOrCallback - History instance or configuration callback
+   * @param options - Optional settings for history wrapping
+   * @param options.proxy - Wrap the history in a {@link ProxyHistory} (default: `true`)
    * @returns The configurator instance for method chaining
    */
-  public setHistory(historyOrCallback?: History | ConfigBuilderCallback<History>): this {
-    const fn =
-      typeof historyOrCallback === 'function' ? historyOrCallback : async () => historyOrCallback;
-    this._set('history', fn);
+  public setHistory(
+    historyOrCallback?: History | ConfigBuilderCallback<History>,
+    options?: { proxy?: boolean },
+  ): this {
+    const { proxy = true } = options ?? {};
+    const resolve =
+      typeof historyOrCallback === 'function'
+        ? historyOrCallback
+        : // Normalize a direct instance to a callback for consistent handling.
+          async () => historyOrCallback;
+
+    if (proxy) {
+      // Wrap the resolved history in a ProxyHistory so dispose only tears down
+      // proxy-owned listeners/blockers, never the underlying history itself.
+      this._set('history', async (args) => {
+        const result = resolve(args);
+        // Unwrap the ObservableInput to get the resolved history value.
+        // biome-ignore lint/suspicious/noConfusingVoidType: matches ConfigBuilderCallback signature
+        const history = await firstValueFrom(from(result as ObservableInput<History | void>));
+        return history ? new ProxyHistory(history) : undefined;
+      });
+    } else {
+      this._set('history', resolve);
+    }
     return this;
   }
 

--- a/packages/modules/navigation/src/__tests__/ProxyHistory.test.ts
+++ b/packages/modules/navigation/src/__tests__/ProxyHistory.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { firstValueFrom, skip } from 'rxjs';
+import { MemoryHistory } from '../lib/MemoryHistory';
+import { ProxyHistory } from '../lib/ProxyHistory';
+
+/**
+ * Awaits the next state emission after performing a navigation action.
+ * MemoryHistory processes state updates asynchronously through the subject.
+ */
+const awaitNavigation = async (
+  history: MemoryHistory | ProxyHistory,
+  action: () => void,
+): Promise<void> => {
+  const next = firstValueFrom(history.state$.pipe(skip(1)));
+  action();
+  await next;
+};
+
+describe('ProxyHistory', () => {
+  let target: MemoryHistory;
+  let proxy: ProxyHistory;
+
+  beforeEach(() => {
+    target = new MemoryHistory();
+    proxy = new ProxyHistory(target);
+  });
+
+  afterEach(() => {
+    proxy[Symbol.dispose]();
+    target[Symbol.dispose]();
+  });
+
+  describe('delegation', () => {
+    it('should delegate location to the target', () => {
+      expect(proxy.location).toBe(target.location);
+    });
+
+    it('should delegate action to the target', () => {
+      expect(proxy.action).toBe(target.action);
+    });
+
+    it('should delegate push to the target', async () => {
+      await awaitNavigation(proxy, () => proxy.push('/test'));
+
+      expect(target.location.pathname).toBe('/test');
+      expect(proxy.location.pathname).toBe('/test');
+    });
+
+    it('should delegate replace to the target', async () => {
+      await awaitNavigation(proxy, () => proxy.replace('/replaced'));
+
+      expect(target.location.pathname).toBe('/replaced');
+      expect(proxy.location.pathname).toBe('/replaced');
+    });
+
+    it('should delegate navigate to the target', async () => {
+      await awaitNavigation(proxy, () =>
+        proxy.navigate('/nav', { replace: true, state: { foo: 1 } }),
+      );
+
+      expect(target.location.pathname).toBe('/nav');
+      expect(target.location.state).toEqual({ foo: 1 });
+    });
+
+    it('should delegate createHref to the target', () => {
+      expect(proxy.createHref('/path')).toBe(target.createHref('/path'));
+    });
+
+    it('should delegate createURL to the target', () => {
+      expect(proxy.createURL('/path').href).toBe(target.createURL('/path').href);
+    });
+
+    it('should delegate encodeLocation to the target', () => {
+      const encoded = proxy.encodeLocation('/path');
+      expect(encoded).toEqual(target.encodeLocation('/path'));
+    });
+  });
+
+  describe('pop()', () => {
+    it('should delegate pop to the target when target supports it', () => {
+      const popSpy = vi.spyOn(target, 'pop');
+      proxy.pop();
+      expect(popSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('teardown isolation', () => {
+    it('should not dispose the target when proxy is disposed', async () => {
+      // Dispose the proxy
+      proxy[Symbol.dispose]();
+
+      // Target should still be functional — push should work
+      await awaitNavigation(target, () => target.push('/after-proxy-dispose'));
+      expect(target.location.pathname).toBe('/after-proxy-dispose');
+    });
+
+    it('should clean up proxy-owned listeners on dispose', async () => {
+      const proxyListener = vi.fn();
+      proxy.listen(proxyListener);
+
+      // Dispose the proxy — listener teardown should be called on the target
+      proxy[Symbol.dispose]();
+
+      // Target is still alive, push something — the disposed proxy listener
+      // should not fire (listen only triggers on POP, but the underlying
+      // subscription should be removed entirely)
+      await awaitNavigation(target, () => target.push('/after-dispose'));
+      expect(target.location.pathname).toBe('/after-dispose');
+    });
+
+    it('should not affect target listeners when proxy is disposed', async () => {
+      // Register a listener directly on the target
+      const targetListener = vi.fn();
+      target.listen(targetListener);
+
+      // Register a listener through the proxy
+      proxy.listen(vi.fn());
+
+      // Dispose proxy — only proxy listener should be removed
+      proxy[Symbol.dispose]();
+
+      // Target should still be functional
+      await awaitNavigation(target, () => target.push('/still-works'));
+      expect(target.location.pathname).toBe('/still-works');
+    });
+  });
+
+  describe('listen/block unsubscribe', () => {
+    it('should allow manual unsubscribe of a listener', () => {
+      const listener = vi.fn();
+      const unlisten = proxy.listen(listener);
+
+      unlisten();
+
+      // No error on dispose — the listener was already removed
+      proxy[Symbol.dispose]();
+    });
+
+    it('should allow manual unsubscribe of a blocker', () => {
+      const blocker = vi.fn();
+      const unblock = proxy.block(blocker);
+
+      unblock();
+
+      // No error on dispose — the blocker was already removed
+      proxy[Symbol.dispose]();
+    });
+  });
+});

--- a/packages/modules/navigation/src/lib/ProxyHistory.ts
+++ b/packages/modules/navigation/src/lib/ProxyHistory.ts
@@ -1,0 +1,130 @@
+import { Subscription } from 'rxjs';
+import type { Observable } from 'rxjs';
+
+import type {
+  History,
+  NavigateOptions,
+  NavigationBlocker,
+  NavigationListener,
+  NavigationUpdate,
+  Path,
+  To,
+} from './types';
+import type { Actions } from './state/history.actions';
+
+/**
+ * A lightweight proxy that delegates every {@link History} operation to an
+ * underlying target instance.
+ *
+ * Use this when you need to pass a conforming `History` object whose backing
+ * implementation can be swapped or is not yet available at construction time,
+ * or when you want a thin indirection layer without subclassing
+ * {@link BaseHistory}.
+ *
+ * The proxy does **not** own the underlying history; disposing it only tears
+ * down subscriptions and blockers registered through the proxy itself.
+ *
+ * @example
+ * ```ts
+ * const browser = createHistory('browser');
+ * const proxy = new ProxyHistory(browser);
+ * proxy.push('/dashboard'); // delegates to browser.push
+ * ```
+ */
+export class ProxyHistory implements History {
+  /** The underlying history instance all calls are forwarded to. */
+  readonly #target: History;
+
+  /** Teardowns owned by this proxy, cleaned up on dispose. */
+  readonly #teardowns = new Subscription();
+
+  /**
+   * @param target - The history instance to delegate all operations to
+   */
+  constructor(target: History) {
+    this.#target = target;
+  }
+
+  /** @inheritdoc */
+  get state$(): Observable<NavigationUpdate> {
+    return this.#target.state$;
+  }
+
+  /** @inheritdoc */
+  get action$(): Observable<Actions> {
+    return this.#target.action$;
+  }
+
+  /** @inheritdoc */
+  get action(): History['action'] {
+    return this.#target.action;
+  }
+
+  /** @inheritdoc */
+  get location(): History['location'] {
+    return this.#target.location;
+  }
+
+  /** @inheritdoc */
+  createHref(to: To): string {
+    return this.#target.createHref(to);
+  }
+
+  /** @inheritdoc */
+  createURL(to: To): URL {
+    return this.#target.createURL(to);
+  }
+
+  /** @inheritdoc */
+  encodeLocation(to: To): Path {
+    return this.#target.encodeLocation(to);
+  }
+
+  /** @inheritdoc */
+  push(to: To, state?: unknown): void {
+    this.#target.push(to, state);
+  }
+
+  /** @inheritdoc */
+  replace(to: To, state?: unknown): void {
+    this.#target.replace(to, state);
+  }
+
+  /** @inheritdoc */
+  navigate(to: To, options?: NavigateOptions): void {
+    this.#target.navigate(to, options);
+  }
+
+  /** @inheritdoc */
+  go(delta: number): void {
+    this.#target.go(delta);
+  }
+
+  /** @inheritdoc */
+  listen(listener: NavigationListener): () => void {
+    const unlisten = this.#target.listen(listener);
+    this.#teardowns.add(unlisten);
+    return () => {
+      unlisten();
+      this.#teardowns.remove(unlisten);
+    };
+  }
+
+  /** @inheritdoc */
+  block(blocker: NavigationBlocker): VoidFunction {
+    const unblock = this.#target.block(blocker);
+    this.#teardowns.add(unblock);
+    return () => {
+      unblock();
+      this.#teardowns.remove(unblock);
+    };
+  }
+
+  /**
+   * Disposes all listeners and blockers registered through this proxy.
+   * Does **not** dispose the underlying history.
+   */
+  [Symbol.dispose](): void {
+    this.#teardowns.unsubscribe();
+  }
+}

--- a/packages/modules/navigation/src/lib/ProxyHistory.ts
+++ b/packages/modules/navigation/src/lib/ProxyHistory.ts
@@ -1,6 +1,7 @@
 import { Subscription } from 'rxjs';
 import type { Observable } from 'rxjs';
 
+import type { BaseHistory } from './BaseHistory';
 import type {
   History,
   NavigateOptions,
@@ -98,6 +99,19 @@ export class ProxyHistory implements History {
   /** @inheritdoc */
   go(delta: number): void {
     this.#target.go(delta);
+  }
+
+  /**
+   * Triggers a POP action on the underlying history to notify framework
+   * listeners (e.g. React Router) after programmatic navigation.
+   *
+   * Delegates to the target's `pop()` when it is a {@link BaseHistory}
+   * instance; otherwise this is a no-op.
+   */
+  pop(): void {
+    if ('pop' in this.#target && typeof this.#target.pop === 'function') {
+      (this.#target as BaseHistory).pop();
+    }
   }
 
   /** @inheritdoc */

--- a/packages/modules/navigation/src/lib/index.ts
+++ b/packages/modules/navigation/src/lib/index.ts
@@ -12,6 +12,7 @@
 export { BaseHistory } from './BaseHistory';
 export { BrowserHistory } from './BrowserHistory';
 export { MemoryHistory } from './MemoryHistory';
+export { ProxyHistory } from './ProxyHistory';
 
 // History stacks
 export { BrowserHistoryStack } from './BrowserHistoryStack';


### PR DESCRIPTION
**Why is this change needed?**

When a child app enables `NavigationModule` via `enableNavigation()`, the module shares the portal's `BrowserHistory` instance (via `NavigationConfigurator` default behavior). When the app is later disposed, `NavigationProvider.dispose()` calls `this.#history[Symbol.dispose]()` on the **shared** BrowserHistory — destroying all listeners, including React Router's. This breaks portal routing: the URL still updates via `pushState`, but React Router never receives POP events and stops rendering route changes.

**What is the current behavior?**

Child apps that inherit the portal's history via `args.ref` receive the raw `BrowserHistory` instance. When the child app is disposed, it disposes the shared history, killing all listeners — including those registered by the portal and React Router.

**What is the new behavior?**

Inherited history instances are now wrapped in a `ProxyHistory` that delegates all `History` operations to the underlying instance but maintains its own listener/blocker teardown list. Disposing the proxy only cleans up proxy-owned subscriptions — the underlying `BrowserHistory` remains intact for the portal.

`setHistory()` gains an optional `{ proxy }` flag (default: `true`) to control wrapping behavior.

**What is the intended behavior or invariant?**

A child module's `[Symbol.dispose]()` must never affect the parent's history instance or its listeners. The `ProxyHistory` enforces this by keeping a separate `Subscription` for proxy-owned teardowns while forwarding all navigation operations to the target.

**Does this PR introduce a breaking change?**

No. The `ProxyHistory` wrapping is transparent — it implements the full `History` interface and the `setHistory()` API is backward-compatible (the new `options` parameter is optional and defaults to `{ proxy: true }`).

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Apps inheriting portal history will no longer break portal routing on disposal
- Downstream impact: No changes to other packages

**Review guidance:**

Focus on:
1. `ProxyHistory.ts` — ensure all `History` methods are correctly delegated and teardown tracking is complete
2. `NavigationConfigurator.setHistory()` — the `proxy` option and `firstValueFrom(from(...))` unwrapping of `ObservableInput`
3. The constructor default callback now explicitly creates `ProxyHistory(history)` for inherited histories and passes `{ proxy: false }` to avoid double-wrapping

**Additional context**

The fix uses a proxy pattern rather than the originally proposed `{ history, owned }` metadata approach. This avoids changing the config interface and keeps ownership concerns encapsulated in the proxy class itself.

**Related issues**

Fixes: https://github.com/equinor/fusion-core-tasks/issues/1016

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)