### PR TITLE
fix(dev-portal): add missing react/router tsconfig project reference

### DIFF
--- a/.changeset/fusion-framework-cli_release.md
+++ b/.changeset/fusion-framework-cli_release.md
@@ -1,8 +1,5 @@
 ---
 "@equinor/fusion-framework-cli": patch
-"@equinor/fusion-framework-dev-portal": patch
 ---
 
-Add missing `react/router` project reference to `dev-portal` tsconfig to fix publish pipeline failure.
-
-The `tsc -b` build step did not know to build `@equinor/fusion-framework-react-router` first, causing Vite to fail when resolving the import during `prepack`. CLI is bumped to trigger a re-publish of the version that failed in CI.
+Internal: republish `@equinor/fusion-framework-cli` after a failed CI publish; no consumer-facing changes are included in this release.

--- a/.changeset/fusion-framework-cli_release.md
+++ b/.changeset/fusion-framework-cli_release.md
@@ -1,0 +1,8 @@
+---
+"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-dev-portal": patch
+---
+
+Add missing `react/router` project reference to `dev-portal` tsconfig to fix publish pipeline failure.
+
+The `tsc -b` build step did not know to build `@equinor/fusion-framework-react-router` first, causing Vite to fail when resolving the import during `prepack`. CLI is bumped to trigger a re-publish of the version that failed in CI.

--- a/packages/dev-portal/tsconfig.json
+++ b/packages/dev-portal/tsconfig.json
@@ -63,6 +63,9 @@
       "path": "../react/components/people-resolver"
     },
     {
+      "path": "../react/router"
+    },
+    {
       "path": "../dev-server"
     }
   ],


### PR DESCRIPTION
**Why is this change needed?**

The CI publish pipeline fails when building `@equinor/fusion-framework-dev-portal` because `@equinor/fusion-framework-react-router` is imported in `Router.tsx` but not listed as a project reference in the tsconfig.

**What is the current behavior?**

`tsc -b --noCheck` does not know to build `@equinor/fusion-framework-react-router` first, so its `dist/` directory doesn't exist when Vite runs. This causes Rolldown to fail resolving the import during `prepack` in the publish pipeline.

The build succeeds locally only when the workspace packages are already cached from a previous `pnpm build`.

**What is the new behavior?**

The `react/router` project reference is added to `packages/dev-portal/tsconfig.json`, ensuring `tsc -b` builds the dependency before Vite bundling.

**What is the intended behavior or invariant?**

All workspace imports used by `dev-portal` must have corresponding project references in its tsconfig so that `tsc -b` correctly builds the dependency graph in clean CI environments.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch for both `dev-portal` and `cli` (to re-publish the version that failed in CI)
- Consumer impact: None — this is an internal build fix
- Downstream impact: Unblocks the publish pipeline

**Review guidance:**

Straightforward one-line addition to tsconfig references. The changeset bumps CLI as well to trigger re-publish of the version that failed.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)