### PR TITLE
chore: add missing changesets for merged dependency bumps

### DIFF
--- a/.changeset/fusion-framework-cli_bump-simple-git.md
+++ b/.changeset/fusion-framework-cli_bump-simple-git.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-cli-plugin-ai-index": patch
+---
+
+Internal: Bump `simple-git` from 3.35.2 to 3.36.0.

--- a/.changeset/fusion-framework-dev-portal_bump-eds-core-react.md
+++ b/.changeset/fusion-framework-dev-portal_bump-eds-core-react.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-dev-portal": patch
+"@equinor/fusion-framework-react-components-bookmark": patch
+---
+
+Internal: Bump `@equinor/eds-core-react` from 2.4.1 to 2.5.0.

--- a/.changeset/fusion-framework-module-ai_bump-langchain.md
+++ b/.changeset/fusion-framework-module-ai_bump-langchain.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-ai": patch
+"@equinor/fusion-framework-cli-plugin-ai-index": patch
+"@equinor/fusion-framework-cli-plugin-ai-chat": patch
+---
+
+Internal: Bump LangChain ecosystem dependencies (`langchain`, `@langchain/core`, `@langchain/community`, `@langchain/textsplitters`).

--- a/.changeset/fusion-framework-module-msal-node_bump-msal-node.md
+++ b/.changeset/fusion-framework-module-msal-node_bump-msal-node.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-msal-node": patch
+---
+
+Internal: Bump `@azure/msal-node` from 5.0.2 to 5.1.3.

--- a/.changeset/fusion-framework-react-ag-charts_bump-ag-charts.md
+++ b/.changeset/fusion-framework-react-ag-charts_bump-ag-charts.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-ag-charts": patch
+---
+
+Internal: Bump `ag-charts-community` and `ag-charts-react` from 13.1.0 to 13.2.1.

--- a/.changeset/fusion-framework-react-router_bump-react-router.md
+++ b/.changeset/fusion-framework-react-router_bump-react-router.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Internal: Bump `react-router` from 7.13.2 to 7.14.1.

--- a/.changeset/fusion-framework-vite-plugin-api-service_bump-path-to-regexp.md
+++ b/.changeset/fusion-framework-vite-plugin-api-service_bump-path-to-regexp.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vite-plugin-api-service": patch
+---
+
+Internal: Bump `path-to-regexp` from 8.3.0 to 8.4.2.


### PR DESCRIPTION
## Summary

Adds missing changesets for dependency bumps that were merged without them. These track version bumps for published packages affected by Dependabot PRs.

### Changesets added

| Changeset | Package(s) | Dependency PR |
|---|---|---|
| `react-ag-charts_bump-ag-charts` | `@equinor/fusion-framework-react-ag-charts` | #4406 |
| `react-router_bump-react-router` | `@equinor/fusion-framework-react-router` | #4429 |
| `module-msal-node_bump-msal-node` | `@equinor/fusion-framework-module-msal-node` | #4456 |
| `cli_bump-simple-git` | `fusion-framework-cli`, `cli-plugin-ai-index` | #4411 |
| `vite-plugin-api-service_bump-path-to-regexp` | `fusion-framework-vite-plugin-api-service` | #4424 |
| `module-ai_bump-langchain` | `module-ai`, `cli-plugin-ai-index`, `cli-plugin-ai-chat` | #4408 |
| `dev-portal_bump-eds-core-react` | `dev-portal`, `react-components-bookmark` | #4425 |

All are `patch` bumps with `Internal:` prefix — no consumer-facing API changes.