### PR TITLE
chore: add custom-dependency-pr-solver skill

### DIFF
--- a/.agents/skills/custom-dependency-pr-solver/CHANGELOG.md
+++ b/.agents/skills/custom-dependency-pr-solver/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.0.0
+
+- Initial skill scaffold
+- Batch Dependabot PR processing workflow
+- Auto-merge for high-confidence dependency updates
+- Research and verdict comment templates
+- Changeset decision and confidence criteria references

--- a/.agents/skills/custom-dependency-pr-solver/SKILL.md
+++ b/.agents/skills/custom-dependency-pr-solver/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: custom-dependency-pr-solver
+description: 'Batch-process Dependabot PRs end-to-end: checkout, rebase, research, changeset, validate, and auto-merge high-confidence PRs as admin squash. USE FOR: process all Dependabot PRs, clear dependency backlog, solve dependency PRs, merge safe dependency updates. DO NOT USE FOR: single-PR deep review (use fusion-dependency-review), feature PRs, non-Dependabot dependency PRs, or PRs requiring manual code changes.'
+license: MIT
+compatibility: Requires GitHub CLI (`gh`) authenticated with admin merge rights. Requires pnpm and the Fusion Framework monorepo build toolchain.
+metadata:
+  version: "0.0.0"
+  status: experimental
+  owner: "@equinor/fusion-core"
+  tags:
+    - github
+    - dependabot
+    - dependency-updates
+    - batch-workflow
+    - auto-merge
+  mcp:
+    suggested:
+      - github
+---
+
+# Dependency PR Solver
+
+Batch workflow that processes open Dependabot PRs sequentially: checkout, rebase, research, create changesets, validate, and auto-merge high-confidence PRs with admin squash merge.
+
+## When to use
+
+Use this skill when you want to process multiple Dependabot PRs in a single session with automated merge for safe updates.
+
+Typical triggers:
+
+- "Process all open Dependabot PRs"
+- "Clear the dependency PR backlog"
+- "Solve dependency PRs"
+- "Merge safe dependency updates"
+- "Handle open Dependabot PRs and merge what's safe"
+- "Batch process dependency updates"
+
+## When not to use
+
+Do not use this skill for:
+
+- Deep single-PR review (use `fusion-dependency-review` instead)
+- Feature PRs or application code reviews
+- Non-Dependabot dependency PRs (Renovate, manual bumps)
+- PRs that require manual code changes beyond changesets
+- When you lack admin merge rights on the repository
+
+## Required inputs
+
+### Mandatory
+
+- **Repository**: owner and name (infer from current workspace when possible)
+- **Confirmation**: explicit user approval before starting the batch
+
+### Optional
+
+- PR filter: specific PR numbers to include or exclude
+- Merge strategy override: skip auto-merge entirely (review-only mode)
+- Confidence threshold override: merge only `high` (default) or also `medium`
+
+## Instructions
+
+### Step 1 — List and triage open Dependabot PRs
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,headRefName,baseRefName,mergeable,statusCheckRollup
+```
+
+Present a summary table to the user:
+
+| PR | Title | Base | CI | Mergeable |
+|----|-------|------|-----|-----------|
+
+Ask the user to confirm which PRs to process, or confirm "all".
+
+### Step 2 — Process each PR sequentially
+
+For each PR in the confirmed set, execute Steps 3–8 in order. Track progress with todos. If a PR fails at any step, log the failure, skip to the next PR, and include it in the final report.
+
+### Step 3 — Checkout and rebase
+
+1. Fetch the PR branch:
+   ```bash
+   gh pr checkout <number>
+   ```
+2. Rebase onto the base branch (usually `main`):
+   ```bash
+   git rebase origin/<base-branch>
+   ```
+3. If rebase conflicts occur, abort the rebase, mark the PR as `needs-manual-intervention`, and skip to the next PR.
+4. After successful rebase, force-push:
+   ```bash
+   git push --force-with-lease
+   ```
+5. Install dependencies after rebase:
+   ```bash
+   pnpm install --frozen-lockfile
+   ```
+   If lockfile is out of sync after rebase, run `pnpm install` without `--frozen-lockfile`, commit the lockfile update, and push.
+
+### Step 4 — Research changes
+
+For each dependency updated in the PR:
+
+1. Identify the package(s) and version change from the PR diff and commit message.
+2. Research upstream changes: changelog, release notes, breaking changes, security advisories.
+3. Check existing PR comments and review threads.
+4. Post a research comment to the PR using `assets/research-comment-template.md`.
+
+Use web search or npm registry for changelog and advisory lookups. Keep research focused — do not deep-dive unless a concern is found.
+
+### Step 5 — Create changesets
+
+Determine whether a changeset is needed using `references/changeset-decision.md`.
+
+**Rules:**
+
+- If the dependency is used by a published package, create a changeset.
+- If the dependency touches a compilable package (`cli`, `dev-portal`, `dev-server`, or any package with a `build` script and `publishConfig`), a changeset is **mandatory**.
+- Use `patch` bump for dependency updates unless the upstream change is a major version bump with breaking changes.
+- Use the `Internal:` prefix for the changeset summary.
+- One changeset per affected published package.
+
+**Changeset creation:**
+
+```bash
+# Create .changeset/<package-name>_bump-<dep-name>.md
+```
+
+```markdown
+---
+"@equinor/<package-name>": patch
+---
+
+Internal: bump `<dependency>` from `<old>` to `<new>`.
+```
+
+Commit the changeset:
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for <dependency> bump"
+git push
+```
+
+### Step 6 — Build, test, lint, and format
+
+Run the full validation suite:
+
+```bash
+pnpm build && pnpm test && pnpm -w check
+```
+
+If any step fails:
+
+1. Capture the error output.
+2. Attempt a targeted fix only if trivial (e.g., formatting with `pnpm format`).
+3. If the fix is non-trivial, mark the PR as `needs-manual-intervention`.
+
+### Step 7 — Assess merge confidence
+
+Evaluate confidence using `references/confidence-criteria.md`. Score as `high`, `medium`, or `low`.
+
+**High confidence** (auto-merge candidate):
+
+- Patch or minor version bump
+- No breaking changes identified
+- All validation passes (build + test + lint)
+- No unresolved reviewer concerns
+- Lockfile-only or minimal manifest changes
+- No security advisories on the target version
+
+**Medium confidence** (report, do not auto-merge):
+
+- Minor version bump with new features but no breaking changes
+- Validation passes but with warnings
+- Upstream release is very recent (< 48 hours)
+
+**Low confidence** (skip, flag for manual review):
+
+- Major version bump
+- Breaking changes identified
+- Validation failures
+- Security concerns
+- Unresolved reviewer comments
+- Rebase conflicts
+
+### Step 8 — Merge or report
+
+**If high confidence:**
+
+1. Post a verdict comment to the PR using `assets/verdict-comment-template.md`.
+2. Squash merge as admin:
+   ```bash
+   gh pr merge <number> --squash --admin
+   ```
+
+**If medium or low confidence:**
+
+1. Post the verdict comment with findings.
+2. Do not merge. Include in the final report as "needs manual review".
+
+### Step 9 — Final batch report
+
+After all PRs are processed, present a summary:
+
+| PR | Title | Status | Confidence | Action |
+|----|-------|--------|------------|--------|
+| #N | ... | merged / skipped / failed | high/med/low | merged / needs review / needs intervention |
+
+Include:
+
+- Total PRs processed
+- PRs merged
+- PRs skipped (with reasons)
+- PRs needing manual intervention (with specific issues)
+
+## Examples
+
+- User: "Process all open Dependabot PRs"
+  - Result: list 8 open PRs, user confirms all, process sequentially, merge 5 high-confidence, report 2 medium and 1 low for manual review.
+
+- User: "Solve dependency PRs but don't merge anything"
+  - Result: process all PRs in review-only mode, post research and verdict comments, report all results without merging.
+
+- User: "Handle Dependabot PRs #42 and #45"
+  - Result: process only the specified PRs, merge if high confidence, report otherwise.
+
+## Expected output
+
+- Research comment posted to each processed PR
+- Changesets created and committed where required
+- Verdict comment posted to each PR with validation results and confidence
+- High-confidence PRs merged via admin squash
+- Final batch summary table with per-PR status and actions taken
+- List of PRs requiring manual intervention with specific reasons
+
+## Safety & constraints
+
+Never:
+
+- Merge without posting a research comment and verdict comment first
+- Merge a PR with failing validation (build, test, or lint)
+- Merge a PR with unresolved security concerns
+- Merge a PR with major version bumps without explicit user override
+- Merge the base branch into a Dependabot PR branch (rebase only)
+- Skip changeset creation for compilable packages
+- Force-push without `--force-with-lease`
+- Process PRs without initial user confirmation of the batch
+
+Always:
+
+- Rebase Dependabot branches onto base; never merge base into the PR branch
+- Post research and verdict comments before any merge action
+- Create changesets for published package dependency changes
+- Run full validation (`pnpm build && pnpm test && pnpm -w check`) before merge
+- Report exact validation output in the verdict comment
+- Track per-PR status throughout the batch
+- Present a final summary after all PRs are processed
+- Return to `main` branch after batch processing is complete

--- a/.agents/skills/custom-dependency-pr-solver/SKILL.md
+++ b/.agents/skills/custom-dependency-pr-solver/SKILL.md
@@ -55,8 +55,8 @@ Do not use this skill for:
 ### Optional
 
 - PR filter: specific PR numbers to include or exclude
-- Merge strategy override: skip auto-merge entirely (review-only mode)
-- Confidence threshold override: merge only `high` (default) or also `medium`
+- `--review-only`: skip auto-merge entirely (post research and verdict comments without merging)
+- `--merge-medium`: also auto-merge medium-confidence PRs (default: only `high`)
 
 ## Instructions
 
@@ -79,8 +79,9 @@ For each PR in the confirmed set, execute Steps 3–8 in order. Track progress w
 
 ### Step 3 — Checkout and rebase
 
-1. Fetch the PR branch:
+1. Fetch the latest base branch and PR branch:
    ```bash
+   git fetch origin <base-branch>
    gh pr checkout <number>
    ```
 2. Rebase onto the base branch (usually `main`):
@@ -100,12 +101,10 @@ For each PR in the confirmed set, execute Steps 3–8 in order. Track progress w
 
 ### Step 4 — Research changes
 
-For each dependency updated in the PR:
-
-1. Identify the package(s) and version change from the PR diff and commit message.
-2. Research upstream changes: changelog, release notes, breaking changes, security advisories.
+1. Identify all package(s) and version changes from the PR diff and commit message.
+2. For each dependency, research upstream changes: changelog, release notes, breaking changes, security advisories.
 3. Check existing PR comments and review threads.
-4. Post a research comment to the PR using `assets/research-comment-template.md`.
+4. Post a **single** research comment per PR using `assets/research-comment-template.md`, listing all updated dependencies in one comment.
 
 Use web search or npm registry for changelog and advisory lookups. Keep research focused — do not deep-dive unless a concern is found.
 
@@ -158,31 +157,7 @@ If any step fails:
 
 ### Step 7 — Assess merge confidence
 
-Evaluate confidence using `references/confidence-criteria.md`. Score as `high`, `medium`, or `low`.
-
-**High confidence** (auto-merge candidate):
-
-- Patch or minor version bump
-- No breaking changes identified
-- All validation passes (build + test + lint)
-- No unresolved reviewer concerns
-- Lockfile-only or minimal manifest changes
-- No security advisories on the target version
-
-**Medium confidence** (report, do not auto-merge):
-
-- Minor version bump with new features but no breaking changes
-- Validation passes but with warnings
-- Upstream release is very recent (< 48 hours)
-
-**Low confidence** (skip, flag for manual review):
-
-- Major version bump
-- Breaking changes identified
-- Validation failures
-- Security concerns
-- Unresolved reviewer comments
-- Rebase conflicts
+Evaluate confidence using `references/confidence-criteria.md`. Score as `high`, `medium`, or `low`. See that file for the full criteria — do not duplicate the checklist here.
 
 ### Step 8 — Merge or report
 

--- a/.agents/skills/custom-dependency-pr-solver/SKILL.md
+++ b/.agents/skills/custom-dependency-pr-solver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: custom-dependency-pr-solver
-description: 'Batch-process Dependabot PRs end-to-end: checkout, rebase, research, changeset, validate, and auto-merge high-confidence PRs as admin squash. USE FOR: process all Dependabot PRs, clear dependency backlog, solve dependency PRs, merge safe dependency updates. DO NOT USE FOR: single-PR deep review (use fusion-dependency-review), feature PRs, non-Dependabot dependency PRs, or PRs requiring manual code changes.'
+description: 'Batch-process Dependabot PRs end-to-end: checkout, rebase, research, changeset, validate, and auto-merge high-confidence PRs as admin squash. USE FOR: process all Dependabot PRs, clear dependency backlog, batch-merge safe Dependabot updates, batch-process dependency PRs. DO NOT USE FOR: single-PR deep review (use fusion-dependency-review), feature PRs, non-Dependabot dependency PRs, or PRs requiring manual code changes.'
 license: MIT
 compatibility: Requires GitHub CLI (`gh`) authenticated with admin merge rights. Requires pnpm and the Fusion Framework monorepo build toolchain.
 metadata:
@@ -30,10 +30,10 @@ Typical triggers:
 
 - "Process all open Dependabot PRs"
 - "Clear the dependency PR backlog"
-- "Solve dependency PRs"
-- "Merge safe dependency updates"
-- "Handle open Dependabot PRs and merge what's safe"
-- "Batch process dependency updates"
+- "Batch-process dependency PRs"
+- "Batch-merge safe Dependabot updates"
+- "Handle all open Dependabot PRs and merge what's safe"
+- "Solve all dependency PRs"
 
 ## When not to use
 

--- a/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
+++ b/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
@@ -1,0 +1,39 @@
+# 🤖 Dependency Update Research
+
+## PR Snapshot
+
+| Signal | Notes |
+| ------ | ----- |
+| PR | `#<number>` |
+| Dependency | `<name>` |
+| Version jump | `<from>` → `<to>` |
+| Update lane | `<patch/minor/major>` |
+| Ecosystem | `<npm>` |
+| Change scope | `<lockfile-only / manifest + lockfile>` |
+| CI status | `<passing/failing/pending/unknown>` |
+| Branch health | `<current / behind base / rebased>` |
+| Consumer role | `<runtime / build / test / dev-tooling>` |
+
+## Upstream Changes
+
+<!-- Key changelog entries, new features, deprecations, or behavioral changes. -->
+
+## Breaking Changes
+
+<!-- Concrete breakage or migration work. "None identified" if clean. -->
+
+## Security
+
+<!-- CVEs, advisories, or supply-chain concerns. "No advisories found" if clean. -->
+
+## Affected Packages
+
+| Package | Dependency role | Changeset needed |
+|---------|----------------|-----------------|
+| `@equinor/<name>` | `<prod/dev/peer>` | `<yes/no>` |
+
+## Sources
+
+- Changelog: `<link>`
+- npm: `<link>`
+- Advisory: `<link or "none">`

--- a/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
+++ b/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
@@ -5,14 +5,16 @@
 | Signal | Notes |
 | ------ | ----- |
 | PR | `#<number>` |
-| Dependency | `<name>` |
-| Version jump | `<from>` → `<to>` |
-| Update lane | `<patch/minor/major>` |
-| Ecosystem | `<npm>` |
 | Change scope | `<lockfile-only / manifest + lockfile>` |
 | CI status | `<passing/failing/pending/unknown>` |
 | Branch health | `<current / behind base / rebased>` |
-| Consumer role | `<runtime / build / test / dev-tooling>` |
+
+## Dependencies Updated
+
+| Dependency | From | To | Lane | Consumer role |
+|------------|------|----|------|---------------|
+| `<name>` | `<from>` | `<to>` | `<patch/minor/major>` | `<runtime / build / test / dev-tooling>` |
+| `<name>` | `<from>` | `<to>` | `<patch/minor/major>` | `<runtime / build / test / dev-tooling>` |
 
 ## Upstream Changes
 

--- a/.agents/skills/custom-dependency-pr-solver/assets/verdict-comment-template.md
+++ b/.agents/skills/custom-dependency-pr-solver/assets/verdict-comment-template.md
@@ -1,0 +1,42 @@
+# 🤖 Dependency Update Verdict
+
+## Decision
+
+| Signal | Notes |
+| ------ | ----- |
+| Recommendation | `<merge / hold / decline>` |
+| Confidence | `<high / medium / low>` |
+
+## Validation Results
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Build (`pnpm build`) | `<pass/fail>` | |
+| Test (`pnpm test`) | `<pass/fail>` | |
+| Lint & Format (`pnpm -w check`) | `<pass/fail>` | |
+
+## Changesets
+
+| Package | Bump | File |
+|---------|------|------|
+| `@equinor/<name>` | `patch` | `.changeset/<filename>.md` |
+
+## Assessment
+
+### Security
+- Signal: `<clear / concern / blocking>`
+- Detail: <!-- brief note -->
+
+### Compatibility
+- Signal: `<clear / concern / blocking>`
+- Detail: <!-- brief note -->
+
+### Impact
+- Signal: `<clear / concern / blocking>`
+- Detail: <!-- brief note -->
+
+## Action
+
+`<Merged via admin squash / Skipped — needs manual review / Skipped — validation failure>`
+
+<!-- If merged: commit SHA. If skipped: specific reason and recommended next steps. -->

--- a/.agents/skills/custom-dependency-pr-solver/references/changeset-decision.md
+++ b/.agents/skills/custom-dependency-pr-solver/references/changeset-decision.md
@@ -28,7 +28,8 @@ Any package under `packages/` with `"publishConfig": { "access": "public" }` req
 
 - Lockfile-only changes with no `package.json` manifest modifications in published packages
 - Changes to `devDependencies` that do not affect the published output
-- Changes only affecting `cookbooks/` dev dependencies
+
+> **Note:** `cookbooks/*` packages are versioned and published — always create a changeset when their dependencies change, including dev dependencies.
 
 ## Bump type
 

--- a/.agents/skills/custom-dependency-pr-solver/references/changeset-decision.md
+++ b/.agents/skills/custom-dependency-pr-solver/references/changeset-decision.md
@@ -1,0 +1,56 @@
+# Changeset Decision for Dependency PRs
+
+## When a changeset is mandatory
+
+A changeset **must** be created when the dependency update affects any published package. In the Fusion Framework monorepo, all packages with `publishConfig` in their `package.json` are published.
+
+### Compilable packages (always require changesets)
+
+These packages produce build artifacts and must always get a changeset for dependency changes:
+
+- `@equinor/fusion-framework-cli` — CLI tool (rollup build, has `bin` executables)
+- `@equinor/fusion-framework-dev-portal` — Dev portal app (vite build)
+- `@equinor/fusion-framework-dev-server` — Dev server library (tsc build)
+
+### Other published packages
+
+Any package under `packages/` with `"publishConfig": { "access": "public" }` requires a changeset when its dependencies change. This includes:
+
+- `@equinor/fusion-framework` (core)
+- `@equinor/fusion-framework-app`
+- `@equinor/fusion-framework-react`
+- `@equinor/fusion-framework-module-*`
+- `@equinor/fusion-framework-react-*`
+- `@equinor/fusion-framework-vite-plugin-*`
+- `@equinor/fusion-log`
+
+## When to skip
+
+- Lockfile-only changes with no `package.json` manifest modifications in published packages
+- Changes to `devDependencies` that do not affect the published output
+- Changes only affecting `cookbooks/` dev dependencies
+
+## Bump type
+
+| Upstream change | Bump type | Summary prefix |
+|----------------|-----------|----------------|
+| Patch or minor dep update | `patch` | `Internal:` |
+| Major dep update (no breaking consumer impact) | `patch` | `Internal:` |
+| Major dep update with consumer-facing changes | `minor` or `major` | (describe the impact) |
+
+## Changeset format
+
+```markdown
+---
+"@equinor/<package-name>": patch
+---
+
+Internal: bump `<dependency>` from `<old-version>` to `<new-version>`.
+```
+
+## Identifying affected packages
+
+1. Check which `package.json` files changed in the PR diff.
+2. For each changed `package.json`, read the `name` field.
+3. If the package has `publishConfig`, it needs a changeset.
+4. If only `pnpm-lock.yaml` changed, trace which packages are affected by checking the lockfile diff for workspace package entries.

--- a/.agents/skills/custom-dependency-pr-solver/references/confidence-criteria.md
+++ b/.agents/skills/custom-dependency-pr-solver/references/confidence-criteria.md
@@ -1,0 +1,45 @@
+# Merge Confidence Criteria
+
+## High confidence — auto-merge candidate
+
+All of the following must be true:
+
+- [ ] Patch or minor version bump (no major)
+- [ ] No breaking changes identified in upstream changelog
+- [ ] No security advisories on the target version
+- [ ] All validation passes: `pnpm build && pnpm test && pnpm -w check`
+- [ ] No unresolved reviewer comments on the PR
+- [ ] Change scope is lockfile-only or minimal manifest change
+- [ ] Upstream release is at least 48 hours old
+- [ ] Dependency is not a critical runtime dependency with broad consumer surface
+
+## Medium confidence — report only
+
+One or more of the following:
+
+- Minor version bump with new features (but no breaking changes)
+- Validation passes with non-blocking warnings
+- Upstream release is very recent (< 48 hours)
+- Dependency has broad consumer surface but change is backward-compatible
+- Changeset was required and created, but the impact scope is unclear
+
+## Low confidence — skip and flag
+
+One or more of the following:
+
+- Major version bump
+- Breaking changes identified upstream
+- Validation failures (build, test, or lint)
+- Security advisory exists on either the current or target version
+- Unresolved reviewer comments or maintainer concerns
+- Rebase conflicts that could not be resolved automatically
+- Dependency is deprecated or has known stability issues
+- Multiple interdependent packages affected with unclear interaction
+
+## Overrides
+
+The user may override the confidence threshold:
+
+- `--merge-medium`: also auto-merge medium-confidence PRs
+- Review-only mode: skip all merges regardless of confidence
+- Explicit PR exclusion: skip specific PRs from auto-merge

--- a/.github/instructions/dependabot-pr.instructions.md
+++ b/.github/instructions/dependabot-pr.instructions.md
@@ -7,19 +7,39 @@ name: Dependabot PR Rules
 
 ## TL;DR (for AI agents)
 
-- Use `.agents/skills/fusion-dependency-review/SKILL.md` as the default review workflow for Dependabot PRs.
-- Do not approve, merge, push, close, or comment on a Dependabot PR without explicit user confirmation.
+- Choose the right skill based on intent:
+  - **Single PR review** → `.agents/skills/fusion-dependency-review/SKILL.md`
+  - **Batch processing / clear backlog** → `.agents/skills/custom-dependency-pr-solver/SKILL.md`
+- Do not approve, merge, push, close, or comment on a Dependabot PR without explicit user confirmation (batch-level confirmation counts for the solver skill).
 - If the branch needs refreshing, use rebase-only refreshes; never merge the base branch into the PR branch.
 - If the PR needs patching, follow `.github/instructions/workflow-contribution.instructions.md`.
 - Treat missing changesets, missing validation, or weak PR-template usage as explicit findings.
 
-## Default workflow
+## Workflow routing
+
+Determine which workflow to use based on the user's intent:
+
+| Intent | Skill | Confirmation model |
+|--------|-------|--------------------|
+| Review a single dependency PR in detail | `fusion-dependency-review` | Per-PR confirmation before merge |
+| Batch-process multiple Dependabot PRs with auto-merge for safe updates | `custom-dependency-pr-solver` | Batch-level confirmation, then auto-merge high-confidence PRs |
+
+If the intent is ambiguous, ask: "Do you want to review a single PR in detail, or batch-process multiple Dependabot PRs?"
+
+## Single-PR workflow (fusion-dependency-review)
 
 1. Identify the target Dependabot PR by URL or PR number.
 2. Review it with `.agents/skills/fusion-dependency-review/SKILL.md`.
 3. If branch updates are required, rebase onto the latest base branch; do not merge the base branch into the PR branch.
 4. If code changes are required, apply `.github/instructions/workflow-contribution.instructions.md` before committing or updating the PR.
 5. Before approval or merge, verify required validation status, changeset handling, and PR-body quality.
+
+## Batch workflow (custom-dependency-pr-solver)
+
+1. List all open Dependabot PRs and present to the user for batch confirmation.
+2. Process each confirmed PR with `.agents/skills/custom-dependency-pr-solver/SKILL.md`.
+3. High-confidence PRs (all validation passes, no breaking changes, no security concerns) are auto-merged via admin squash after posting research and verdict comments.
+4. Medium and low-confidence PRs are reported but never auto-merged.
 
 ## Safety
 

--- a/.github/instructions/dependabot-pr.instructions.md
+++ b/.github/instructions/dependabot-pr.instructions.md
@@ -7,39 +7,17 @@ name: Dependabot PR Rules
 
 ## TL;DR (for AI agents)
 
-- Choose the right skill based on intent:
-  - **Single PR review** → `.agents/skills/fusion-dependency-review/SKILL.md`
-  - **Batch processing / clear backlog** → `.agents/skills/custom-dependency-pr-solver/SKILL.md`
 - Do not approve, merge, push, close, or comment on a Dependabot PR without explicit user confirmation (batch-level confirmation counts for the solver skill).
 - If the branch needs refreshing, use rebase-only refreshes; never merge the base branch into the PR branch.
 - If the PR needs patching, follow `.github/instructions/workflow-contribution.instructions.md`.
 - Treat missing changesets, missing validation, or weak PR-template usage as explicit findings.
 
-## Workflow routing
+## Skills
 
-Determine which workflow to use based on the user's intent:
-
-| Intent | Skill | Confirmation model |
-|--------|-------|--------------------|
-| Review a single dependency PR in detail | `fusion-dependency-review` | Per-PR confirmation before merge |
-| Batch-process multiple Dependabot PRs with auto-merge for safe updates | `custom-dependency-pr-solver` | Batch-level confirmation, then auto-merge high-confidence PRs |
-
-If the intent is ambiguous, ask: "Do you want to review a single PR in detail, or batch-process multiple Dependabot PRs?"
-
-## Single-PR workflow (fusion-dependency-review)
-
-1. Identify the target Dependabot PR by URL or PR number.
-2. Review it with `.agents/skills/fusion-dependency-review/SKILL.md`.
-3. If branch updates are required, rebase onto the latest base branch; do not merge the base branch into the PR branch.
-4. If code changes are required, apply `.github/instructions/workflow-contribution.instructions.md` before committing or updating the PR.
-5. Before approval or merge, verify required validation status, changeset handling, and PR-body quality.
-
-## Batch workflow (custom-dependency-pr-solver)
-
-1. List all open Dependabot PRs and present to the user for batch confirmation.
-2. Process each confirmed PR with `.agents/skills/custom-dependency-pr-solver/SKILL.md`.
-3. High-confidence PRs (all validation passes, no breaking changes, no security concerns) are auto-merged via admin squash after posting research and verdict comments.
-4. Medium and low-confidence PRs are reported but never auto-merged.
+| Intent | Skill |
+|--------|-------|
+| Review a single dependency PR in detail | `.agents/skills/fusion-dependency-review/SKILL.md` |
+| Batch-process multiple Dependabot PRs with auto-merge | `.agents/skills/custom-dependency-pr-solver/SKILL.md` |
 
 ## Safety
 

--- a/.github/prompts/dependabot.prompt.md
+++ b/.github/prompts/dependabot.prompt.md
@@ -5,9 +5,24 @@ name: Dependabot PR Handler Prompt
 
 # Dependabot PR Handler Prompt
 
-You are handling a Dependabot pull request. Follow the instructions in `.github/instructions/dependabot-pr.instructions.md` **completely and in order**.
+You are handling Dependabot pull requests. Follow the instructions in `.github/instructions/dependabot-pr.instructions.md` **completely and in order**.
 
-## Initial Step: Identify the PR
+## Initial Step: Determine Workflow
+
+### If the user wants to batch-process multiple PRs:
+- Use the batch workflow: `.agents/skills/custom-dependency-pr-solver/SKILL.md`
+- List all open Dependabot PRs, confirm the batch with the user, and process sequentially
+- High-confidence PRs are auto-merged after posting research and verdict comments
+- Proceed with the solver skill's instructions
+
+### If the user wants to review a single PR:
+- Use the single-PR workflow below
+- Proceed to "Identify the PR"
+
+### If the intent is unclear:
+- Ask: "Do you want to review a single PR in detail, or batch-process multiple Dependabot PRs?"
+
+## Identify the PR (single-PR workflow)
 
 ### If PR URL is provided:
 - Extract PR details: repository owner, repository name, PR number, and branch name

--- a/.github/prompts/dependabot.prompt.md
+++ b/.github/prompts/dependabot.prompt.md
@@ -3,81 +3,26 @@ description: Prompt for handling Dependabot pull requests
 name: Dependabot PR Handler Prompt
 ---
 
-# Dependabot PR Handler Prompt
+# Dependabot PR Handler
 
-You are handling Dependabot pull requests. Follow the instructions in `.github/instructions/dependabot-pr.instructions.md` **completely and in order**.
+Follow `.github/instructions/dependabot-pr.instructions.md` for safety rules.
 
-## Initial Step: Determine Workflow
+## Determine intent
 
-### If the user wants to batch-process multiple PRs:
-- Use the batch workflow: `.agents/skills/custom-dependency-pr-solver/SKILL.md`
-- List all open Dependabot PRs, confirm the batch with the user, and process sequentially
-- High-confidence PRs are auto-merged after posting research and verdict comments
-- Proceed with the solver skill's instructions
+Ask the user if unclear:
 
-### If the user wants to review a single PR:
-- Use the single-PR workflow below
-- Proceed to "Identify the PR"
+- **"Review a single PR"** → load and follow `.agents/skills/fusion-dependency-review/SKILL.md`
+- **"Process all / batch-process / clear backlog"** → load and follow `.agents/skills/custom-dependency-pr-solver/SKILL.md`
 
-### If the intent is unclear:
-- Ask: "Do you want to review a single PR in detail, or batch-process multiple Dependabot PRs?"
+## If no PR is specified
 
-## Identify the PR (single-PR workflow)
+List open Dependabot PRs first:
 
-### If PR URL is provided:
-- Extract PR details: repository owner, repository name, PR number, and branch name
-- Store these details for use throughout the workflow
-- Proceed to Step 2: Create Git Worktree for PR
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title
+```
 
-### If NO PR URL is provided:
-You MUST do the following:
-
-1. **List Dependabot PRs** (always do this first):
-   - Execute: `gh pr list --author "app/dependabot" --state open --json number,title`
-   - Display the list of open Dependabot PRs to the user in a formatted way:
-     ```
-     Open Dependabot PRs:
-     
-     #<number> - <title>
-     
-     [Repeat for each PR]
-     ```
-   - Categorize PRs by update type (MAJOR/MINOR/PATCH) if possible from the title or labels
-   - Group by update type if multiple PRs exist
-
-2. **Ask user to select PR**:
-   - Prompt: "Please provide the Dependabot PR number (e.g., 1234) or PR URL from the list above"
-   - Wait for user response
-   - Parse the response to extract PR number or URL
-   - If PR number provided: Use `gh pr view <PR_NUMBER>` to get full PR details
-   - Store PR details (repository owner, name, PR number, branch name)
-   - Proceed to Step 2: Create Git Worktree for PR
-
-**CRITICAL**: Never auto-select a PR. The user MUST explicitly choose which PR to handle.
-
-## After PR Selection
-
-Once the PR is identified (either from URL, ID, or user selection from list), continue with the full workflow from `.github/instructions/dependabot-pr.instructions.md`:
-
-1. ✅ Select PR (completed above)
-2. Create Git Worktree for PR
-3. Rebase Branch
-4. Research Dependencies
-5. Post Research Comment (MANDATORY - use `gh pr comment <PR_NUMBER> -F <file>.md`)
-6. Install Dependencies
-7. Build Project
-8. Run Tests
-9. Run Linting
-10. Generate Changeset
-11. Push Changes
-12. Comment PR Results (MANDATORY - use `gh pr comment <PR_NUMBER> -F <file>.md`)
-13. Squash Merge PR (optional, requires user approval)
-14. Cleanup Repository
-15. Finalize Instruction
-
-## Important Reminders
-
-- **Read the full instruction file**: `.github/instructions/dependabot-pr.instructions.md` before starting
+Let the user choose a PR (single review) or confirm the batch (solver).
 - **Never skip steps**: Especially Steps 5 and 12 (comment posting)
 - **Execute commands**: When posting comments, you MUST run `gh pr comment <PR_NUMBER> -F <comment-file>.md`, not just say you will
 - **Get user consent**: For all critical operations (comments, pushes, merges)


### PR DESCRIPTION
**Why is this change needed?**

Processing Dependabot PRs is a recurring manual task that follows a consistent pattern: checkout, rebase, research, create changesets, validate, and merge. This skill encodes that workflow so it can be executed as a batch operation with auto-merge for high-confidence updates.

**What is the current behavior?**

Dependabot PRs are reviewed individually using `fusion-dependency-review`. There is no batch-processing workflow, and each PR requires manual checkout, changeset creation, validation, and merge steps.

**What is the new behavior?**

A new `custom-dependency-pr-solver` skill provides an end-to-end batch workflow:
- Lists all open Dependabot PRs and confirms the batch with the user
- For each PR: checkout → rebase → research comment → changeset creation → full validation (`pnpm build && pnpm test && pnpm -w check`) → confidence scoring → admin squash merge for high-confidence PRs
- Posts research and verdict comments to each PR before any merge
- Produces a final batch summary report

**What is the intended behavior or invariant?**

- High-confidence PRs (patch/minor, no breaking changes, all validation passes, no security concerns) are merged automatically via admin squash
- Medium and low confidence PRs are reported but never auto-merged
- Changesets are mandatory for compilable packages (cli, dev-portal, dev-server) and any published package affected by the dependency change
- Research and verdict comments are always posted before merge
- Rebase-only branch updates; never merge base into PR branch

**Does this PR introduce a breaking change?**

No. This is a new skill addition with no impact on existing code or workflows.

**Impact assessment:**

- Breaking changes: No
- Version bump: N/A (skill catalog content, not a published package)
- Consumer impact: None
- Downstream impact: None

**Review guidance:**

Focus on the workflow sequencing in `SKILL.md`, the changeset decision rules in `references/changeset-decision.md`, and the confidence criteria in `references/confidence-criteria.md`. The comment templates in `assets/` follow the same pattern as `fusion-dependency-review`.

**Additional context**

This skill complements `fusion-dependency-review` (single-PR deep review) with a batch-processing counterpart. The `fusion-dependency-review` skill remains the right choice for detailed individual PR analysis.

Skill structure:
```
.agents/skills/custom-dependency-pr-solver/
├── SKILL.md                              (259 lines)
├── CHANGELOG.md
├── assets/
│   ├── research-comment-template.md
│   └── verdict-comment-template.md
└── references/
    ├── changeset-decision.md
    └── confidence-criteria.md
```

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)