### PR TITLE
fix(dev-server,spa): resolve portal proxy bootstrap failures

### DIFF
--- a/.changeset/fusion-framework-cli_fix-portal-config-auth.md
+++ b/.changeset/fusion-framework-cli_fix-portal-config-auth.md
@@ -1,6 +1,5 @@
 ---
 "@equinor/fusion-framework-cli": patch
-"@equinor/fusion-framework-dev-server": patch
 ---
 
 Fix 401 Unauthorized responses when loading the portal-config API in the Fusion dev server.

--- a/.changeset/fusion-framework-cli_fix-portal-config-auth.md
+++ b/.changeset/fusion-framework-cli_fix-portal-config-auth.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-dev-server": patch
+---
+
+Fix 401 Unauthorized responses when loading the portal-config API in the Fusion dev server.
+
+The default service worker resource list now includes `/@fusion-api/portal-config` with the CI scope so the service worker injects a Bearer token for portal-config API calls (manifest, config, and bundle fetches) during bootstrap and other direct requests.
+
+Also adds `scopes?: string[]` to the `FusionService` type so the type correctly reflects the service discovery response shape and is no longer misleading when services do include scopes.
+
+Fixes: https://github.com/equinor/fusion/issues/830

--- a/.changeset/fusion-framework-vite-plugin-spa_fix-portal-proxy-entrypoint-slashes.md
+++ b/.changeset/fusion-framework-vite-plugin-spa_fix-portal-proxy-entrypoint-slashes.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Fix SPA bootstrap portal template URL construction to normalize slash boundaries between `/portal-proxy`, `assetPath`, and `templateEntry`.
+
+This avoids malformed entrypoint imports like `/portal-proxy//bundles/...` that can fail with unauthorized dynamic module fetches in dev-server scenarios where `spa.templateEnv.portal.proxy` is enabled.

--- a/packages/cli/src/bin/utils/create-dev-server.ts
+++ b/packages/cli/src/bin/utils/create-dev-server.ts
@@ -117,6 +117,13 @@ const createDevServerTemplate = (
         rewrite: '/@fusion-api/portal-config',
         scopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
       },
+      {
+        // Inject auth for direct portal-config API calls (manifest and config fetches).
+        // This keeps portal bootstrap requests authenticated even when they are issued
+        // before the regular client token flow has attached Authorization headers.
+        url: '/@fusion-api/portal-config',
+        scopes: ['5a842df8-3238-415d-b168-9f16a6a6031b/.default'],
+      },
     ],
   },
   // todo - deep merge with user config

--- a/packages/dev-server/src/types.ts
+++ b/packages/dev-server/src/types.ts
@@ -15,6 +15,17 @@ export type FusionService = {
   uri: string;
   /** Human-readable display name of the service. */
   name: string;
+  /**
+   * OAuth scopes required when requesting tokens for this service.
+   *
+   * @remarks
+   * When present, these scopes are forwarded through {@link processServices} so the
+   * Fusion Framework HTTP module can acquire a Bearer token for service requests.
+   * If absent (i.e. the service discovery endpoint does not return scopes), the HTTP
+   * client will make unauthenticated requests — use the service worker resource
+   * configuration to inject auth in that case.
+   */
+  scopes?: string[];
 };
 
 /**

--- a/packages/vite-plugins/spa/src/html/bootstrap.ts
+++ b/packages/vite-plugins/spa/src/html/bootstrap.ts
@@ -14,6 +14,7 @@ import {
 } from '@equinor/fusion-framework-module-telemetry';
 import { ConsoleAdapter } from '@equinor/fusion-framework-module-telemetry/console-adapter';
 
+import { createPortalEntryPoint } from './create-portal-entry-point.js';
 import { registerServiceWorker } from './register-service-worker.js';
 
 import { version } from '../version.js';
@@ -163,13 +164,11 @@ enableTelemetry(configurator, {
   document.body.innerHTML = '';
   document.body.appendChild(el);
 
-  const portalEntryPoint = [
-    portalProxy ? '/portal-proxy' : '',
+  const portalEntryPoint = createPortalEntryPoint(
+    portalProxy ? '/portal-proxy' : undefined,
     portal_manifest.build.assetPath,
     portal_manifest.build.templateEntry,
-  ]
-    .filter(Boolean)
-    .join('/');
+  );
 
   // @todo: should test if the entrypoint is external or internal
   // @todo: add proper return type

--- a/packages/vite-plugins/spa/src/html/create-portal-entry-point.ts
+++ b/packages/vite-plugins/spa/src/html/create-portal-entry-point.ts
@@ -6,15 +6,15 @@
  */
 export const createPortalEntryPoint = (...segments: Array<string | undefined | null>): string => {
   const normalized = segments
-    .filter((segment): segment is string => Boolean(segment))
+    .filter((segment): segment is string => segment !== undefined && segment !== null)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
     .map((segment, index) => {
-      const value = segment.trim();
       if (index === 0) {
-        return value.replace(/\/+$/g, '');
+        return segment.replace(/\/+$/g, '');
       }
-      return value.replace(/^\/+|\/+$/g, '');
-    })
-    .filter(Boolean);
+      return segment.replace(/^\/+|\/+$/g, '');
+    });
 
   return normalized.join('/');
 };

--- a/packages/vite-plugins/spa/src/html/create-portal-entry-point.ts
+++ b/packages/vite-plugins/spa/src/html/create-portal-entry-point.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the portal template entrypoint URL used by the SPA bootstrap loader.
+ *
+ * @param segments - Ordered URL/path segments such as proxy prefix, asset path, and template entry.
+ * @returns A normalized entrypoint string with single slashes between segments.
+ */
+export const createPortalEntryPoint = (...segments: Array<string | undefined | null>): string => {
+  const normalized = segments
+    .filter((segment): segment is string => Boolean(segment))
+    .map((segment, index) => {
+      const value = segment.trim();
+      if (index === 0) {
+        return value.replace(/\/+$/g, '');
+      }
+      return value.replace(/^\/+|\/+$/g, '');
+    })
+    .filter(Boolean);
+
+  return normalized.join('/');
+};

--- a/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
+++ b/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
@@ -29,6 +29,8 @@ describe('createPortalEntryPoint', () => {
       '/index.mjs?import',
     );
 
-    expect(result).toBe('https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/index.mjs?import');
+    expect(result).toBe(
+      'https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/index.mjs?import'
+    );
   });
 });

--- a/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
+++ b/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
@@ -30,7 +30,7 @@ describe('createPortalEntryPoint', () => {
     );
 
     expect(result).toBe(
-      'https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/index.mjs?import'
+      'https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/index.mjs?import',
     );
   });
 });

--- a/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
+++ b/packages/vite-plugins/spa/tests/create-portal-entry-point.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPortalEntryPoint } from '../src/html/create-portal-entry-point';
+
+describe('createPortalEntryPoint', () => {
+  it('should avoid double slashes when proxy prefix and asset path both include slash boundaries', () => {
+    const result = createPortalEntryPoint(
+      '/portal-proxy',
+      '/bundles/templates/app-portal@2.0.1/dist',
+      'index.mjs?import',
+    );
+
+    expect(result).toBe('/portal-proxy/bundles/templates/app-portal@2.0.1/dist/index.mjs?import');
+  });
+
+  it('should normalize trailing and leading slashes across all segments', () => {
+    const result = createPortalEntryPoint(
+      '/portal-proxy/',
+      '/bundles/templates/app-portal@2.0.1/dist/',
+      '/index.mjs?import',
+    );
+
+    expect(result).toBe('/portal-proxy/bundles/templates/app-portal@2.0.1/dist/index.mjs?import');
+  });
+
+  it('should preserve absolute origin when asset path points to an external URL', () => {
+    const result = createPortalEntryPoint(
+      'https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/',
+      '/index.mjs?import',
+    );
+
+    expect(result).toBe('https://cdn.example.com/bundles/templates/app-portal@2.0.1/dist/index.mjs?import');
+  });
+});

--- a/packages/vite-plugins/spa/vitest.config.ts
+++ b/packages/vite-plugins/spa/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineProject } from 'vitest/config';
+
+import { name, version } from './package.json';
+
+export default defineProject({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    name: `${name}@${version}`,
+  },
+});


### PR DESCRIPTION
**Why is this change needed?**
Consumer issue #830 reported that app dev-server startup could result in a blank page due to failed portal template loading and unauthorized portal-config API requests.

**What is the current behavior?**
When `spa.templateEnv.portal.proxy` is enabled, portal entrypoint URL assembly could produce malformed paths with a double slash (for example `/portal-proxy//bundles/...`), causing dynamic import failure. In addition, direct bootstrap portal-config API requests could fail with 401 during startup flows.

**What is the new behavior?**
Portal entrypoint URL construction now normalizes slash boundaries between proxy prefix, asset path, and template entry.

The dev-server default service-worker resources now also include `/@fusion-api/portal-config` token injection so direct portal-config API calls during bootstrap are authenticated.

`FusionService` typing now includes optional `scopes` to reflect service discovery response shape.

**What is the intended behavior or invariant?**
Portal bootstrap import URLs must be stable and slash-normalized regardless of leading/trailing slash combinations in source segments, and portal-config bootstrap requests must carry a valid Bearer token in local dev startup scenarios.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Fixes dev-server startup failures for portal bootstrap/proxy flows
- Downstream impact: Affects `@equinor/fusion-framework-vite-plugin-spa`, `@equinor/fusion-framework-cli`, and `@equinor/fusion-framework-dev-server`

**Review guidance:**
- Validate slash normalization in `createPortalEntryPoint` and its use in SPA bootstrap.
- Confirm service-worker resource config includes `/@fusion-api/portal-config` with CI scope.
- Confirm no regressions for existing `/portal-proxy` rewrite behavior.

**Additional context**
Validation run:
- `pnpm --filter @equinor/fusion-framework-vite-plugin-spa test -- --run tests/create-portal-entry-point.test.ts`
- `pnpm --filter @equinor/fusion-framework-vite-plugin-spa build`
- `pnpm --filter @equinor/fusion-framework-cli build`
- `pnpm --filter @equinor/fusion-framework-dev-server build`

**Related issues**
Reference: https://github.com/equinor/fusion/issues/830

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
