### PR TITLE
Fix/react router/exports from router

### DIFF
--- a/.changeset/fusion-framework-react-router_sort-exports.md
+++ b/.changeset/fusion-framework-react-router_sort-exports.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+External: export additional packages from react-router that apps may require to operate without needing react-router installed.
+
+Internal: sort barrel exports in the router package index for deterministic ordering; no public API or runtime behavior changes.

--- a/.changeset/fusion-framework-react-router_sort-exports.md
+++ b/.changeset/fusion-framework-react-router_sort-exports.md
@@ -4,4 +4,4 @@
 
 External: export additional packages from react-router that apps may require to operate without needing react-router installed.
 
-Internal: sort barrel exports in the router package index for deterministic ordering; no public API or runtime behavior changes.
+Internal: sort barrel exports in the router package index for deterministic ordering; this sorting change does not change runtime behavior or the public API.

--- a/.changeset/fusion-framework-react-router_sort-exports.md
+++ b/.changeset/fusion-framework-react-router_sort-exports.md
@@ -2,6 +2,6 @@
 "@equinor/fusion-framework-react-router": patch
 ---
 
-External: export additional packages from react-router that apps may require to operate without needing react-router installed.
+External: re-export additional React Router symbols that apps may require to operate without needing `react-router` installed.
 
 Internal: sort barrel exports in the router package index for deterministic ordering; this sorting change does not change runtime behavior or the public API.

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -1,5 +1,5 @@
 export { Router } from './Router.js';
-export { routerContext, useRouterContext, FusionRouterContextProvider } from './context.js';
+export { FusionRouterContextProvider, routerContext, useRouterContext } from './context.js';
 export type { RouteSchemaEntry } from './routes/to-route-schema.js';
 export type {
   ActionFunction,
@@ -10,36 +10,43 @@ export type {
   LoaderFunction,
   LoaderFunctionArgs,
   RouteComponentProps,
+  RouteNode,
+  RouteObject,
   RouterComponent,
   RouterContext,
   RouterHandle,
   RouterSchema,
-  RouteNode,
-  RouteObject,
 } from './types.js';
 
 // Re-export commonly used React Router hooks, components, and utilities
 // so consumers don't need to install or import `react-router` directly.
 export {
+  createMemoryRouter,
   Form,
   Link,
   NavLink,
   Navigate,
+  NavigateFunction,
   Outlet,
-  redirect,
   RouterProvider,
+  UNSAFE_RouteContext,
+  matchPath,
+  matchRoutes,
+  redirect,
+  type LinkProps,
+  type RouterProviderProps,
   useActionData,
   useFormAction,
-  useLoaderData,
   useLocation,
+  useLoaderData,
   useMatch,
   useMatches,
   useNavigate,
   useNavigation,
+  useOutlet,
+  useOutletContext,
   useParams,
   useRouteError,
   useSearchParams,
   useSubmit,
-  type LinkProps,
-  type RouterProviderProps,
 } from 'react-router';


### PR DESCRIPTION
External: export additional packages from react-router that apps may require to operate without needing react-router installed.

Internal: sort barrel exports in the router package index for deterministic ordering; no public API or runtime behavior changes.