### PR TITLE
Fix/react router/package exports

### DIFF
--- a/.changeset/fancy-squids-admire.md
+++ b/.changeset/fancy-squids-admire.md
@@ -1,5 +1,7 @@
 ---
-"@equinor/fusion-framework-react-router": patch
+"@equinor/fusion-framework-react-router": major
 ---
 
 Remove exports from `react-router` that users should not use in implementation.
+
+Breaking Changes: Removes `RouterProvider`, users should use `Router` instead.

--- a/.changeset/fancy-squids-admire.md
+++ b/.changeset/fancy-squids-admire.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Remove exports from `react-router` that users should not use in implementation.

--- a/cookbooks/portal-analytics/src/Router.tsx
+++ b/cookbooks/portal-analytics/src/Router.tsx
@@ -1,15 +1,7 @@
-import {
-  Outlet,
-  RouterProvider,
-  type RouterProviderProps,
-  useParams,
-} from '@equinor/fusion-framework-react-router';
+import { Outlet, Router as FusionRouter, useParams } from '@equinor/fusion-framework-react-router';
 import { AppLoader } from './AppLoader';
 import { Header } from './components/Header';
 
-import { useFramework } from '@equinor/fusion-framework-react';
-import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
-import { useState } from 'react';
 import { styled } from 'styled-components';
 import { Portal } from './Portal';
 import { useAppContextNavigation } from './useAppContextNavigation';
@@ -35,6 +27,11 @@ const Styled = {
   `,
 };
 
+/**
+ * Root layout component for the portal analytics app.
+ *
+ * Renders the header, portal panel, and a scrollable main area via `Outlet`.
+ */
 const Root = () => {
   return (
     <Styled.ContentContainer>
@@ -49,12 +46,16 @@ const Root = () => {
   );
 };
 
+/**
+ * Route component that extracts the `appKey` parameter and delegates to {@link AppLoader}.
+ */
 // eslint-disable-next-line react/no-multi-comp
 const AppRoute = () => {
   const { appKey } = useParams();
   return appKey ? <AppLoader appKey={appKey} /> : null;
 };
 
+/** Route definitions for the portal analytics app. */
 const routes = [
   {
     path: '/',
@@ -68,16 +69,15 @@ const routes = [
   },
 ];
 
+/**
+ * Top-level router for the Fusion Portal Analytics app.
+ *
+ * Renders the application via `FusionRouter`. Observes context changes through
+ * {@link useAppContextNavigation} to keep the URL in sync.
+ */
 // eslint-disable-next-line react/no-multi-comp
 export const Router = () => {
-  const { navigation } = useFramework<[NavigationModule]>().modules;
-  const [router] = useState(() => navigation.createRouter(routes));
   // observe the context changes and navigate when the context changes
   useAppContextNavigation();
-  return (
-    <RouterProvider
-      router={router as unknown as RouterProviderProps['router']}
-      fallbackElement={<p>wooot</p>}
-    />
-  );
+  return <FusionRouter routes={routes} />;
 };

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -1,17 +1,9 @@
 import { useBookmarkNavigate } from '@equinor/fusion-framework-react-module-bookmark/portal';
 
-import {
-  Outlet,
-  RouterProvider,
-  type RouterProviderProps,
-  useParams,
-} from '@equinor/fusion-framework-react-router';
+import { Outlet, Router as FusionRouter, useParams } from '@equinor/fusion-framework-react-router';
 import AppLoader from './AppLoader';
 import { Header } from './Header';
 
-import { useFramework } from '@equinor/fusion-framework-react';
-import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
-import { useState } from 'react';
 import { styled } from 'styled-components';
 import { useAppContextNavigation } from './useAppContextNavigation';
 
@@ -82,15 +74,12 @@ const routes = [
 /**
  * Top-level router for the Fusion Dev Portal.
  *
- * Creates a router instance from the framework navigation module and
- * renders it via `RouterProvider`. Observes context changes through
+ * Renders the application via `FusionRouter`. Observes context changes through
  * {@link useAppContextNavigation} to keep the URL in sync.
  */
 // eslint-disable-next-line react/no-multi-comp
 export const Router = () => {
-  const { navigation } = useFramework<[NavigationModule]>().modules;
-  const [router] = useState(() => navigation.createRouter(routes));
   // observe the context changes and navigate when the context changes
   useAppContextNavigation();
-  return <RouterProvider router={router as unknown as RouterProviderProps['router']} />;
+  return <FusionRouter routes={routes} />;
 };

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -21,15 +21,11 @@ export type {
 // Re-export commonly used React Router hooks, components, and utilities
 // so consumers don't need to install or import `react-router` directly.
 export {
-  createMemoryRouter,
   Form,
   Link,
   NavLink,
   Navigate,
-  NavigateFunction,
   Outlet,
-  RouterProvider,
-  UNSAFE_RouteContext,
   matchPath,
   matchRoutes,
   redirect,

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -30,7 +30,6 @@ export {
   matchRoutes,
   redirect,
   type LinkProps,
-  type RouterProviderProps,
   useActionData,
   useFormAction,
   useLocation,


### PR DESCRIPTION
Remove exports from `react-router` that users should not use in implementation.