### PR TITLE
Fix/react router/package exports

### DIFF
--- a/.changeset/smart-needles-grab.md
+++ b/.changeset/smart-needles-grab.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Export `useResolvedPath` from `react-router`

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -41,6 +41,7 @@ export {
   useOutlet,
   useOutletContext,
   useParams,
+  useResolvedPath,
   useRouteError,
   useSearchParams,
   useSubmit,


### PR DESCRIPTION
export hook `useResolvedPath` from `react-router`.