### PR TITLE
chore: add changesets for merged dependency bumps

### DIFF
--- a/.changeset/fusion-framework-cli_bump-simple-git.md
+++ b/.changeset/fusion-framework-cli_bump-simple-git.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-cli": patch
+"@equinor/fusion-framework-cli-plugin-ai-index": patch
+---
+
+Internal: bump `simple-git` from `3.35.2` to `3.36.0`.

--- a/.changeset/fusion-framework-module-msal-node_bump-msal-node.md
+++ b/.changeset/fusion-framework-module-msal-node_bump-msal-node.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-msal-node": patch
+---
+
+Internal: bump `@azure/msal-node` from `5.0.2` to `5.1.4` and `@azure/msal-node-extensions` from `5.0.2` to `5.1.4`.

--- a/.changeset/fusion-framework-module-msal_bump-msal-browser.md
+++ b/.changeset/fusion-framework-module-msal_bump-msal-browser.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-msal": patch
+---
+
+Internal: bump `@azure/msal-browser` from `5.4.0` to `5.8.0`.

--- a/.changeset/fusion-framework-react-router_bump-react-router.md
+++ b/.changeset/fusion-framework-react-router_bump-react-router.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Internal: bump `react-router` from `7.13.2` to `7.14.2`.


### PR DESCRIPTION
Adds patch changesets for recently merged Dependabot PRs that bumped runtime dependencies:

- `@azure/msal-node` 5.0.2 → 5.1.4 (#4503)
- `@azure/msal-node-extensions` 5.0.2 → 5.1.4 (#4499)
- `@azure/msal-browser` 5.4.0 → 5.8.0 (#4500)
- `simple-git` 3.35.2 → 3.36.0 (#4501)
- `react-router` 7.13.2 → 7.14.2 (#4486)

These were lockfile-only changes merged without changesets. Adding changesets retroactively so published packages get patch version bumps.