### PR TITLE
feat(cli): auto-enable debug mode from RUNNER_DEBUG env var

### DIFF
--- a/.changeset/fusion-framework-cli-plugin-ai-base_add-debug-option.md
+++ b/.changeset/fusion-framework-cli-plugin-ai-base_add-debug-option.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli-plugin-ai-base": minor
+---
+
+Add `-d, --debug` option to all AI CLI commands, with automatic activation via the `RUNNER_DEBUG` environment variable.
+
+When GitHub Actions debug logging is enabled (`RUNNER_DEBUG=1`), all `ffc ai` commands now start in debug mode automatically. Debug output includes environment, auth mode, AI service URL, scopes, and token acquisition status.

--- a/.changeset/fusion-framework-cli-plugin-ai-index_debug-logging.md
+++ b/.changeset/fusion-framework-cli-plugin-ai-index_debug-logging.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli-plugin-ai-index": patch
+---
+
+Add verbose debug logging to the `ai index add` pipeline when `--debug` is active.
+
+Debug output includes config/pattern details, skipped files, per-file chunk counts, embedding batch sizes, upsert document IDs, and git diff file listings.

--- a/.changeset/fusion-framework-cli_runner-debug-default.md
+++ b/.changeset/fusion-framework-cli_runner-debug-default.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Default the `--debug` flag to `true` when the `RUNNER_DEBUG` environment variable is set.
+
+All app, portal, auth, and create commands now automatically enable debug mode in GitHub Actions debug runs without requiring `--debug` in workflow YAML.

--- a/packages/cli-plugins/ai-base/src/options/options.ts
+++ b/packages/cli-plugins/ai-base/src/options/options.ts
@@ -51,6 +51,14 @@ export const indexNameOption = createOption(
   'Azure AI Search index name',
 ).env('FUSION_AI_INDEX_NAME');
 
+/** `-d, --debug` | `RUNNER_DEBUG` — enable verbose logging */
+export const debugOption = createOption(
+  '-d, --debug',
+  'Enable debug mode for verbose logging',
+)
+  .env('RUNNER_DEBUG')
+  .default(false);
+
 export default {
   envOption,
   tokenOption,
@@ -59,4 +67,5 @@ export default {
   chatModelOption,
   embedModelOption,
   indexNameOption,
+  debugOption,
 };

--- a/packages/cli-plugins/ai-base/src/options/schema.ts
+++ b/packages/cli-plugins/ai-base/src/options/schema.ts
@@ -21,6 +21,7 @@ export const AiOptionsSchema = z
     chatModel: z.string().min(1).optional(),
     embedModel: z.string().min(1).optional(),
     indexName: z.string().min(1).optional(),
+    debug: z.coerce.boolean().default(false),
   })
   .describe('Base Fusion AI command options');
 

--- a/packages/cli-plugins/ai-base/src/options/types.ts
+++ b/packages/cli-plugins/ai-base/src/options/types.ts
@@ -19,4 +19,6 @@ export interface AiOptions {
   embedModel?: string;
   /** Azure AI Search index name. Required for vector search / indexing operations. */
   indexName?: string;
+  /** Enable debug mode for verbose logging. */
+  debug?: boolean;
 }

--- a/packages/cli-plugins/ai-base/src/options/with-options.ts
+++ b/packages/cli-plugins/ai-base/src/options/with-options.ts
@@ -2,6 +2,7 @@ import { type Command, InvalidOptionArgumentError } from 'commander';
 import {
   chatModelOption,
   clientIdOption,
+  debugOption,
   embedModelOption,
   envOption,
   indexNameOption,
@@ -38,6 +39,7 @@ export const withOptions = (
   command.addOption(tokenOption);
   command.addOption(tenantIdOption);
   command.addOption(clientIdOption);
+  command.addOption(debugOption);
 
   if (args?.includeChat) command.addOption(chatModelOption);
   if (args?.includeEmbedding) command.addOption(embedModelOption);

--- a/packages/cli-plugins/ai-base/src/setup-framework.ts
+++ b/packages/cli-plugins/ai-base/src/setup-framework.ts
@@ -46,6 +46,8 @@ const isAuthError = (error: unknown): boolean => {
  * @throws {Error} When authentication fails after the interactive retry.
  */
 export const setupFramework = async (options: AiOptions): Promise<FusionFramework<[AIModule]>> => {
+  const debug = options.debug ?? false;
+
   // Service-discovery mode: resolve URL + scopes from Fusion service registry
   const auth: FusionFrameworkSettings['auth'] = options.token
     ? { token: options.token }
@@ -56,8 +58,19 @@ export const setupFramework = async (options: AiOptions): Promise<FusionFramewor
 
   const env = (options.env as FusionEnv) ?? FusionEnv.ContinuesIntegration;
 
+  if (debug) {
+    console.debug('[debug] Environment:', env);
+    console.debug('[debug] Auth mode:', options.token ? 'static-token' : 'MSAL');
+    if (!options.token) {
+      console.debug('[debug] Tenant ID:', (auth as { tenantId: string }).tenantId);
+      console.debug('[debug] Client ID:', (auth as { clientId: string }).clientId);
+    }
+  }
+
   /** Initialise the framework, resolve the AI service, and pre-cache tokens. */
   const initAndSetup = async (): Promise<FusionFramework<[AIModule]>> => {
+    if (debug) console.debug('[debug] Initializing framework with AI module…');
+
     const framework = await initializeFramework<[AIModule]>({ env, auth }, (configurator) => {
       enableAI(configurator);
     });
@@ -67,10 +80,17 @@ export const setupFramework = async (options: AiOptions): Promise<FusionFramewor
     const service = await framework.serviceDiscovery.resolveService('ai');
     const scopes = service.scopes ?? service.defaultScopes ?? [];
 
+    if (debug) {
+      console.debug('[debug] AI service URL:', service.uri);
+      console.debug('[debug] AI service scopes:', scopes);
+    }
+
     // Pre-cache a token for the AI service scopes so strategy callbacks
     // don't attempt (and fail) a silent acquisition later.
     const token = await framework.auth.acquireAccessToken({ request: { scopes } });
     if (!token) throw new Error('Failed to acquire access token for the AI service.');
+
+    if (debug) console.debug('[debug] Token acquired successfully');
 
     return framework;
   };

--- a/packages/cli-plugins/ai-index/src/bin/embed.ts
+++ b/packages/cli-plugins/ai-index/src/bin/embed.ts
@@ -152,8 +152,20 @@ const MAX_RETRIES = 4;
  */
 export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
   const { framework, options, config, filePatterns } = binOptions;
+  const debug = options.debug ?? false;
 
   console.log(`📇 Index: ${options.indexName}`);
+
+  if (debug) {
+    console.debug('[debug] Embed model:', options.embedModel);
+    console.debug('[debug] File patterns:', filePatterns);
+    console.debug('[debug] Allowed patterns:', config.index?.patterns ?? ['**/*.ts', '**/*.tsx', '**/*.md', '**/*.mdx']);
+    console.debug('[debug] Raw patterns:', config.index?.rawPatterns ?? []);
+    console.debug('[debug] Ignore patterns:', config.index?.ignore ?? defaultIgnore);
+    console.debug('[debug] Diff mode:', options.diff);
+    console.debug('[debug] Dry run:', options.dryRun);
+    console.debug('[debug] Clean:', options.clean);
+  }
 
   const progress = new ProgressDisplay();
 
@@ -227,6 +239,9 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
     }),
     filter((file) => {
       const matches = multimatch(file.relativePath, allowedFilePatterns);
+      if (debug && matches.length === 0) {
+        console.debug('[debug] Skipped (no pattern match):', file.relativePath);
+      }
       return matches.length > 0;
     }),
     tap((file) => {
@@ -283,6 +298,9 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
     mergeMap(async (file) => {
       const documents = await parseMarkdownFile(file);
       docCount++;
+      if (debug) {
+        console.debug(`[debug] Markdown ${file.relativePath} → ${documents.length} chunk(s)`);
+      }
       progress.update(LINE_PARSE, `📄 Parsing [${docCount}] ${file.relativePath}`);
       return { status: file.status, documents };
     }),
@@ -294,6 +312,9 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
     map((file) => {
       const documents = parseTsDocFromFileSync(file);
       docCount++;
+      if (debug) {
+        console.debug(`[debug] TypeScript ${file.relativePath} → ${documents.length} chunk(s)`);
+      }
       progress.update(LINE_PARSE, `📄 Parsing [${docCount}] ${file.relativePath}`);
       return { status: file.status, documents };
     }),
@@ -337,8 +358,11 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
     bufferTime(EMBED_BUFFER_FLUSH_MS, null, EMBED_BATCH_SIZE),
     filter((batch) => batch.length > 0),
     mergeMap(
-      (batch) =>
-        from(embeddingService.embedDocuments(batch.map((d) => d.pageContent))).pipe(
+      (batch) => {
+        if (debug) {
+          console.debug(`[debug] Embedding batch of ${batch.length} documents`);
+        }
+        return from(embeddingService.embedDocuments(batch.map((d) => d.pageContent))).pipe(
           retry({
             count: MAX_RETRIES,
             delay: (error, retryIndex) => {
@@ -378,7 +402,8 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
               return { ...document, metadata };
             });
           }),
-        ),
+        );
+      },
       EMBED_BATCH_CONCURRENCY,
     ),
     finalize(() => {
@@ -398,6 +423,9 @@ export async function embed(binOptions: EmbeddingsBinOptions): Promise<void> {
         return undefined;
       }
       if (!options.dryRun) {
+        if (debug) {
+          console.debug(`[debug] Upserting batch of ${documents.length} documents:`, documents.map((d) => d.id));
+        }
         await vectorStoreService.addDocuments(documents);
       }
       return {

--- a/packages/cli-plugins/ai-index/src/bin/get-diff.ts
+++ b/packages/cli-plugins/ai-index/src/bin/get-diff.ts
@@ -25,6 +25,11 @@ export async function getDiff(options: CommandOptions): Promise<ChangedFile[]> {
     }
 
     console.log(`📝 Found ${changedFiles.length} changed files matching patterns`);
+    if (options.debug) {
+      for (const file of changedFiles) {
+        console.debug(`[debug] ${file.status}: ${file.filepath}`);
+      }
+    }
     return changedFiles;
   } catch (error) {
     console.error(`❌ Git diff error: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/packages/cli/src/cli/commands/app/build.ts
+++ b/packages/cli/src/cli/commands/app/build.ts
@@ -50,7 +50,7 @@ export const command = createCommand('build')
       '  $ ffc app build app.manifest.dev.ts --debug',
     ].join('\n'),
   )
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .argument('[manifest]', 'Manifest file to use for building (e.g., app.manifest.ts)')
   .action(async (manifest, opt) => {
     const log = new ConsoleLogger('app:build', { debug: opt.debug });

--- a/packages/cli/src/cli/commands/app/dev.ts
+++ b/packages/cli/src/cli/commands/app/dev.ts
@@ -56,7 +56,7 @@ export const command = createCommand('dev')
       'See https://equinor.github.io/fusion-framework/cli/docs/dev-server-config.html for configuration options.',
     ].join('\n'),
   )
-  .option('--debug', 'Enable debug mode')
+  .option('--debug', 'Enable debug mode', !!process.env.RUNNER_DEBUG)
   .option('--manifest <path>', 'Path to the app manifest file (app.manifest[.env]?.[ts,js,json])')
   .option('--config <path>', 'Path to the app config file (app.config[.env]?.[ts,js,json])')
   .option('--env <environment>', 'Runtime environment for the dev server', 'local')

--- a/packages/cli/src/cli/commands/app/manifest.ts
+++ b/packages/cli/src/cli/commands/app/manifest.ts
@@ -54,7 +54,7 @@ export const command = createCommand('manifest')
       '  $ ffc app manifest --debug',
     ].join('\n'),
   )
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .option('-o, --output <string>', 'Output the result to stdout or a file', 'stdout')
   .option('-s, --silent', 'Silent mode, suppresses output except errors')
   .argument('[manifest]', 'Manifest build file to use (e.g., app.manifest[.env]?.[ts,js,json])')

--- a/packages/cli/src/cli/commands/app/pack.ts
+++ b/packages/cli/src/cli/commands/app/pack.ts
@@ -71,7 +71,7 @@ export const command = createCommand('pack')
     'Directory where the archive will be saved (default: current working directory)',
     process.cwd(),
   )
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .option(
     '-s, --snapshot [identifier]',
     'Generate a snapshot version (optionally with custom identifier). The identifier defaults to "snapshot" if not provided.',

--- a/packages/cli/src/cli/commands/auth/token.ts
+++ b/packages/cli/src/cli/commands/auth/token.ts
@@ -56,7 +56,7 @@ export const command = createCommand('token')
       '  $ ffc auth token --tenant my-tenant --client my-client-id --silent',
     ].join('\n'),
   )
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .option('--silent', 'Only output the token (no extra logging)')
   .action(async (options) => {
     const log = options.silent ? null : new ConsoleLogger('auth:token', { debug: options.debug });

--- a/packages/cli/src/cli/commands/create/app.ts
+++ b/packages/cli/src/cli/commands/create/app.ts
@@ -186,7 +186,7 @@ export const createAppCommand = (name: string) =>
     .option('-d, --directory <path>', 'Directory to create the app in', '.')
     .option('--branch <branch>', 'Branch to checkout', 'main')
     .option('--clean', 'Clean the repo directory before cloning')
-    .option('--debug', 'Enable debug mode for verbose logging')
+    .option('--debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
     .option(
       '--git-protocol <protocol>',
       'Git protocol to use for cloning (https or ssh) - skips prompt if provided',

--- a/packages/cli/src/cli/commands/portal/build.ts
+++ b/packages/cli/src/cli/commands/portal/build.ts
@@ -43,7 +43,7 @@ export const command = createCommand('build')
       '',
     ].join('\n'),
   )
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .argument(
     '[manifest]',
     'Manifest build file to use for building (e.g., portal.manifest[.env]?.[ts|js|json])',

--- a/packages/cli/src/cli/commands/portal/config.ts
+++ b/packages/cli/src/cli/commands/portal/config.ts
@@ -64,7 +64,7 @@ export const command = withAuthOptions(
         '  $ ffc portal config --env prod my-custom.config.ts',
       ].join('\n'),
     )
-    .option('--debug', 'Enable debug mode for verbose logging')
+    .option('--debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
     .option('--silent', 'Silent mode, suppresses output except errors')
     .option(
       '--publish <name@version>',

--- a/packages/cli/src/cli/commands/portal/dev.ts
+++ b/packages/cli/src/cli/commands/portal/dev.ts
@@ -51,7 +51,7 @@ export const command = createCommand('dev')
       'See https://equinor.github.io/fusion-framework/cli/docs/dev-server-config.html for configuration options.',
     ].join('\n'),
   )
-  .option('--debug', 'Enable debug mode')
+  .option('--debug', 'Enable debug mode', !!process.env.RUNNER_DEBUG)
   .option('--env <environment>', 'Runtime environment for the dev server', 'local')
   .option('--port <port>', 'Port for the development server', '3000')
   .action(async (options) => {

--- a/packages/cli/src/cli/commands/portal/pack.ts
+++ b/packages/cli/src/cli/commands/portal/pack.ts
@@ -46,7 +46,7 @@ export const command = createCommand('pack')
     'Name of the output archive file (default: out/bundle.zip)',
     'out/bundle.zip',
   )
-  .option('-d, --debug [boolean]', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug [boolean]', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .option('--schema [string]', 'Schema file to use for validation')
   .argument('[manifest]', 'Manifest file to use for bundling (e.g., my-portal.manifest.ts)')
   .action(async (manifest, options) => {

--- a/packages/cli/src/cli/commands/portal/publish.ts
+++ b/packages/cli/src/cli/commands/portal/publish.ts
@@ -60,7 +60,7 @@ export const command = withAuthOptions(
         '  $ ffc portal publish --tag pr-1234',
       ].join('\n'),
     )
-    .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+    .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
     .addOption(createEnvOption({ allowDev: false }))
     .option(
       '-m, --manifest [string]',

--- a/packages/cli/src/cli/commands/portal/schema.ts
+++ b/packages/cli/src/cli/commands/portal/schema.ts
@@ -54,7 +54,7 @@ export const command = createCommand('schema')
   )
   .addOption(createEnvOption({ allowDev: true }))
   .option('-o, --output <string>', 'Output file name (default: stdout)', 'stdout')
-  .option('-d, --debug', 'Enable debug mode for verbose logging', false)
+  .option('-d, --debug', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
   .option('-v, --validate <file>', 'Validate the generated schema against a JSON file')
   .argument('[schema]', 'Schema build file to use (e.g., portal.schema[.env]?.[ts,js,json])')
   .action(async (manifest, args) => {

--- a/packages/cli/src/cli/commands/portal/upload.ts
+++ b/packages/cli/src/cli/commands/portal/upload.ts
@@ -49,7 +49,7 @@ export const command = withAuthOptions(
         '  $ ffc portal upload --debug',
       ].join('\n'),
     )
-    .option('-d, --debug [boolean]', 'Enable debug mode for verbose logging', false)
+    .option('-d, --debug [boolean]', 'Enable debug mode for verbose logging', !!process.env.RUNNER_DEBUG)
     .addOption(createEnvOption({ allowDev: false }))
     .argument('<bundle>', 'Portal bundle to upload (e.g., out/bundle.zip)')
     .action(async (bundle, options) => {


### PR DESCRIPTION
**Why is this change needed?**

When GitHub Actions workflows run in debug mode (`RUNNER_DEBUG=1`), the CLI commands had no way to automatically enable verbose logging. Operators had to manually add `--debug` flags to every CLI invocation in workflow YAML files.

**What is the current behavior?**

All CLI `--debug` flags default to `false` and must be explicitly passed. AI commands (`ffc ai index add`, `ffc ai index create`, etc.) have no `--debug` option at all. Debug mode in GitHub Actions has no effect on CLI verbosity.

**What is the new behavior?**

- All AI commands gain a `-d, --debug` option via the `ai-base` plugin, bound to the `RUNNER_DEBUG` environment variable.
- `setupFramework` logs environment, auth mode, AI service URL, scopes, and token status when debug is active.
- The `ai index add` pipeline logs config details, skipped files, per-file chunk counts, embedding batch sizes, upsert document IDs, and git diff file listings.
- All existing app, portal, auth, and create commands now default `--debug` to `!!process.env.RUNNER_DEBUG`, so enabling GitHub Actions debug logging automatically enables CLI debug output everywhere.

**What is the intended behavior or invariant?**

When `RUNNER_DEBUG` is set (any truthy value), all CLI commands should produce verbose diagnostic output without requiring changes to workflow YAML. When the env var is absent, behavior is unchanged — debug defaults to `false`.

**Does this PR introduce a breaking change?**

No. Existing behavior is preserved when `RUNNER_DEBUG` is not set. The new `--debug` option on AI commands is additive.

**Impact assessment:**

- Breaking changes: No
- Version bump: `minor` for `cli-plugin-ai-base` (new option), `patch` for `cli-plugin-ai-index` and `cli` (debug logging and default change)
- Consumer impact: No action required — debug output is opt-in via env var or flag
- Downstream impact: None — the change is contained within CLI packages

**Review guidance:**

- Check the `RUNNER_DEBUG` env var binding in `ai-base/src/options/options.ts` — uses `z.coerce.boolean()` to handle `"1"` → `true`
- Verify debug log placement in `setup-framework.ts` and `embed.ts` covers the most useful diagnostic info
- Confirm the `!!process.env.RUNNER_DEBUG` default in app/portal commands doesn't interfere with explicit `--debug` flag usage

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)