### PR TITLE
feat(azure-identity): add Azure Identity auth module with OS-level token persistence

### DIFF
--- a/.changeset/fusion-framework-cli_azure-identity-migration.md
+++ b/.changeset/fusion-framework-cli_azure-identity-migration.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-cli": minor
+---
+
+Migrate CLI authentication from `@equinor/fusion-framework-module-msal-node` to `@equinor/fusion-framework-module-azure-identity`.
+
+`ffc auth login` and `ffc auth token` now use `InteractiveBrowserCredential` with OS-level token persistence — tokens survive across process restarts without re-prompting.
+
+Ref: https://github.com/equinor/fusion-core-tasks/issues/1067

--- a/.changeset/fusion-framework-cli_azure-identity-migration.md
+++ b/.changeset/fusion-framework-cli_azure-identity-migration.md
@@ -1,9 +1,9 @@
 ---
-"@equinor/fusion-framework-cli": minor
+"@equinor/fusion-framework-cli": major
 ---
 
-Migrate CLI authentication from `@equinor/fusion-framework-module-msal-node` to `@equinor/fusion-framework-module-azure-identity`.
+**BREAKING:** Replace CLI authentication backend from `@equinor/fusion-framework-module-msal-node` with `@equinor/fusion-framework-module-azure-identity`.
 
-`ffc auth login` and `ffc auth token` now use `InteractiveBrowserCredential` with OS-level token persistence — tokens survive across process restarts without re-prompting.
+`ffc auth login` and `ffc auth token` now use `InteractiveBrowserCredential` with OS-level token persistence — tokens survive across process restarts without re-prompting. The previous MSAL-based token cache is no longer used; users must re-authenticate with `ffc auth login` after upgrading.
 
 Ref: https://github.com/equinor/fusion-core-tasks/issues/1067

--- a/.changeset/fusion-framework-docs_azure-identity-page.md
+++ b/.changeset/fusion-framework-docs_azure-identity-page.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Add Azure Identity module documentation page and sidebar entry under Modules → Auth. Rename existing MSAL Node entry to "NodeJS (MSAL - legacy)".

--- a/.changeset/fusion-framework-module-azure-identity_initial-release.md
+++ b/.changeset/fusion-framework-module-azure-identity_initial-release.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-module-azure-identity": minor
+---
+
+Add new Azure Identity authentication module with three auth modes:
+
+- **`interactive`** — `InteractiveBrowserCredential` with `AuthenticationRecord` persistence via OS keychain (Keychain / DPAPI / libsecret)
+- **`default_credential`** — `DefaultAzureCredential` for CI/CD, managed identity, and Azure CLI
+- **`token_only`** — static access token passthrough
+
+Includes a type-safe configurator with mode-specific setters (`setInteractive`, `setDefaultCredential`, `setTokenOnly`) and convenience enablers for each mode.
+
+Ref: https://github.com/equinor/fusion-core-tasks/issues/1067

--- a/.github/workflows/index-docs.yml
+++ b/.github/workflows/index-docs.yml
@@ -108,14 +108,6 @@ jobs:
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           allow-no-subscriptions: true
 
-      - name: Acquire Fusion token
-        run: |
-          token=$(az account get-access-token \
-            --scope ${{ vars.FUSION_AI_SP_SCOPE }} \
-            --query accessToken --output tsv)
-          echo "::add-mask::${token}"
-          echo "FUSION_TOKEN=${token}" >> "$GITHUB_ENV"
-
       - name: Ensure index exists
         env:
           FUSION_ENV: ${{ vars.FUSION_ENV }}

--- a/packages/cli-plugins/ai-base/src/setup-framework.ts
+++ b/packages/cli-plugins/ai-base/src/setup-framework.ts
@@ -5,41 +5,16 @@ import { initializeFramework, FusionEnv } from '@equinor/fusion-framework-cli/bi
 import type { FusionFrameworkSettings, FusionFramework } from '@equinor/fusion-framework-cli/bin';
 import type { AiOptions } from './options/index.js';
 
-import { execFileSync } from 'node:child_process';
-
 /** Initialized framework instance with the AI module. */
 export type FrameworkInstance = FusionFramework<[AIModule]>;
 
 /**
- * Check whether an error (possibly wrapped in a cause chain) is an
- * authentication-related failure that may be recoverable via interactive login.
- *
- * @internal
- */
-const isAuthError = (error: unknown): boolean => {
-  let current: unknown = error;
-  while (current) {
-    if (current instanceof Error) {
-      if (
-        current.name === 'NoAccountsError' ||
-        current.name === 'SilentTokenAcquisitionError' ||
-        current.message.includes('No accounts found')
-      ) {
-        return true;
-      }
-    }
-    current = (current as { cause?: unknown }).cause;
-  }
-  return false;
-};
-
-/**
  * Creates a Fusion Framework instance with the AI module enabled.
  *
- * Initialises the Fusion Framework with service discovery and MSAL auth,
- * resolves the `'ai'` service endpoint, and pre-caches a bearer token.
- * If MSAL has no cached credentials, the CLI's interactive `auth login`
- * flow is spawned automatically before retrying.
+ * Uses Azure Identity's `DefaultAzureCredential` by default, which resolves
+ * credentials from the environment (OIDC, managed identity, Azure CLI, etc.).
+ * When an explicit token is provided via `--token` or `FUSION_TOKEN`, that
+ * token is used directly instead.
  *
  * @param options - CLI options resolved by {@link withOptions}.
  * @returns A fully initialised framework instance with the AI module.
@@ -48,23 +23,18 @@ const isAuthError = (error: unknown): boolean => {
 export const setupFramework = async (options: AiOptions): Promise<FusionFramework<[AIModule]>> => {
   const debug = options.debug ?? false;
 
-  // Service-discovery mode: resolve URL + scopes from Fusion service registry
+  // Auth strategy:
+  // 1. Explicit token (--token / FUSION_TOKEN) → MSAL token_only passthrough
+  // 2. Everything else → Azure Identity (DefaultAzureCredential)
   const auth: FusionFrameworkSettings['auth'] = options.token
     ? { token: options.token }
-    : {
-        tenantId: options.tenantId ?? '3aa4a235-b6e2-48d5-9195-7fcf05b459b0',
-        clientId: options.clientId ?? 'a318b8e1-0295-4e17-98d5-35f67dfeba14',
-      };
+    : { defaultCredential: true };
 
   const env = (options.env as FusionEnv) ?? FusionEnv.ContinuesIntegration;
 
   if (debug) {
     console.debug('[debug] Environment:', env);
-    console.debug('[debug] Auth mode:', options.token ? 'static-token' : 'MSAL');
-    if (!options.token) {
-      console.debug('[debug] Tenant ID:', (auth as { tenantId: string }).tenantId);
-      console.debug('[debug] Client ID:', (auth as { clientId: string }).clientId);
-    }
+    console.debug('[debug] Auth mode:', options.token ? 'static-token' : 'azure-identity');
   }
 
   /** Initialise the framework, resolve the AI service, and pre-cache tokens. */
@@ -95,28 +65,7 @@ export const setupFramework = async (options: AiOptions): Promise<FusionFramewor
     return framework;
   };
 
-  try {
-    return await initAndSetup();
-  } catch (error: unknown) {
-    // If the failure is auth-related and we're not using a static token,
-    // spawn the CLI's own `auth login` (starts local server + browser)
-    // and retry the full init sequence.
-    if (!isAuthError(error) || options.token) throw error;
-
-    const cliEntry = process.argv[1];
-    if (!cliEntry) {
-      throw new Error(
-        'Failed to acquire access token and could not determine CLI path for interactive login.',
-      );
-    }
-
-    console.log('No cached credentials — launching interactive login…');
-    execFileSync(process.execPath, [cliEntry, 'auth', 'login'], {
-      stdio: 'inherit',
-    });
-
-    return await initAndSetup();
-  }
+  return await initAndSetup();
 };
 
 export default setupFramework;

--- a/packages/cli-plugins/ai-base/src/setup-framework.ts
+++ b/packages/cli-plugins/ai-base/src/setup-framework.ts
@@ -24,7 +24,7 @@ export const setupFramework = async (options: AiOptions): Promise<FusionFramewor
   const debug = options.debug ?? false;
 
   // Auth strategy:
-  // 1. Explicit token (--token / FUSION_TOKEN) → MSAL token_only passthrough
+  // 1. Explicit token (--token / FUSION_TOKEN) → direct token passthrough
   // 2. Everything else → Azure Identity (DefaultAzureCredential)
   const auth: FusionFrameworkSettings['auth'] = options.token
     ? { token: options.token }

--- a/packages/cli/docs/auth.md
+++ b/packages/cli/docs/auth.md
@@ -1,16 +1,16 @@
-The Fusion Framework CLI provides secure, robust authentication for both automation and interactive development scenarios by leveraging Microsoft's MSAL (Microsoft Authentication Library) and Azure Active Directory (Azure AD). Authentication is handled through the Fusion Framework for Node.js, using the `@equinor/fusion-framework-module-msal-node` package, which is built on top of Microsoft's official `msal-node` library. This ensures standards-compliant, up-to-date authentication flows and seamless integration across Fusion Framework applications and tools.
+The Fusion Framework CLI provides secure, robust authentication for both automation and interactive development scenarios using Azure Identity and Azure Active Directory (Azure AD). Authentication is handled through the `@equinor/fusion-framework-module-azure-identity` package, which wraps `@azure/identity` credentials with OS-level token caching via `@azure/identity-cache-persistence`. This ensures standards-compliant, up-to-date authentication flows and seamless integration across Fusion Framework applications and tools.
 
-For detailed information about the underlying authentication module, see the [MSAL Node Module documentation](https://equinor.github.io/fusion-framework/modules/auth/msal-node/).
+For detailed information about the underlying authentication module, see the [Azure Identity Module README](../../packages/modules/azure-identity/README.md).
 
 > [!TIP]
 > The CLI exposes two binary aliases: `fusion-framework-cli` and `ffc`. All examples below use the long form, but you can substitute `ffc` anywhere — e.g. `ffc auth login`, `ffc auth token`.
 
 ## Key features
 - **Multiple authentication modes:**
+  - `interactive`: Browser-based Azure AD login with OS-level token caching (CLI tools, development).
+  - `default_credential`: Ambient credential chain — environment variables, managed identity, Azure CLI (CI/CD, infrastructure).
   - `token_only`: Use a pre-provided token (e.g., for CI/CD and automation).
-  - `silent`: Acquire tokens silently using cached or refresh tokens (background services, scripts).
-  - `interactive`: Prompt for authentication via a local HTTP server (CLI tools, development).
-- **Secure token storage:** Tokens are encrypted at rest using platform-specific mechanisms (e.g., Secure Enclave on macOS, DPAPI on Windows).
+- **Secure token storage:** Tokens and authentication records are encrypted at rest using platform-specific mechanisms (Keychain on macOS, DPAPI on Windows, libsecret on Linux) via `@azure/msal-node-extensions`.
 - **Consistent experience:** The same authentication logic and token handling is used across CLI and app environments.
 
 ## Azure AD Concepts: Tenant, Client App, and Scopes
@@ -95,7 +95,7 @@ ffc auth token
 > # or: export FUSION_TOKEN=$(ffc auth token --silent)
 > ```
 
-> [!Note] This command requires an interactive user context and MSAL Node. It is not suitable for CI/CD environments, as there is no user available in those scenarios. Use it for local development, testing, or whenever you need to preserve a Fusion token for your own scripts or tools.
+> [!Note] This command requires an interactive user context. It is not suitable for CI/CD environments, as there is no user available in those scenarios. Use it for local development, testing, or whenever you need to preserve a Fusion token for your own scripts or tools.
 
 ## CI/CD
 
@@ -174,6 +174,7 @@ runs:
 
 ## Additional Resources
 
-- [MSAL Node Module Documentation](https://equinor.github.io/fusion-framework/modules/auth/msal-node/) - Complete reference for the underlying authentication module
-- [libsecret Setup Guide](https://equinor.github.io/fusion-framework/modules/auth/msal-node/docs/libsecret.html) - Platform-specific setup for secure credential storage on Linux systems
+- [Azure Identity Module README](../../packages/modules/azure-identity/README.md) - Complete reference for the underlying authentication module
+- [Azure Identity documentation](https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme) - Microsoft's official Azure Identity SDK docs
+- [libsecret Setup Guide](https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-cache-persistence-readme) - Platform-specific setup for secure credential storage
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@equinor/fusion-framework-dev-portal": "workspace:*",
     "@equinor/fusion-framework-dev-server": "workspace:*",
-    "@equinor/fusion-framework-module-msal-node": "workspace:*",
+    "@equinor/fusion-framework-module-azure-identity": "workspace:*",
     "@equinor/fusion-framework-vite-plugin-raw-imports": "workspace:*",
     "@equinor/fusion-imports": "workspace:*",
     "@types/inquirer": "^9.0.9",

--- a/packages/cli/src/bin/framework.node.ts
+++ b/packages/cli/src/bin/framework.node.ts
@@ -3,7 +3,10 @@ import {
   type ModulesInstance,
   type AnyModule,
 } from '@equinor/fusion-framework-module';
-import { enableAuthModule, type MsalNodeModule } from '@equinor/fusion-framework-module-msal-node';
+import {
+  enableAzureIdentityAuth,
+  type AzureIdentityModule,
+} from '@equinor/fusion-framework-module-azure-identity';
 import { type HttpModule, module as httpModule } from '@equinor/fusion-framework-module-http';
 import {
   type ServiceDiscoveryModule,
@@ -12,9 +15,7 @@ import {
 import isContinuousIntegration from 'is-ci';
 
 // Define the module types used in the framework instance
-// This tuple ensures type safety for the framework's module composition
-// Add or remove modules here to change the framework's capabilities
-type Modules = [MsalNodeModule, HttpModule, ServiceDiscoveryModule];
+type Modules = [AzureIdentityModule, HttpModule, ServiceDiscoveryModule];
 
 /**
  * Type representing the initialized Fusion Framework instance.
@@ -82,12 +83,20 @@ interface AuthInteractiveOptions extends Omit<AuthSilentOptions, 'interactive'> 
 }
 
 /**
+ * Auth option for Azure Identity's DefaultAzureCredential.
+ * No configuration needed — credentials are resolved from the environment.
+ */
+interface AuthDefaultCredentialOptions {
+  defaultCredential: true;
+}
+
+/**
  * Settings for initializing the Fusion Framework.
  * Includes environment, authentication, and service discovery options.
  */
 export type FusionFrameworkSettings = {
   env?: (typeof FusionEnv)[keyof typeof FusionEnv];
-  auth: AuthTokenOptions | AuthSilentOptions | AuthInteractiveOptions;
+  auth: AuthTokenOptions | AuthSilentOptions | AuthInteractiveOptions | AuthDefaultCredentialOptions;
   serviceDiscovery?: {
     url?: string;
     scope?: string[];
@@ -140,37 +149,49 @@ export const configureFramework = (
   // Enable the service discovery module
   enableServiceDiscovery(configurator);
 
-  // Enable the authentication module with custom configuration logic
-  enableAuthModule(configurator, (builder) => {
-    const { auth } = config;
-    // Handle direct token authentication
-    if ('token' in auth && auth.token) {
-      const { token } = auth as AuthTokenOptions;
-      builder.setMode('token_only');
-      builder.setAccessToken(token);
+  // Enable the authentication module — Azure Identity for all modes
+  const { auth } = config;
+
+  enableAzureIdentityAuth(configurator, (builder) => {
+    if ('defaultCredential' in auth && auth.defaultCredential) {
+      // Use DefaultAzureCredential (CI/CD, managed identity, OIDC)
+      builder.setDefaultCredential();
       return;
     }
 
-    // Handle silent or interactive authentication
-    const { clientId, tenantId, interactive } = auth as AuthSilentOptions;
+    if ('token' in auth && auth.token) {
+      // Use a pre-obtained static token
+      builder.setTokenOnly(auth.token);
+      return;
+    }
+
+    // Interactive or silent — both use InteractiveBrowserCredential.
+    // The credential silently uses cached tokens and only opens a browser
+    // when no cached credentials are available.
+    const { clientId, tenantId } = auth as AuthSilentOptions;
     if (!clientId || !tenantId) {
-      // Both clientId and tenantId are required for these modes
       throw new Error('clientId and tenantId are required for auth module');
     }
 
-    // Set client configuration for authentication
-    builder.setClientConfig(tenantId, clientId);
-
-    // Set authentication mode based on interactive flag
-    builder.setMode(interactive ? 'interactive' : 'silent');
-    if (interactive) {
-      // For interactive mode, server configuration is required
+    if ('interactive' in auth && auth.interactive) {
       const { server } = auth as AuthInteractiveOptions;
       if (!server.port) {
         throw new Error('server.port is required for interactive mode');
       }
-      builder.setServerPort(server.port);
-      builder.setServerOnOpen(server.onOpen);
+      builder.setInteractive({
+        tenantId,
+        clientId,
+        redirectPort: server.port,
+        onOpen: server.onOpen,
+      });
+    } else {
+      // Non-interactive callers (token, logout) — use a default port.
+      // InteractiveBrowserCredential will use cached tokens silently.
+      builder.setInteractive({
+        tenantId,
+        clientId,
+        redirectPort: 49741,
+      });
     }
   });
 

--- a/packages/cli/src/bin/framework.node.ts
+++ b/packages/cli/src/bin/framework.node.ts
@@ -96,7 +96,11 @@ interface AuthDefaultCredentialOptions {
  */
 export type FusionFrameworkSettings = {
   env?: (typeof FusionEnv)[keyof typeof FusionEnv];
-  auth: AuthTokenOptions | AuthSilentOptions | AuthInteractiveOptions | AuthDefaultCredentialOptions;
+  auth:
+    | AuthTokenOptions
+    | AuthSilentOptions
+    | AuthInteractiveOptions
+    | AuthDefaultCredentialOptions;
   serviceDiscovery?: {
     url?: string;
     scope?: string[];

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -70,19 +70,13 @@ export const command = createCommand('login')
     try {
       log.start('Logging in...');
       const record = await framework.auth.login({ request: { scopes } });
-      const authRecord = record as {
-        username?: string;
-        tenantId?: string;
-        clientId?: string;
-        authority?: string;
-      };
-      log.info('username:', chalk.green(authRecord.username ?? 'unknown'));
-      log.info('tenant:  ', chalk.yellow(authRecord.tenantId ?? 'unknown'));
-      log.info('client:  ', chalk.yellow(authRecord.clientId ?? 'unknown'));
+      log.info('username:', chalk.green(record.username));
+      log.info('tenant:  ', chalk.yellow(record.tenantId));
+      log.info('client:  ', chalk.yellow(record.clientId));
       for (const scope of scopes) {
         log.info('scope:   ', chalk.dim(scope));
       }
-      log.succeed('Successfully logged in', chalk.greenBright(authRecord.username ?? 'unknown'));
+      log.succeed('Successfully logged in', chalk.greenBright(record.username));
     } catch (error) {
       log.fail(
         'Failed to log in 🥺',

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -82,7 +82,7 @@ export const command = createCommand('login')
       for (const scope of scopes) {
         log.info('scope:   ', chalk.dim(scope));
       }
-      log.succeed('Successfully logged in', chalk.greenBright(authRecord.username));
+      log.succeed('Successfully logged in', chalk.greenBright(authRecord.username ?? 'unknown'));
     } catch (error) {
       log.fail(
         'Failed to log in 🥺',

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -69,14 +69,20 @@ export const command = createCommand('login')
 
     try {
       log.start('Logging in...');
-      const authToken = await framework.auth.login({ request: { scopes } });
-      log.info('username:', chalk.green(authToken.account?.username));
-      log.info('tenant:  ', chalk.yellow(authToken.tenantId));
-      log.info('audience:', chalk.yellow(authToken.account?.idTokenClaims?.aud));
-      for (const scope of authToken.scopes) {
+      const record = await framework.auth.login({ request: { scopes } });
+      const authRecord = record as {
+        username?: string;
+        tenantId?: string;
+        clientId?: string;
+        authority?: string;
+      };
+      log.info('username:', chalk.green(authRecord.username ?? 'unknown'));
+      log.info('tenant:  ', chalk.yellow(authRecord.tenantId ?? 'unknown'));
+      log.info('client:  ', chalk.yellow(authRecord.clientId ?? 'unknown'));
+      for (const scope of scopes) {
         log.info('scope:   ', chalk.dim(scope));
       }
-      log.succeed('Successfully logged in', chalk.greenBright(authToken.account?.name));
+      log.succeed('Successfully logged in', chalk.greenBright(authRecord.username));
     } catch (error) {
       log.fail(
         'Failed to log in 🥺',

--- a/packages/cli/src/cli/commands/auth/token.ts
+++ b/packages/cli/src/cli/commands/auth/token.ts
@@ -1,6 +1,7 @@
 import { createCommand } from 'commander';
 
 import { ConsoleLogger, initializeFramework } from '@equinor/fusion-framework-cli/bin';
+import { NoCredentialError } from '@equinor/fusion-framework-module-azure-identity';
 
 import { withAuthOptions } from '../../options/auth.js';
 
@@ -84,7 +85,7 @@ export const command = createCommand('token')
         log?.info('Access token:', accessToken);
       }
     } catch (error) {
-      if (!options.silent && error instanceof Error && error.message.includes('no token')) {
+      if (!options.silent && error instanceof NoCredentialError) {
         log?.fail('No cached credentials found, please login first');
       } else {
         throw error;

--- a/packages/cli/src/cli/commands/auth/token.ts
+++ b/packages/cli/src/cli/commands/auth/token.ts
@@ -1,7 +1,5 @@
 import { createCommand } from 'commander';
 
-import { NoAccountsError } from '@equinor/fusion-framework-module-msal-node/error';
-
 import { ConsoleLogger, initializeFramework } from '@equinor/fusion-framework-cli/bin';
 
 import { withAuthOptions } from '../../options/auth.js';
@@ -86,8 +84,8 @@ export const command = createCommand('token')
         log?.info('Access token:', accessToken);
       }
     } catch (error) {
-      if (!options.silent && error instanceof NoAccountsError) {
-        log?.fail('No accounts found, please login first');
+      if (!options.silent && error instanceof Error && error.message.includes('no token')) {
+        log?.fail('No cached credentials found, please login first');
       } else {
         throw error;
       }

--- a/packages/modules/azure-identity/README.md
+++ b/packages/modules/azure-identity/README.md
@@ -1,0 +1,169 @@
+# @equinor/fusion-framework-module-azure-identity
+
+Azure Identity authentication module for the Fusion Framework.
+Provides three authentication modes — ambient credentials, interactive browser login, and static token — all registering under the `'auth'` module slot as a drop-in replacement for `@equinor/fusion-framework-module-msal-node`.
+
+## When to use
+
+| Scenario | Mode |
+|---|---|
+| CI/CD with OIDC (GitHub Actions `azure/login`, Azure Pipelines) | `default_credential` |
+| Managed identity (Azure VMs, App Service, Container Apps) | `default_credential` |
+| Azure CLI login (`az login`) flowing through automatically | `default_credential` |
+| CLI tools requiring user sign-in via browser | `interactive` |
+| Scripts with a pre-obtained `FUSION_TOKEN` | `token_only` |
+
+Both this module and `@equinor/fusion-framework-module-msal-node` register under the `'auth'` slot, so only one can be active at a time.
+
+## Install
+
+```sh
+pnpm add @equinor/fusion-framework-module-azure-identity
+```
+
+## Quick start
+
+### Default credential (CI/CD, managed identity)
+
+No configuration needed — credentials are resolved from the environment automatically.
+
+```typescript
+import { enableAzureIdentityAuth } from '@equinor/fusion-framework-module-azure-identity';
+
+enableAzureIdentityAuth(configurator);
+```
+
+### Interactive browser login
+
+Opens the user's default browser for Azure AD login. Tokens and the `AuthenticationRecord` are cached to the OS keychain so subsequent invocations resolve silently.
+
+```typescript
+import { enableAzureIdentityInteractive } from '@equinor/fusion-framework-module-azure-identity';
+
+enableAzureIdentityInteractive(configurator, {
+  tenantId: '3aa4a235-...',
+  clientId: 'a318b8e1-...',
+  redirectPort: 49741,
+  onOpen: (url) => console.log(`Open: ${url}`),
+});
+```
+
+### Static token
+
+Use a pre-obtained access token. Login and logout are not supported.
+
+```typescript
+import { enableAzureIdentityTokenOnly } from '@equinor/fusion-framework-module-azure-identity';
+
+enableAzureIdentityTokenOnly(configurator, process.env.FUSION_TOKEN!);
+```
+
+### Acquiring tokens
+
+After initialisation, acquire tokens the same way as with the MSAL module:
+
+```typescript
+const token = await framework.auth.acquireAccessToken({
+  request: { scopes: ['api://my-api/.default'] },
+});
+```
+
+## Authentication modes
+
+### `default_credential` — ambient environment
+
+Uses `DefaultAzureCredential` which tries these sources in order:
+
+1. **Environment variables** (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE`, etc.)
+2. **Workload identity** (Kubernetes pods with Azure Workload Identity)
+3. **Managed identity** (Azure VMs, App Service, Container Apps)
+4. **Azure CLI** (`az login` session)
+5. **Azure PowerShell** (`Connect-AzAccount` session)
+6. **Azure Developer CLI** (`azd auth login` session)
+
+In GitHub Actions after `azure/login@v3` with OIDC, option 1 is used automatically.
+
+`login()` and `logout()` throw — there is no interactive session to manage.
+
+### `interactive` — browser-based login
+
+Uses `InteractiveBrowserCredential` with an authorization code flow through a localhost redirect. Designed for CLI tools (`ffc auth login`, `ffc auth token`).
+
+- On first run, opens the browser for Azure AD login
+- Saves the `AuthenticationRecord` to OS-level secure storage via `@azure/msal-node-extensions` (Keychain on macOS, DPAPI on Windows, libsecret on Linux)
+- On subsequent runs, loads the record and acquires tokens silently from the cached credential
+
+```typescript
+// Explicit login (opens browser)
+const record = await framework.auth.login({
+  request: { scopes: ['api://my-api/.default'] },
+});
+console.log('Logged in as', record.username);
+
+// Silent token acquisition (no browser)
+const token = await framework.auth.acquireAccessToken({
+  request: { scopes: ['api://my-api/.default'] },
+});
+
+// Clear cached credentials
+await framework.auth.logout();
+```
+
+### `token_only` — static access token
+
+Returns a pre-obtained token string. `login()` and `logout()` throw.
+
+## Token cache persistence
+
+The module registers `cachePersistencePlugin` from `@azure/identity-cache-persistence` at load time, enabling encrypted OS-level token caching:
+
+| Platform | Backend |
+|---|---|
+| macOS | Keychain |
+| Windows | DPAPI |
+| Linux | libsecret |
+
+In `interactive` mode, the `AuthenticationRecord` (account metadata that tells the credential which cached tokens to look up) is additionally stored via `@azure/msal-node-extensions` secure persistence.
+
+## Configurator API
+
+The generic `enableAzureIdentityAuth` accepts a callback for full control:
+
+```typescript
+enableAzureIdentityAuth(configurator, (builder) => {
+  // Option A — mode-specific setter
+  builder.setInteractive({ tenantId, clientId, redirectPort: 49741 });
+
+  // Option B — full config object (discriminated union)
+  builder.setConfig({
+    mode: 'interactive',
+    tenantId,
+    clientId,
+    redirectPort: 49741,
+  });
+
+  // Option C — default credential (no args)
+  builder.setDefaultCredential();
+
+  // Option D — static token
+  builder.setTokenOnly(token);
+});
+```
+
+## Exports
+
+| Export | Description |
+|---|---|
+| `enableAzureIdentityAuth` | Generic enabler with configurator callback |
+| `enableAzureIdentityDefaultCredential` | One-liner enabler for `default_credential` mode |
+| `enableAzureIdentityInteractive` | One-liner enabler for `interactive` mode |
+| `enableAzureIdentityTokenOnly` | One-liner enabler for `token_only` mode |
+| `AzureIdentityAuthConfigurator` | Configurator class with type-safe setters |
+| `AzureIdentityAuthConfig` | Discriminated union config type |
+| `InteractiveAuthOptions` | Options for interactive mode |
+| `AuthProviderDefaultCredential` | Provider class for ambient credentials |
+| `AuthProviderInteractiveBrowser` | Provider class for browser login |
+| `AuthProviderTokenOnly` | Provider class for static tokens |
+| `IAuthProvider` | Auth provider interface |
+| `AzureIdentityModule` | Module type for generic parameters |
+| `azureIdentityModule` | Raw module definition |

--- a/packages/modules/azure-identity/package.json
+++ b/packages/modules/azure-identity/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@equinor/fusion-framework-module-azure-identity",
+  "version": "0.1.0",
+  "description": "Fusion Framework authentication module using Azure Identity. Supports ambient credentials (DefaultAzureCredential), interactive browser login, and static token modes.",
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "prepack": "pnpm build"
+  },
+  "keywords": [
+    "azure",
+    "identity",
+    "auth",
+    "authentication",
+    "default-credential",
+    "managed-identity",
+    "oidc"
+  ],
+  "author": "",
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/equinor/fusion-framework.git",
+    "directory": "packages/modules/azure-identity"
+  },
+  "dependencies": {
+    "@azure/identity": "^4.9.1",
+    "@azure/identity-cache-persistence": "^1.3.0",
+    "@azure/msal-node-extensions": "^5.1.4",
+    "@equinor/fusion-framework-module": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/modules/azure-identity/src/AuthProvider.interface.ts
+++ b/packages/modules/azure-identity/src/AuthProvider.interface.ts
@@ -1,4 +1,21 @@
 /**
+ * Minimal authentication record returned by {@link IAuthProvider.login}.
+ *
+ * Mirrors the subset of `AuthenticationRecord` from `@azure/identity` that
+ * downstream consumers typically need, without coupling them to the Azure SDK.
+ */
+export interface AuthRecord {
+  /** The authenticated user's UPN or email address. */
+  readonly username: string;
+  /** The Azure AD tenant that issued the credential. */
+  readonly tenantId: string;
+  /** The application (client) ID used for authentication. */
+  readonly clientId: string;
+  /** The authority URL (e.g. `https://login.microsoftonline.com/<tenantId>`). */
+  readonly authority: string;
+}
+
+/**
  * Interface for authentication providers in the Fusion Framework.
  *
  * Provides a minimal contract for acquiring access tokens. Implementations may
@@ -9,8 +26,10 @@ export interface IAuthProvider {
   /**
    * Initiates a login flow. Not supported by all credential types — implementations
    * that do not support user interaction should throw.
+   *
+   * @returns The authentication record from the completed flow.
    */
-  login(options: { request: { scopes: string[] } }): Promise<unknown>;
+  login(options: { request: { scopes: string[] } }): Promise<AuthRecord>;
 
   /**
    * Clears any cached session. Not supported by all credential types — implementations

--- a/packages/modules/azure-identity/src/AuthProvider.interface.ts
+++ b/packages/modules/azure-identity/src/AuthProvider.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Interface for authentication providers in the Fusion Framework.
+ *
+ * Provides a minimal contract for acquiring access tokens. Implementations may
+ * support login/logout (interactive flows) or throw if those operations are not
+ * applicable to the credential type.
+ */
+export interface IAuthProvider {
+  /**
+   * Initiates a login flow. Not supported by all credential types — implementations
+   * that do not support user interaction should throw.
+   */
+  login(options: { request: { scopes: string[] } }): Promise<unknown>;
+
+  /**
+   * Clears any cached session. Not supported by all credential types — implementations
+   * that have no session state should throw.
+   */
+  logout(): Promise<void>;
+
+  /**
+   * Acquires an access token for the specified scopes.
+   *
+   * @param options - The scopes to request.
+   * @returns The access token string.
+   */
+  acquireAccessToken(options: {
+    request: { scopes: string[] };
+    interactive?: boolean;
+  }): Promise<string>;
+}

--- a/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
+++ b/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
@@ -1,16 +1,24 @@
 import { DefaultAzureCredential } from '@azure/identity';
-import { useIdentityPlugin } from '@azure/identity';
-import { cachePersistencePlugin } from '@azure/identity-cache-persistence';
 import type { IAuthProvider } from './AuthProvider.interface.js';
 import { NoCredentialError } from './errors.js';
 
-// Register the persistence plugin once at module load so that all
-// Azure Identity credentials (DefaultAzureCredential, InteractiveBrowserCredential)
-// can use encrypted OS-level token caching (Keychain on macOS, DPAPI on Windows,
-// libsecret on Linux). Placed here because this module is always imported first
-// via the barrel export, ensuring the plugin is available before any credential
-// is constructed.
-useIdentityPlugin(cachePersistencePlugin);
+let pluginRegistered = false;
+
+/**
+ * Lazily registers the Azure Identity cache persistence plugin on first use.
+ *
+ * Deferred to avoid loading `keytar` (a native C++ addon) at import time,
+ * which would fail in CI environments where the prebuilt binary is unavailable
+ * (e.g. `ERR_DLOPEN_FAILED`). The plugin is registered once before any
+ * credential is constructed.
+ */
+export async function ensureCachePersistencePlugin(): Promise<void> {
+  if (pluginRegistered) return;
+  const { useIdentityPlugin } = await import('@azure/identity');
+  const { cachePersistencePlugin } = await import('@azure/identity-cache-persistence');
+  useIdentityPlugin(cachePersistencePlugin);
+  pluginRegistered = true;
+}
 
 /**
  * Authentication provider backed by Azure Identity's `DefaultAzureCredential`.

--- a/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
+++ b/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
@@ -2,6 +2,7 @@ import { DefaultAzureCredential } from '@azure/identity';
 import { useIdentityPlugin } from '@azure/identity';
 import { cachePersistencePlugin } from '@azure/identity-cache-persistence';
 import type { IAuthProvider } from './AuthProvider.interface.js';
+import { NoCredentialError } from './errors.js';
 
 // Register the persistence plugin once at module load so that all
 // Azure Identity credentials (DefaultAzureCredential, InteractiveBrowserCredential)
@@ -40,7 +41,7 @@ export class AuthProviderDefaultCredential implements IAuthProvider {
    * Not supported — credentials are resolved from the environment.
    * @throws {Error} Always.
    */
-  login(_options: { request: { scopes: string[] } }): Promise<never> {
+  async login(_options: { request: { scopes: string[] } }): Promise<never> {
     throw new Error('Login is not supported in default_credential mode');
   }
 
@@ -48,7 +49,7 @@ export class AuthProviderDefaultCredential implements IAuthProvider {
    * Not supported — there is no session to clear.
    * @throws {Error} Always.
    */
-  logout(): Promise<never> {
+  async logout(): Promise<never> {
     throw new Error('Logout is not supported in default_credential mode');
   }
 
@@ -62,7 +63,7 @@ export class AuthProviderDefaultCredential implements IAuthProvider {
   async acquireAccessToken(options: { request: { scopes: string[] } }): Promise<string> {
     const tokenResponse = await this.#credential.getToken(options.request.scopes);
     if (!tokenResponse) {
-      throw new Error(
+      throw new NoCredentialError(
         'DefaultAzureCredential returned no token. Verify that Azure credentials are available in the environment.',
       );
     }

--- a/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
+++ b/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
@@ -1,0 +1,73 @@
+import { DefaultAzureCredential } from '@azure/identity';
+import { useIdentityPlugin } from '@azure/identity';
+import { cachePersistencePlugin } from '@azure/identity-cache-persistence';
+import type { IAuthProvider } from './AuthProvider.interface.js';
+
+// Register the persistence plugin once at module load so that all
+// Azure Identity credentials (DefaultAzureCredential, InteractiveBrowserCredential)
+// can use encrypted OS-level token caching (Keychain on macOS, DPAPI on Windows,
+// libsecret on Linux). Placed here because this module is always imported first
+// via the barrel export, ensuring the plugin is available before any credential
+// is constructed.
+useIdentityPlugin(cachePersistencePlugin);
+
+/**
+ * Authentication provider backed by Azure Identity's `DefaultAzureCredential`.
+ *
+ * Acquires tokens through the standard credential chain:
+ * environment variables, workload identity, managed identity, Azure CLI, etc.
+ *
+ * Ideal for CI/CD workflows where `azure/login` has established OIDC federation,
+ * or for services running with a managed identity.
+ *
+ * Login and logout are not applicable — credentials come from the ambient
+ * environment.
+ *
+ * @example
+ * ```typescript
+ * enableAzureIdentityAuth(configurator);
+ * // framework.auth.acquireAccessToken({ request: { scopes } });
+ * ```
+ */
+export class AuthProviderDefaultCredential implements IAuthProvider {
+  readonly #credential: DefaultAzureCredential;
+
+  constructor() {
+    this.#credential = new DefaultAzureCredential();
+  }
+
+  /**
+   * Not supported — credentials are resolved from the environment.
+   * @throws {Error} Always.
+   */
+  login(_options: { request: { scopes: string[] } }): Promise<never> {
+    throw new Error('Login is not supported in default_credential mode');
+  }
+
+  /**
+   * Not supported — there is no session to clear.
+   * @throws {Error} Always.
+   */
+  logout(): Promise<never> {
+    throw new Error('Logout is not supported in default_credential mode');
+  }
+
+  /**
+   * Acquires an access token using the `DefaultAzureCredential` chain.
+   *
+   * @param options - An object containing the scopes to request.
+   * @returns The access token string.
+   * @throws {Error} When no credential source is available or token acquisition fails.
+   */
+  async acquireAccessToken(options: { request: { scopes: string[] } }): Promise<string> {
+    const tokenResponse = await this.#credential.getToken(options.request.scopes);
+    if (!tokenResponse) {
+      throw new Error(
+        'DefaultAzureCredential returned no token. Verify that Azure credentials are available in the environment.',
+      );
+    }
+    return tokenResponse.token;
+  }
+}
+
+export default AuthProviderDefaultCredential;

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -1,0 +1,152 @@
+import {
+  InteractiveBrowserCredential,
+  type AuthenticationRecord,
+  serializeAuthenticationRecord,
+  deserializeAuthenticationRecord,
+} from '@azure/identity';
+import { PersistenceCreator, type IPersistence } from '@azure/msal-node-extensions';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { IAuthProvider } from './AuthProvider.interface.js';
+import type { InteractiveAuthOptions } from './configurator.js';
+
+/**
+ * Authentication provider backed by Azure Identity's `InteractiveBrowserCredential`.
+ *
+ * Opens the user's default browser for Azure AD login using an authorization code
+ * flow with a localhost redirect. Tokens are persisted to the OS keychain via
+ * `cachePersistencePlugin` (registered at module load in `AuthProviderDefaultCredential`).
+ *
+ * The {@link AuthenticationRecord} is stored via `@azure/msal-node-extensions`
+ * secure persistence (Keychain on macOS, DPAPI on Windows, libsecret on Linux)
+ * so that subsequent CLI invocations can silently acquire tokens from the cache
+ * without re-opening the browser.
+ *
+ * @example
+ * ```typescript
+ * const provider = await AuthProviderInteractiveBrowser.create({
+ *   tenantId: '3aa4a235-...',
+ *   clientId: 'a318b8e1-...',
+ *   redirectPort: 49741,
+ * });
+ * const record = await provider.login({ request: { scopes: ['user.read'] } });
+ * const token = await provider.acquireAccessToken({ request: { scopes: ['user.read'] } });
+ * ```
+ */
+export class AuthProviderInteractiveBrowser implements IAuthProvider {
+  readonly #credential: InteractiveBrowserCredential;
+  readonly #authRecordPersistence: IPersistence;
+  #authRecord: AuthenticationRecord | undefined;
+
+  private constructor(
+    options: InteractiveAuthOptions,
+    authRecordPersistence: IPersistence,
+    authenticationRecord?: AuthenticationRecord,
+  ) {
+    this.#authRecordPersistence = authRecordPersistence;
+    this.#authRecord = authenticationRecord;
+    this.#credential = new InteractiveBrowserCredential({
+      tenantId: options.tenantId,
+      clientId: options.clientId,
+      redirectUri: `http://localhost:${options.redirectPort}`,
+      tokenCachePersistenceOptions: { enabled: true },
+      ...(authenticationRecord ? { authenticationRecord } : {}),
+    });
+  }
+
+  /**
+   * Creates an `AuthProviderInteractiveBrowser`, initialising OS-level secure
+   * persistence and loading any previously stored {@link AuthenticationRecord}
+   * so that silent token acquisition works across process restarts.
+   *
+   * @param options - Azure AD tenant, client, redirect port, and optional browser callback.
+   * @returns A fully initialised provider with any persisted auth record pre-loaded.
+   */
+  static async create(options: InteractiveAuthOptions): Promise<AuthProviderInteractiveBrowser> {
+    // OS-level secure storage: Keychain (macOS), DPAPI (Windows), libsecret (Linux)
+    const persistence = await PersistenceCreator.createPersistence({
+      cachePath: join(
+        homedir(),
+        '.fusion',
+        `auth-record-${options.tenantId}_${options.clientId}.json`,
+      ),
+      serviceName: 'Fusion.CLI.AuthRecord',
+      accountName: `${options.tenantId}_${options.clientId}`,
+    });
+
+    let record: AuthenticationRecord | undefined;
+    try {
+      const content = await persistence.load();
+      if (content) {
+        record = deserializeAuthenticationRecord(content);
+      }
+    } catch {
+      // No persisted record — first run or cleared
+    }
+
+    return new AuthProviderInteractiveBrowser(options, persistence, record);
+  }
+
+  /**
+   * Opens the system browser for Azure AD authentication and returns the
+   * {@link AuthenticationRecord} on success.
+   *
+   * The record is saved to OS-level secure storage so subsequent process
+   * invocations can silently acquire tokens without re-authenticating.
+   *
+   * @param options - Scopes to request.
+   * @returns The authentication record from the interactive flow.
+   * @throws {Error} When interactive authentication does not return a record.
+   */
+  async login(options: { request: { scopes: string[] } }): Promise<AuthenticationRecord> {
+    const record = await this.#credential.authenticate(options.request.scopes);
+    if (!record) {
+      throw new Error('Interactive authentication did not return an authentication record.');
+    }
+    await this.#authRecordPersistence.save(serializeAuthenticationRecord(record));
+    this.#authRecord = record;
+    return record;
+  }
+
+  /**
+   * Removes the persisted authentication record from secure storage.
+   *
+   * The OS-level token cache is not cleared programmatically. Run `az logout`
+   * or clear your OS credential store for a full wipe.
+   */
+  async logout(): Promise<void> {
+    await this.#authRecordPersistence.delete();
+    this.#authRecord = undefined;
+  }
+
+  /**
+   * Acquires an access token for the given scopes.
+   *
+   * If no {@link AuthenticationRecord} was loaded from persistence, performs a
+   * one-time interactive authentication and saves the record so that all
+   * subsequent calls (including from new processes) resolve silently.
+   *
+   * @param options - Scopes to request.
+   * @returns The access token string.
+   * @throws {Error} When the credential returns no token.
+   */
+  async acquireAccessToken(options: { request: { scopes: string[] } }): Promise<string> {
+    // If no auth record exists yet, authenticate interactively once and persist
+    // the record so future invocations can resolve tokens silently.
+    if (!this.#authRecord) {
+      const record = await this.#credential.authenticate(options.request.scopes);
+      if (record) {
+        await this.#authRecordPersistence.save(serializeAuthenticationRecord(record));
+        this.#authRecord = record;
+      }
+    }
+
+    const tokenResponse = await this.#credential.getToken(options.request.scopes);
+    if (!tokenResponse) {
+      throw new Error(
+        'InteractiveBrowserCredential returned no token. Ensure you have logged in first.',
+      );
+    }
+    return tokenResponse.token;
+  }
+}

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -9,6 +9,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { IAuthProvider } from './AuthProvider.interface.js';
 import type { InteractiveAuthOptions } from './configurator.js';
+import { NoCredentialError } from './errors.js';
 
 /**
  * Authentication provider backed by Azure Identity's `InteractiveBrowserCredential`.
@@ -50,6 +51,15 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
       clientId: options.clientId,
       redirectUri: `http://localhost:${options.redirectPort}`,
       tokenCachePersistenceOptions: { enabled: true },
+      ...(options.onOpen
+        ? {
+            browserCustomizationOptions: {
+              openBrowser: async (url: string) => {
+                options.onOpen?.(url);
+              },
+            },
+          }
+        : {}),
       ...(authenticationRecord ? { authenticationRecord } : {}),
     });
   }
@@ -143,7 +153,7 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
 
     const tokenResponse = await this.#credential.getToken(options.request.scopes);
     if (!tokenResponse) {
-      throw new Error(
+      throw new NoCredentialError(
         'InteractiveBrowserCredential returned no token. Ensure you have logged in first.',
       );
     }

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -4,7 +4,7 @@ import {
   serializeAuthenticationRecord,
   deserializeAuthenticationRecord,
 } from '@azure/identity';
-import { PersistenceCreator, type IPersistence } from '@azure/msal-node-extensions';
+import type { IPersistence } from '@azure/msal-node-extensions';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { IAuthProvider } from './AuthProvider.interface.js';
@@ -73,6 +73,10 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
    * @returns A fully initialised provider with any persisted auth record pre-loaded.
    */
   static async create(options: InteractiveAuthOptions): Promise<AuthProviderInteractiveBrowser> {
+    // Dynamically import to avoid loading the native `keytar` binary at
+    // module-load time, which fails on CI runners missing `libsecret`.
+    const { PersistenceCreator } = await import('@azure/msal-node-extensions');
+
     // OS-level secure storage: Keychain (macOS), DPAPI (Windows), libsecret (Linux)
     const persistence = await PersistenceCreator.createPersistence({
       cachePath: join(

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -136,18 +136,26 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
   /**
    * Acquires an access token for the given scopes.
    *
-   * If no {@link AuthenticationRecord} was loaded from persistence, performs a
-   * one-time interactive authentication and saves the record so that all
-   * subsequent calls (including from new processes) resolve silently.
+   * If no {@link AuthenticationRecord} was loaded from persistence, this method
+   * throws {@link NoCredentialError} unless `options.interactive` is `true`.
+   * When interactive, it performs a one-time browser authentication and saves
+   * the record so that all subsequent calls resolve silently.
    *
-   * @param options - Scopes to request.
+   * @param options - Scopes to request, and whether interactive prompting is allowed.
    * @returns The access token string.
-   * @throws {Error} When the credential returns no token.
+   * @throws {NoCredentialError} When no cached credential exists and interactive is not enabled.
+   * @throws {NoCredentialError} When the credential returns no token.
    */
-  async acquireAccessToken(options: { request: { scopes: string[] } }): Promise<string> {
-    // If no auth record exists yet, authenticate interactively once and persist
-    // the record so future invocations can resolve tokens silently.
+  async acquireAccessToken(options: {
+    request: { scopes: string[] };
+    interactive?: boolean;
+  }): Promise<string> {
     if (!this.#authRecord) {
+      if (!options.interactive) {
+        throw new NoCredentialError(
+          'No cached credentials found. Run `ffc auth login` first, or pass interactive: true.',
+        );
+      }
       const record = await this.#credential.authenticate(options.request.scopes);
       if (record) {
         await this.#authRecordPersistence.save(serializeAuthenticationRecord(record));

--- a/packages/modules/azure-identity/src/AuthProviderTokenOnly.ts
+++ b/packages/modules/azure-identity/src/AuthProviderTokenOnly.ts
@@ -18,12 +18,12 @@ export class AuthProviderTokenOnly implements IAuthProvider {
   }
 
   /** @throws Always — login is not supported with a static token. */
-  login(_options: { request: { scopes: string[] } }): Promise<never> {
+  async login(_options: { request: { scopes: string[] } }): Promise<never> {
     throw new Error('Login is not supported in token-only mode');
   }
 
   /** @throws Always — logout is not supported with a static token. */
-  logout(): Promise<never> {
+  async logout(): Promise<never> {
     throw new Error('Logout is not supported in token-only mode');
   }
 

--- a/packages/modules/azure-identity/src/AuthProviderTokenOnly.ts
+++ b/packages/modules/azure-identity/src/AuthProviderTokenOnly.ts
@@ -1,0 +1,39 @@
+import type { IAuthProvider } from './AuthProvider.interface.js';
+
+/**
+ * Authentication provider that returns a static, pre-obtained access token.
+ *
+ * Used for CI/CD pipelines and automation where a token is supplied externally
+ * (e.g. via `FUSION_TOKEN` environment variable). Login and logout are not
+ * supported — the token is used as-is until it expires.
+ */
+export class AuthProviderTokenOnly implements IAuthProvider {
+  readonly #accessToken: string;
+
+  /**
+   * @param token - The static access token to return from {@link acquireAccessToken}.
+   */
+  constructor(token: string) {
+    this.#accessToken = token;
+  }
+
+  /** @throws Always — login is not supported with a static token. */
+  login(_options: { request: { scopes: string[] } }): Promise<never> {
+    throw new Error('Login is not supported in token-only mode');
+  }
+
+  /** @throws Always — logout is not supported with a static token. */
+  logout(): Promise<never> {
+    throw new Error('Logout is not supported in token-only mode');
+  }
+
+  /**
+   * Returns the pre-obtained access token.
+   *
+   * @param _options - Ignored — the static token is returned regardless of scopes.
+   * @returns The static access token string.
+   */
+  acquireAccessToken(_options: { request: { scopes: string[] } }): Promise<string> {
+    return Promise.resolve(this.#accessToken);
+  }
+}

--- a/packages/modules/azure-identity/src/configurator.ts
+++ b/packages/modules/azure-identity/src/configurator.ts
@@ -1,0 +1,156 @@
+import {
+  BaseConfigBuilder,
+  type ConfigBuilderCallbackArgs,
+} from '@equinor/fusion-framework-module';
+
+/**
+ * Discriminated union of Azure Identity auth configurations.
+ *
+ * - `default_credential` — ambient environment (CI/CD, managed identity, Azure CLI).
+ * - `interactive` — opens browser for user login, caches tokens to OS keychain.
+ * - `token_only` — uses a pre-obtained static access token.
+ */
+export type AzureIdentityAuthConfig =
+  | { mode: 'default_credential' }
+  | {
+      mode: 'interactive';
+      tenantId: string;
+      clientId: string;
+      redirectPort: number;
+      onOpen?: (url: string) => void;
+    }
+  | { mode: 'token_only'; accessToken: string };
+
+/**
+ * Configuration options for the interactive browser authentication mode.
+ *
+ * Shared by the configurator setters and the `AuthProviderInteractiveBrowser`
+ * factory — this is the single definition for interactive-mode parameters.
+ *
+ * @see {@link AzureIdentityAuthConfigurator.setInteractive}
+ */
+export interface InteractiveAuthOptions {
+  /** Azure AD tenant (directory) ID. */
+  tenantId: string;
+  /** Azure AD application (client) ID. */
+  clientId: string;
+  /** Port for the localhost redirect URI used during the auth code flow. */
+  redirectPort: number;
+  /** Callback invoked with the login URI once the interactive flow starts. */
+  onOpen?: (url: string) => void;
+}
+
+/**
+ * Configurator for the Azure Identity auth module.
+ *
+ * Provides type-safe setters for each authentication mode. Each setter
+ * requires exactly the options needed for that mode, preventing
+ * misconfiguration at compile time.
+ *
+ * Defaults to `default_credential` when no mode is configured.
+ *
+ * @example Set a complete config object directly
+ * ```typescript
+ * builder.setConfig({
+ *   mode: 'interactive',
+ *   tenantId: '3aa4a235-...',
+ *   clientId: 'a318b8e1-...',
+ *   redirectPort: 49741,
+ * });
+ * ```
+ *
+ * @example Use mode-specific setters
+ * ```typescript
+ * builder.setInteractive({
+ *   tenantId: '3aa4a235-...',
+ *   clientId: 'a318b8e1-...',
+ *   redirectPort: 49741,
+ *   onOpen: (url) => open(url),
+ * });
+ * ```
+ */
+export class AzureIdentityAuthConfigurator extends BaseConfigBuilder<AzureIdentityAuthConfig> {
+  /**
+   * Sets the full configuration object directly.
+   *
+   * The discriminated union ensures the correct shape for each mode.
+   *
+   * @param config - A complete {@link AzureIdentityAuthConfig} object.
+   *
+   * @example
+   * ```typescript
+   * builder.setConfig({ mode: 'default_credential' });
+   * builder.setConfig({ mode: 'token_only', accessToken: '...' });
+   * builder.setConfig({ mode: 'interactive', tenantId, clientId, redirectPort: 49741 });
+   * ```
+   */
+  setConfig(config: AzureIdentityAuthConfig): void {
+    this._set('mode', config.mode);
+    switch (config.mode) {
+      case 'interactive':
+        this._set('tenantId', config.tenantId);
+        this._set('clientId', config.clientId);
+        this._set('redirectPort', config.redirectPort);
+        this._set('onOpen', config.onOpen);
+        break;
+      case 'token_only':
+        this._set('accessToken', config.accessToken);
+        break;
+    }
+  }
+
+  /**
+   * Configures `default_credential` mode using `DefaultAzureCredential`.
+   *
+   * Uses the ambient credential chain: environment variables, workload identity,
+   * managed identity, Azure CLI, etc.
+   */
+  setDefaultCredential(): void {
+    this._set('mode', 'default_credential');
+  }
+
+  /**
+   * Configures `interactive` mode with browser-based login and OS-level
+   * token caching.
+   *
+   * @param options - Tenant, client, redirect port, and optional browser callback.
+   *
+   * @example
+   * ```typescript
+   * builder.setInteractive({
+   *   tenantId: '3aa4a235-...',
+   *   clientId: 'a318b8e1-...',
+   *   redirectPort: 49741,
+   * });
+   * ```
+   */
+  setInteractive(options: InteractiveAuthOptions): void {
+    this._set('mode', 'interactive');
+    this._set('tenantId', options.tenantId);
+    this._set('clientId', options.clientId);
+    this._set('redirectPort', options.redirectPort);
+    this._set('onOpen', options.onOpen);
+  }
+
+  /**
+   * Configures `token_only` mode with a pre-obtained static access token.
+   *
+   * @param accessToken - The access token string.
+   *
+   * @example
+   * ```typescript
+   * builder.setTokenOnly(process.env.FUSION_TOKEN);
+   * ```
+   */
+  setTokenOnly(accessToken: string): void {
+    this._set('mode', 'token_only');
+    this._set('accessToken', accessToken);
+  }
+
+  protected override _buildConfig(
+    init: ConfigBuilderCallbackArgs,
+    initial?: Partial<AzureIdentityAuthConfig>,
+  ) {
+    return super._buildConfig(init, initial);
+  }
+}

--- a/packages/modules/azure-identity/src/enable-module.ts
+++ b/packages/modules/azure-identity/src/enable-module.ts
@@ -1,0 +1,132 @@
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+import { module } from './module.js';
+import type { AzureIdentityAuthConfigurator } from './configurator.js';
+import type { InteractiveAuthOptions } from './configurator.js';
+
+/**
+ * Enables the Azure Identity auth module on a Fusion Framework configurator.
+ *
+ * Registers the auth module under the `'auth'` slot — the same slot used by
+ * the MSAL Node module. Only one auth module can be active at a time.
+ *
+ * @param configurator - The modules configurator to register the module with.
+ * @param configure - Optional callback to set mode, credentials, and options
+ *   on the {@link AzureIdentityAuthConfigurator}. When omitted the module
+ *   defaults to `default_credential` mode.
+ *
+ * @example Default credential (CI/CD, managed identity)
+ * ```typescript
+ * enableAzureIdentityAuth(configurator);
+ * ```
+ *
+ * @example Interactive browser login
+ * ```typescript
+ * enableAzureIdentityAuth(configurator, (builder) => {
+ *   builder.setInteractive({ tenantId, clientId, redirectPort: 49741 });
+ * });
+ * ```
+ *
+ * @example Static token
+ * ```typescript
+ * enableAzureIdentityAuth(configurator, (builder) => {
+ *   builder.setTokenOnly(token);
+ * });
+ * ```
+ *
+ * @example Full config object
+ * ```typescript
+ * enableAzureIdentityAuth(configurator, (builder) => {
+ *   builder.setConfig({ mode: 'interactive', tenantId, clientId, redirectPort: 49741 });
+ * });
+ * ```
+ */
+export const enableAzureIdentityAuth = (
+  // biome-ignore lint/suspicious/noExplicitAny: module configurator accepts any module set
+  configurator: IModulesConfigurator<any, any>,
+  configure?: (builder: AzureIdentityAuthConfigurator) => void,
+): void => {
+  configurator.addConfig({
+    module,
+    configure: (builder) => {
+      if (configure) {
+        configure(builder);
+      } else {
+        // Default to ambient credential resolution
+        builder.setDefaultCredential();
+      }
+    },
+  });
+};
+
+/**
+ * Enables Azure Identity auth in `default_credential` mode.
+ *
+ * Uses the `DefaultAzureCredential` chain: environment variables, workload
+ * identity, managed identity, Azure CLI, etc.
+ *
+ * @param configurator - The modules configurator to register the module with.
+ *
+ * @example
+ * ```typescript
+ * enableAzureIdentityDefaultCredential(configurator);
+ * ```
+ */
+export const enableAzureIdentityDefaultCredential = (
+  // biome-ignore lint/suspicious/noExplicitAny: module configurator accepts any module set
+  configurator: IModulesConfigurator<any, any>,
+): void => {
+  enableAzureIdentityAuth(configurator, (builder) => {
+    builder.setDefaultCredential();
+  });
+};
+
+/**
+ * Enables Azure Identity auth in `interactive` mode with browser-based login
+ * and OS-level token caching (Keychain / DPAPI / libsecret).
+ *
+ * @param configurator - The modules configurator to register the module with.
+ * @param options - Tenant, client, redirect port, and optional browser callback.
+ *
+ * @example
+ * ```typescript
+ * enableAzureIdentityInteractive(configurator, {
+ *   tenantId: '3aa4a235-...',
+ *   clientId: 'a318b8e1-...',
+ *   redirectPort: 49741,
+ *   onOpen: (url) => open(url),
+ * });
+ * ```
+ */
+export const enableAzureIdentityInteractive = (
+  // biome-ignore lint/suspicious/noExplicitAny: module configurator accepts any module set
+  configurator: IModulesConfigurator<any, any>,
+  options: InteractiveAuthOptions,
+): void => {
+  enableAzureIdentityAuth(configurator, (builder) => {
+    builder.setInteractive(options);
+  });
+};
+
+/**
+ * Enables Azure Identity auth in `token_only` mode with a pre-obtained
+ * static access token.
+ *
+ * @param configurator - The modules configurator to register the module with.
+ * @param accessToken - The access token string.
+ *
+ * @example
+ * ```typescript
+ * enableAzureIdentityTokenOnly(configurator, process.env.FUSION_TOKEN);
+ * ```
+ */
+export const enableAzureIdentityTokenOnly = (
+  // biome-ignore lint/suspicious/noExplicitAny: module configurator accepts any module set
+  configurator: IModulesConfigurator<any, any>,
+  accessToken: string,
+): void => {
+  enableAzureIdentityAuth(configurator, (builder) => {
+    builder.setTokenOnly(accessToken);
+  });
+};
+
+export default enableAzureIdentityAuth;

--- a/packages/modules/azure-identity/src/errors.ts
+++ b/packages/modules/azure-identity/src/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown when a provider cannot acquire a token because no cached credentials
+ * or authentication record are available.
+ *
+ * Allows callers (e.g. the CLI `token` command) to discriminate this specific
+ * failure without relying on brittle string matching.
+ */
+export class NoCredentialError extends Error {
+  override readonly name = 'NoCredentialError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/modules/azure-identity/src/index.ts
+++ b/packages/modules/azure-identity/src/index.ts
@@ -29,7 +29,7 @@
  * @packageDocumentation
  */
 
-export { AuthProviderDefaultCredential } from './AuthProviderDefaultCredential.js';
+export { AuthProviderDefaultCredential, ensureCachePersistencePlugin } from './AuthProviderDefaultCredential.js';
 export { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
 export { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
 export { NoCredentialError } from './errors.js';

--- a/packages/modules/azure-identity/src/index.ts
+++ b/packages/modules/azure-identity/src/index.ts
@@ -29,7 +29,10 @@
  * @packageDocumentation
  */
 
-export { AuthProviderDefaultCredential, ensureCachePersistencePlugin } from './AuthProviderDefaultCredential.js';
+export {
+  AuthProviderDefaultCredential,
+  ensureCachePersistencePlugin,
+} from './AuthProviderDefaultCredential.js';
 export { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
 export { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
 export { NoCredentialError } from './errors.js';

--- a/packages/modules/azure-identity/src/index.ts
+++ b/packages/modules/azure-identity/src/index.ts
@@ -37,7 +37,7 @@ export { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser
 export { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
 export { NoCredentialError } from './errors.js';
 
-export type { IAuthProvider } from './AuthProvider.interface.js';
+export type { AuthRecord, IAuthProvider } from './AuthProvider.interface.js';
 export type { AzureIdentityAuthConfig, InteractiveAuthOptions } from './configurator.js';
 export { AzureIdentityAuthConfigurator } from './configurator.js';
 

--- a/packages/modules/azure-identity/src/index.ts
+++ b/packages/modules/azure-identity/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * `@equinor/fusion-framework-module-azure-identity` provides Azure AD authentication
+ * for Node.js applications using `@azure/identity` credentials.
+ *
+ * Supports three modes:
+ *
+ * - **`default_credential`** — `DefaultAzureCredential` for CI/CD, managed identity,
+ *   Azure CLI, and other ambient credential sources.
+ * - **`interactive`** — `InteractiveBrowserCredential` for browser-based login with
+ *   OS-level token caching (Keychain / DPAPI / libsecret).
+ * - **`token_only`** — static access token supplied externally.
+ *
+ * Registers under the `'auth'` module slot as a drop-in replacement for the
+ * MSAL Node module.
+ *
+ * @example
+ * ```typescript
+ * import { enableAzureIdentityAuth } from '@equinor/fusion-framework-module-azure-identity';
+ *
+ * // Default credential (CI/CD, managed identity)
+ * enableAzureIdentityAuth(configurator);
+ *
+ * // Interactive browser login
+ * enableAzureIdentityAuth(configurator, (builder) => {
+ *   builder.setInteractive({ tenantId, clientId, redirectPort: 49741 });
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { AuthProviderDefaultCredential } from './AuthProviderDefaultCredential.js';
+export { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
+export { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
+
+export type { IAuthProvider } from './AuthProvider.interface.js';
+export type { AzureIdentityAuthConfig, InteractiveAuthOptions } from './configurator.js';
+export { AzureIdentityAuthConfigurator } from './configurator.js';
+
+export { module as azureIdentityModule, type AzureIdentityModule } from './module.js';
+
+export {
+  enableAzureIdentityAuth,
+  enableAzureIdentityDefaultCredential,
+  enableAzureIdentityInteractive,
+  enableAzureIdentityTokenOnly,
+} from './enable-module.js';

--- a/packages/modules/azure-identity/src/index.ts
+++ b/packages/modules/azure-identity/src/index.ts
@@ -32,6 +32,7 @@
 export { AuthProviderDefaultCredential } from './AuthProviderDefaultCredential.js';
 export { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
 export { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
+export { NoCredentialError } from './errors.js';
 
 export type { IAuthProvider } from './AuthProvider.interface.js';
 export type { AzureIdentityAuthConfig, InteractiveAuthOptions } from './configurator.js';

--- a/packages/modules/azure-identity/src/module.ts
+++ b/packages/modules/azure-identity/src/module.ts
@@ -1,0 +1,48 @@
+import type { Module } from '@equinor/fusion-framework-module';
+import { AzureIdentityAuthConfigurator, type AzureIdentityAuthConfig } from './configurator.js';
+import { AuthProviderDefaultCredential } from './AuthProviderDefaultCredential.js';
+import { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
+import { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
+import type { IAuthProvider } from './AuthProvider.interface.js';
+
+/**
+ * Azure Identity authentication module for the Fusion Framework.
+ *
+ * Supports three modes:
+ *
+ * - **`default_credential`** — `DefaultAzureCredential` for CI/CD, managed identity,
+ *   and Azure CLI environments.
+ * - **`interactive`** — `InteractiveBrowserCredential` for CLI `login` / `logout`
+ *   flows with browser-based authentication and OS-level token caching.
+ * - **`token_only`** — static access token supplied externally.
+ *
+ * Registers under the module name `'auth'` so it is a drop-in replacement
+ * for `@equinor/fusion-framework-module-msal-node`.
+ */
+export type AzureIdentityModule = Module<'auth', IAuthProvider, AzureIdentityAuthConfigurator>;
+
+export const module: AzureIdentityModule = {
+  name: 'auth',
+  configure: () => new AzureIdentityAuthConfigurator(),
+  initialize: async (args) => {
+    const config: AzureIdentityAuthConfig = await args.config.createConfigAsync(args);
+
+    switch (config.mode) {
+      case 'interactive':
+        return AuthProviderInteractiveBrowser.create({
+          tenantId: config.tenantId,
+          clientId: config.clientId,
+          redirectPort: config.redirectPort,
+          onOpen: config.onOpen,
+        });
+
+      case 'token_only':
+        return new AuthProviderTokenOnly(config.accessToken);
+
+      default:
+        return new AuthProviderDefaultCredential();
+    }
+  },
+};
+
+export default module;

--- a/packages/modules/azure-identity/src/module.ts
+++ b/packages/modules/azure-identity/src/module.ts
@@ -30,12 +30,12 @@ export const module: AzureIdentityModule = {
   initialize: async (args) => {
     const config: AzureIdentityAuthConfig = await args.config.createConfigAsync(args);
 
-    // Register the cache persistence plugin lazily (avoids loading native
-    // keytar binary at import time, which fails on CI runners).
-    await ensureCachePersistencePlugin();
-
     switch (config.mode) {
       case 'interactive':
+        // Register the cache persistence plugin lazily — only interactive mode
+        // needs OS-level token caching. Avoids loading the native `keytar`
+        // binary in CI/headless environments.
+        await ensureCachePersistencePlugin();
         return AuthProviderInteractiveBrowser.create({
           tenantId: config.tenantId,
           clientId: config.clientId,

--- a/packages/modules/azure-identity/src/module.ts
+++ b/packages/modules/azure-identity/src/module.ts
@@ -1,6 +1,9 @@
 import type { Module } from '@equinor/fusion-framework-module';
 import { AzureIdentityAuthConfigurator, type AzureIdentityAuthConfig } from './configurator.js';
-import { AuthProviderDefaultCredential, ensureCachePersistencePlugin } from './AuthProviderDefaultCredential.js';
+import {
+  AuthProviderDefaultCredential,
+  ensureCachePersistencePlugin,
+} from './AuthProviderDefaultCredential.js';
 import { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
 import { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
 import type { IAuthProvider } from './AuthProvider.interface.js';

--- a/packages/modules/azure-identity/src/module.ts
+++ b/packages/modules/azure-identity/src/module.ts
@@ -1,6 +1,6 @@
 import type { Module } from '@equinor/fusion-framework-module';
 import { AzureIdentityAuthConfigurator, type AzureIdentityAuthConfig } from './configurator.js';
-import { AuthProviderDefaultCredential } from './AuthProviderDefaultCredential.js';
+import { AuthProviderDefaultCredential, ensureCachePersistencePlugin } from './AuthProviderDefaultCredential.js';
 import { AuthProviderInteractiveBrowser } from './AuthProviderInteractiveBrowser.js';
 import { AuthProviderTokenOnly } from './AuthProviderTokenOnly.js';
 import type { IAuthProvider } from './AuthProvider.interface.js';
@@ -26,6 +26,10 @@ export const module: AzureIdentityModule = {
   configure: () => new AzureIdentityAuthConfigurator(),
   initialize: async (args) => {
     const config: AzureIdentityAuthConfig = await args.config.createConfigAsync(args);
+
+    // Register the cache persistence plugin lazily (avoids loading native
+    // keytar binary at import time, which fails on CI runners).
+    await ensureCachePersistencePlugin();
 
     switch (config.mode) {
       case 'interactive':

--- a/packages/modules/azure-identity/tsconfig.json
+++ b/packages/modules/azure-identity/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "declarationDir": "./dist/types"
+  },
+  "references": [
+    {
+      "path": "../module"
+    }
+  ],
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@24.12.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@24.12.0)(typescript@5.9.3))(vite@8.0.9(@types/node@24.12.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   cookbooks/app-react:
     devDependencies:
@@ -949,9 +949,9 @@ importers:
       '@equinor/fusion-framework-dev-server':
         specifier: workspace:*
         version: link:../dev-server
-      '@equinor/fusion-framework-module-msal-node':
+      '@equinor/fusion-framework-module-azure-identity':
         specifier: workspace:*
-        version: link:../modules/msal-node
+        version: link:../modules/azure-identity
       '@equinor/fusion-framework-vite-plugin-raw-imports':
         specifier: workspace:*
         version: link:../vite-plugins/raw-imports
@@ -1084,7 +1084,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli-plugins/ai-base:
     dependencies:
@@ -1112,7 +1112,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli-plugins/ai-chat:
     dependencies:
@@ -1143,7 +1143,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli-plugins/ai-index:
     dependencies:
@@ -1213,7 +1213,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli-plugins/copilot:
     dependencies:
@@ -1383,7 +1383,7 @@ importers:
         version: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/framework:
     dependencies:
@@ -1420,7 +1420,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/ag-grid:
     devDependencies:
@@ -1481,7 +1481,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/analytics:
     dependencies:
@@ -1539,7 +1539,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/app:
     dependencies:
@@ -1580,6 +1580,25 @@ importers:
       '@equinor/fusion-framework-module-service-discovery':
         specifier: workspace:^
         version: link:../service-discovery
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/modules/azure-identity:
+    dependencies:
+      '@azure/identity':
+        specifier: ^4.9.1
+        version: 4.13.1
+      '@azure/identity-cache-persistence':
+        specifier: ^1.3.0
+        version: 1.3.0
+      '@azure/msal-node-extensions':
+        specifier: ^5.1.4
+        version: 5.1.4
+      '@equinor/fusion-framework-module':
+        specifier: workspace:^
+        version: link:../module
+    devDependencies:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1725,7 +1744,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/module:
     dependencies:
@@ -1822,7 +1841,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/service-discovery:
     dependencies:
@@ -1875,7 +1894,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/signalr:
     dependencies:
@@ -1928,7 +1947,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/modules/widget:
     dependencies:
@@ -2076,7 +2095,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/react/components/bookmark:
     dependencies:
@@ -2424,7 +2443,7 @@ importers:
         version: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils/imports:
     dependencies:
@@ -2449,7 +2468,7 @@ importers:
         version: 4.6.0
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils/load-env:
     dependencies:
@@ -2465,7 +2484,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils/log:
     dependencies:
@@ -2481,7 +2500,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils/observable:
     dependencies:
@@ -2518,7 +2537,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils/query:
     dependencies:
@@ -2549,7 +2568,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vite-plugins/api-service:
     dependencies:
@@ -2577,7 +2596,7 @@ importers:
         version: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vite-plugins/raw-imports:
     devDependencies:
@@ -2589,7 +2608,7 @@ importers:
         version: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vite-plugins/spa:
     dependencies:
@@ -2800,12 +2819,24 @@ packages:
     resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/identity-cache-persistence@1.3.0':
+    resolution: {integrity: sha512-gk1utd1YazL+88bwOiDbZdqSu5Y7HxbsmQSXoW1qhGqqvbO5lma81mv4UQkS1vK6l2y/yd1v4IoJoOEtnUjikw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
 
   '@azure/msal-browser@5.4.0':
     resolution: {integrity: sha512-GvRbLNk26oPOPpnry4Ym8wtXrmdozGm2Sry5EKfui0siwnEuAKWEeMLLyosDo5nVEIIDO1C2t/+HpVzqqCWlfQ==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-browser@5.8.0':
+    resolution: {integrity: sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@16.0.2':
@@ -2816,8 +2847,16 @@ packages:
     resolution: {integrity: sha512-ge0nGzTLmEE5lg7tSCbTBrYqMGkpFQeQEtqfcKPuGJn/FPFf8Xz51uDfZsm5xpstNZGMYPhHvnYbL8OeNp/aLw==}
     engines: {node: '>=0.8.0'}
 
+  '@azure/msal-common@16.5.1':
+    resolution: {integrity: sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==}
+    engines: {node: '>=0.8.0'}
+
   '@azure/msal-node-extensions@5.0.2':
     resolution: {integrity: sha512-695boK9IFmHrYPviFgj5DaeJ65iUGjzHiSIAgzyIRfwTO8k3J4KrF+xbFy2uC9JZ2U8HHEobi7UGloc768HhUQ==}
+    engines: {node: '>=20'}
+
+  '@azure/msal-node-extensions@5.1.4':
+    resolution: {integrity: sha512-q+C0ardPkXDnKQW2JfSY9n1WOIC02+pJw0U1xMdZNcVMkdp6glBNBU+4Jcef1E/gZh6DPCb9/NLd/+6CVTThKg==}
     engines: {node: '>=20'}
 
   '@azure/msal-node-runtime@0.20.1':
@@ -2825,6 +2864,10 @@ packages:
 
   '@azure/msal-node@5.0.2':
     resolution: {integrity: sha512-3tHeJghckgpTX98TowJoXOjKGuds0L+FKfeHJtoZFl2xvwE6RF65shZJzMQ5EQZWXzh3sE1i9gE+m3aRMachjA==}
+    engines: {node: '>=20'}
+
+  '@azure/msal-node@5.1.4':
+    resolution: {integrity: sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==}
     engines: {node: '>=20'}
 
   '@azure/search-documents@12.2.0':
@@ -9744,6 +9787,10 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -11144,6 +11191,7 @@ packages:
       '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -11435,6 +11483,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -11662,6 +11714,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/identity-cache-persistence@1.3.0':
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.1
+      '@azure/msal-node': 5.1.4
+      '@azure/msal-node-extensions': 5.1.4
+      keytar: 7.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 5.8.0
+      '@azure/msal-node': 5.1.4
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/logger@1.3.0':
     dependencies:
       '@typespec/ts-http-runtime': 0.3.2
@@ -11673,13 +11752,25 @@ snapshots:
     dependencies:
       '@azure/msal-common': 16.2.0
 
+  '@azure/msal-browser@5.8.0':
+    dependencies:
+      '@azure/msal-common': 16.5.1
+
   '@azure/msal-common@16.0.2': {}
 
   '@azure/msal-common@16.2.0': {}
 
+  '@azure/msal-common@16.5.1': {}
+
   '@azure/msal-node-extensions@5.0.2':
     dependencies:
       '@azure/msal-common': 16.0.2
+      '@azure/msal-node-runtime': 0.20.1
+      keytar: 7.9.0
+
+  '@azure/msal-node-extensions@5.1.4':
+    dependencies:
+      '@azure/msal-common': 16.5.1
       '@azure/msal-node-runtime': 0.20.1
       keytar: 7.9.0
 
@@ -11688,6 +11779,12 @@ snapshots:
   '@azure/msal-node@5.0.2':
     dependencies:
       '@azure/msal-common': 16.0.2
+      jsonwebtoken: 9.0.3
+      uuid: 8.3.2
+
+  '@azure/msal-node@5.1.4':
+    dependencies:
+      '@azure/msal-common': 16.5.1
       jsonwebtoken: 9.0.3
       uuid: 8.3.2
 
@@ -16695,7 +16792,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -19602,6 +19699,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.4.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@11.0.0:
     dependencies:
       default-browser: 5.4.0
@@ -21091,7 +21195,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@24.12.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@24.12.0)(typescript@5.9.3))(vite@8.0.9(@types/node@24.12.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.6(@types/node@24.12.0)(typescript@5.9.3))(vite@8.0.9(@types/node@24.12.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -21120,20 +21224,9 @@ snapshots:
       happy-dom: 20.9.0
       jsdom: 29.0.2
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.0)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -21162,18 +21255,7 @@ snapshots:
       happy-dom: 20.9.0
       jsdom: 29.0.2
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -21437,6 +21519,10 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.0
 
   wsl-utils@0.3.1:
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "fusion-code-conventions": {
+      "source": "equinor/fusion-skills",
+      "sourceType": "github",
+      "skillPath": "skills/.system/fusion-code-conventions/SKILL.md",
+      "computedHash": "b5094425d13bf88e9a9a2c76d439f96c20ad5e03d87f956266518d502446bd12"
+    },
     "fusion-dependency-review": {
       "source": "equinor/fusion-skills",
       "sourceType": "github",

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -300,7 +300,11 @@ export default sidebar({
           link: 'msal/',
         },
         {
-          text: 'NodeJS',
+          text: 'NodeJS (Azure Identity)',
+          link: 'azure-identity/',
+        },
+        {
+          text: 'NodeJS (MSAL - legacy)',
           link: 'msal-node/',
         },
       ],

--- a/vue-press/src/modules/auth/azure-identity/README.md
+++ b/vue-press/src/modules/auth/azure-identity/README.md
@@ -1,0 +1,20 @@
+---
+title: Azure Identity Authentication Module
+description: Azure AD authentication for Node.js applications using Azure Identity credentials. Supports ambient credentials (DefaultAzureCredential), interactive browser login with OS-level token caching, and static token modes. Drop-in replacement for the MSAL Node module.
+category: Module
+tag:
+  - auth
+  - azure
+  - azure-identity
+  - authentication
+  - node
+  - cli
+  - keychain
+  - credential
+  - managed-identity
+---
+
+
+<ModuleBadge module="modules/azure-identity" />
+
+<!-- @include: ../../../../../packages/modules/azure-identity/README.md -->


### PR DESCRIPTION
**Why is this change needed?**

The CLI authentication stack relies on `@equinor/fusion-framework-module-msal-node`, which wraps MSAL directly and requires manual token cache management. `ffc auth token` re-prompts the browser on every invocation because the credential has no `AuthenticationRecord` persistence — it cannot find cached tokens after a process restart.

**What is the current behavior?**

- `ffc auth login` opens a browser, acquires a token, but the credential metadata is not persisted.
- `ffc auth token` always triggers a new interactive flow because MSAL has no way to locate cached tokens.
- CI/CD environments cannot use ambient credential chains through a standard framework module.
- The configurator allows misconfiguration (e.g. mode `interactive` without client config) that only surfaces at runtime.

**What is the new behavior?**

- New `@equinor/fusion-framework-module-azure-identity` with three auth modes:
  - `interactive` — `InteractiveBrowserCredential` with `AuthenticationRecord` persistence via OS keychain
  - `default_credential` — `DefaultAzureCredential` for CI/CD, managed identity, Azure CLI
  - `token_only` — static access token passthrough
- Type-safe configurator with mode-specific setters that enforce correct config shapes at compile time.
- Mode-specific enablers (`enableAzureIdentityInteractive`, `enableAzureIdentityDefaultCredential`, `enableAzureIdentityTokenOnly`).
- Custom `NoCredentialError` for stable error discrimination (replaces brittle string matching).
- CLI migrated: `ffc auth login` → `ffc auth token` now resolves silently across restarts.

**What is the intended behavior or invariant?**

After `ffc auth login`, `AuthenticationRecord` is persisted to the OS keychain via `@azure/msal-node-extensions`. Any subsequent `ffc auth token` call — including in a new terminal session — must resolve silently using the cached record without opening a browser. `ffc auth logout` must clear the persisted record. The configurator must prevent misconfiguration at compile time via discriminated union types.

**Does this PR introduce a breaking change?**

Yes — the CLI (`@equinor/fusion-framework-cli`) replaces its auth backend from `msal-node` to `azure-identity`. Users must re-authenticate with `ffc auth login` after upgrading. The previous MSAL-based token cache is no longer used.

The `@equinor/fusion-framework-module-msal-node` package is NOT removed and remains available for existing consumers.

**Impact assessment:**

- Breaking changes: Yes (CLI auth backend replacement)
- Version bump: Major for `cli`, Minor for `azure-identity` (new package)
- Consumer impact: CLI users must run `ffc auth login` once after upgrading. After that, tokens persist silently across restarts.
- Downstream impact: `msal-node` module untouched. New `azure-identity` module is additive.

**Review guidance:**

- Start with `packages/modules/azure-identity/src/` — review the three providers and the configurator
- Check `AuthProviderInteractiveBrowser.ts` for the `AuthenticationRecord` persistence flow (the core fix)
- Check `errors.ts` for the new `NoCredentialError` class
- Verify CLI migration in `packages/cli/src/bin/framework.node.ts`
- Documentation: package README, CLI `auth.md`, VuePress page

**Additional context**

Dependencies: `@azure/identity` ^4.9.1, `@azure/identity-cache-persistence` ^1.3.0, `@azure/msal-node-extensions` ^5.1.4.

**Related issues**

closes: equinor/fusion-core-tasks#1067
ref: equinor/fusion-core-tasks#1066

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)