### PR TITLE
fix(cli): Remove vite-tsconfig-paths package

### DIFF
--- a/.changeset/empty-dogs-pay.md
+++ b/.changeset/empty-dogs-pay.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+CLI: Remove superfluous package 'vite-tsconfig-paths' now included in vite

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -122,7 +122,6 @@
     "semver": "^7.7.4",
     "simple-git": "^3.32.3",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^6.0.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/cli/src/bin/helpers/load-vite-config.ts
+++ b/packages/cli/src/bin/helpers/load-vite-config.ts
@@ -1,5 +1,4 @@
 import { loadConfigFromFile, mergeConfig, type UserConfig } from 'vite';
-import tsConfigPaths from 'vite-tsconfig-paths';
 
 import { basename, dirname, extname } from 'node:path';
 
@@ -54,11 +53,10 @@ export const loadViteConfig = async (env: RuntimeEnv, pkg: ResolvedPackage) => {
   return mergeConfig(
     {
       root,
-      plugins: [
-        tsConfigPaths(),
-        reactRouterPlugin({ debug: true }),
-        rawImportsPlugin({ extensions: ['.md'] }),
-      ],
+      plugins: [reactRouterPlugin({ debug: true }), rawImportsPlugin({ extensions: ['.md'] })],
+      resolve: {
+        tsconfigPaths: true,
+      },
       define: {
         // Set environment variables for the build
         'process.env.NODE_ENV': JSON.stringify(env.mode),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1003,9 +1003,6 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-tsconfig-paths:
-        specifier: ^6.0.4
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -8852,9 +8849,6 @@ packages:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -10839,16 +10833,6 @@ packages:
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -11086,11 +11070,6 @@ packages:
     resolution: {integrity: sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==}
     peerDependencies:
       vite: '>= 2.7'
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -18497,8 +18476,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
-  globrex@0.1.2: {}
-
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
@@ -20900,10 +20877,6 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -21132,16 +21105,6 @@ snapshots:
   vite-plugin-environment@1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       vite: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
-
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@7.3.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
**Why is this change needed?**
The `vite-tsconfig-paths` package has been superseded by Vite's built-in `tsconfigPaths` resolve configuration option (available since Vite 5.0+). This change removes the unnecessary external dependency while preserving the same functionality, reducing the package's dependency footprint.

**What is the current behavior?**
The CLI currently uses the `vite-tsconfig-paths` plugin to resolve TypeScript paths through a dedicated Vite plugin, requiring an additional dependency in package.json.

**What is the new behavior?**
The CLI now leverages Vite's native `resolve.tsconfigPaths` configuration option to achieve the same TypeScript path resolution, eliminating the need for the external package.

**What is the intended behavior or invariant?**
TypeScript path aliases (`tsconfig.json` paths) should continue to be resolved correctly during development and builds. The behavior is identical to the previous implementation; only the underlying mechanism has changed to use Vite's built-in support.

**Does this PR introduce a breaking change?**
No. This is a non-breaking change that preserves existing functionality while reducing dependencies.

**Impact assessment:**
- **Breaking changes**: None
- **Version bump**: Patch (as specified in changeset)
- **Consumer impact**: None. This is an internal CLI optimization.
- **Downstream impact**: None. The CLI's configuration behavior remains identical from a consumer perspective.

**Review guidance:**
- Verify that the `resolve.tsconfigPaths: true` option is correctly positioned in the Vite config merge
- Confirm that the dependency removal from `package.json` is intentional and complete
- Check that existing test suites still pass to ensure TypeScript path resolution works as expected

**Additional context**
- Vite 8.0.0 (the version specified in the CLI's dependencies) includes native support for `tsconfigPaths` in the resolve config
- This removes a maintenance burden and reduces the dependency tree
- The changeset document at `.changeset/empty-dogs-pay.md` describes this as a patch bump for `@equinor/fusion-framework-cli`

**Related issues**
<!-- Add any related issue numbers if applicable -->

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - [x] _Included files validated_
  - [x] _No new linting warnings_
  - [x] _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

