### PR TITLE
docs(react-app): document analytics sub-path

### DIFF
--- a/.changeset/fusion-framework-docs_react-app-analytics.md
+++ b/.changeset/fusion-framework-docs_react-app-analytics.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Add analytics documentation for `@equinor/fusion-framework-react-app/analytics`. Covers the `useTrackFeature` hook, the `AnyValueMap` type dependency note, the `app-feature` event shape, and usage examples for button clicks, data attributes, and component mount tracking.

--- a/packages/react/app/docs/analytics.md
+++ b/packages/react/app/docs/analytics.md
@@ -1,0 +1,116 @@
+# Analytics
+
+React hooks for tracking application feature usage through the Fusion analytics module.
+
+**Import:**
+
+```ts
+import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
+```
+
+The analytics module is enabled and configured by the hosting portal, so **apps running inside a Fusion portal can use these hooks immediately without any setup**.
+
+## When to Track
+
+Use `useTrackFeature` when you want to record a discrete user action or application milestone. Focus on actions that answer a question about user behavior or feature value — you do not need to track every click.
+
+| Use case                | What to track                            | Example event name           |
+| ----------------------- | ---------------------------------------- | ---------------------------- |
+| Button or action clicks | User triggers a specific workflow        | `'export-clicked'`           |
+| Page or component views | A section of the app is displayed        | `'dashboard-loaded'`         |
+| Feature gate checks     | A feature behind a flag is accessed      | `'beta-feature-used'`        |
+| Form submissions        | A user completes a form or wizard step   | `'report-submitted'`         |
+| Error recovery actions  | A user retries or dismisses an error     | `'retry-clicked'`            |
+
+## useTrackFeature
+
+Returns a stable callback for tracking feature usage events. Each event automatically includes the current app key and active context as attributes, so downstream dashboards can group events by application and context without extra work.
+
+**Signature:**
+
+```ts
+function useTrackFeature(): (name: string, data?: AnyValueMap) => void;
+```
+
+| Parameter | Type                       | Description                                  |
+| --------- | -------------------------- | -------------------------------------------- |
+| `name`    | `string`                   | Name of the feature being tracked            |
+| `data`    | `AnyValueMap` _(optional)_ | Additional key-value pairs included with the event |
+
+### Track a Button Click
+
+```tsx
+import { useCallback } from 'react';
+import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
+
+const MyButton = () => {
+  const trackFeature = useTrackFeature();
+
+  const handleClick = useCallback(() => {
+    trackFeature('button-clicked');
+  }, [trackFeature]);
+
+  return <button onClick={handleClick}>Click me</button>;
+};
+```
+
+### Track with Additional Data
+
+Pass a second argument to include custom attributes with the event:
+
+```tsx
+import { useCallback } from 'react';
+import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
+
+const SaveButton = ({ section }: { section: string }) => {
+  const trackFeature = useTrackFeature();
+
+  const handleSave = useCallback(() => {
+    trackFeature('save-clicked', { section, timestamp: Date.now() });
+  }, [trackFeature, section]);
+
+  return <button onClick={handleSave}>Save</button>;
+};
+```
+
+### Track on Component Mount
+
+Use `useEffect` to track when a component or page loads:
+
+```tsx
+import { useEffect } from 'react';
+import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
+
+const Dashboard = () => {
+  const trackFeature = useTrackFeature();
+
+  useEffect(() => {
+    trackFeature('dashboard-loaded');
+  }, [trackFeature]);
+
+  return <div>Dashboard content</div>;
+};
+```
+
+## Prerequisites
+
+The analytics module must be enabled for the hook to work. **In most cases, no app-level configuration is needed** — the hosting Fusion portal already enables and configures analytics. Your app inherits this automatically.
+
+If the module is not available (e.g. in a standalone or custom portal setup), `useTrackFeature` logs an exception via the telemetry provider instead of throwing, so your app will not crash.
+
+### Custom or Standalone Setups
+
+If you are building a custom portal or running outside the standard Fusion portal, enable the analytics module yourself:
+
+```ts
+import { enableAnalytics } from '@equinor/fusion-framework-module-analytics';
+import { ConsoleAnalyticsAdapter } from '@equinor/fusion-framework-module-analytics/adapters';
+
+const configure = (configurator) => {
+  enableAnalytics(configurator, (builder) => {
+    builder.setAdapter('console', async () => new ConsoleAnalyticsAdapter());
+  });
+};
+```
+
+See the [analytics module documentation](https://equinor.github.io/fusion-framework/modules/analytics/) for adapter and collector setup.

--- a/packages/react/app/docs/analytics.md
+++ b/packages/react/app/docs/analytics.md
@@ -8,13 +8,19 @@ React hooks for tracking application feature usage through the Fusion analytics 
 import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
 ```
 
-The analytics module is enabled and configured by the hosting portal, so **apps running inside a Fusion portal can use these hooks immediately without any setup**.
+The analytics module is enabled and configured by the hosting portal, so **apps running inside a Fusion portal can use these hooks immediately without any runtime setup**.
+
+> [!IMPORTANT]
+> `useTrackFeature` accepts an `AnyValueMap` type parameter from `@equinor/fusion-framework-module-analytics`. This package is a `devDependency` of `@equinor/fusion-framework-react-app`, so **no runtime installation is needed** when running inside a Fusion portal. However, if your app imports `AnyValueMap` directly for typing, you may need to add `@equinor/fusion-framework-module-analytics` as a `devDependency` in your own project for TypeScript to resolve the type.
 
 ## When to Track
 
 Use `useTrackFeature` when you want to record a discrete user action or application milestone. Focus on actions that answer a question about user behavior or feature value — you do not need to track every click.
 
-| Use case                | What to track                            | Example event name           |
+> [!NOTE]
+> The `name` argument you pass to the tracking callback becomes `value.feature` in the analytics event. The emitted analytics event always has `name: 'app-feature'` — the `name` you supply is the **feature name**, not the analytics event name.
+
+| Use case                | What to track                            | Example feature name        |
 | ----------------------- | ---------------------------------------- | ---------------------------- |
 | Button or action clicks | User triggers a specific workflow        | `'export-clicked'`           |
 | Page or component views | A section of the app is displayed        | `'dashboard-loaded'`         |


### PR DESCRIPTION
## Description

Add `docs/analytics.md` to `packages/react/app/` covering the `useTrackFeature` hook for tracking feature usage in Fusion apps.

### What's included

- **useTrackFeature**: signature, return value, parameters
- **Examples**: button click tracking, additional data, component mount tracking
- **Prerequisites**: host-managed analytics module, custom/standalone setup guidance

### Source

Uplifted from `src/analytics/README.md` — restructured for the `docs/` folder and indexed retrieval.

Closes equinor/fusion-core-tasks#864