### PR TITLE
docs(react-app): document http sub-path

### DIFF
--- a/packages/react/app/docs/http.md
+++ b/packages/react/app/docs/http.md
@@ -1,0 +1,119 @@
+# HTTP
+
+Make authenticated HTTP calls from your Fusion app using the framework-managed HTTP client.
+
+**Import:**
+
+```ts
+import { useHttpClient } from '@equinor/fusion-framework-react-app/http';
+```
+
+**Selectors sub-path:**
+
+```ts
+import { jsonSelector, blobSelector } from '@equinor/fusion-framework-react-app/http/selectors';
+```
+
+## Overview
+
+The `useHttpClient` hook provides access to named HTTP clients that are pre-configured with authentication, base URLs, and interceptors. Clients must be registered in the app configurator before use — the hook creates a memoised client instance by name.
+
+The `selectors` sub-path re-exports response selectors (`jsonSelector`, `blobSelector`, `createSseSelector`) from the HTTP module, providing typed helpers for parsing fetch responses.
+
+## Configure an HTTP Client
+
+Register a named client in your app's configuration callback:
+
+```ts
+import type { AppConfigurator } from '@equinor/fusion-framework-react-app';
+
+export const configure = (configurator: AppConfigurator) => {
+  configurator.configureHttpClient('my-api', {
+    baseUri: 'https://api.example.com',
+    defaultScopes: ['api://my-api/.default'],
+  });
+};
+```
+
+## useHttpClient
+
+Returns a configured `IHttpClient` instance by name. Throws if no client is registered for the given key.
+
+**Signature:**
+
+```ts
+function useHttpClient(name: string): IHttpClient;
+```
+
+| Parameter | Type     | Description                          |
+| --------- | -------- | ------------------------------------ |
+| `name`    | `string` | Named client key from configuration  |
+
+**Returns:** An `IHttpClient` instance with `fetch`, `json`, `blob`, and other request methods.
+
+### Fetch JSON Data
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useHttpClient } from '@equinor/fusion-framework-react-app/http';
+import { jsonSelector } from '@equinor/fusion-framework-react-app/http/selectors';
+
+type Item = { id: string; name: string };
+
+const ItemList = () => {
+  const client = useHttpClient('my-api');
+  const [items, setItems] = useState<Item[]>([]);
+
+  useEffect(() => {
+    client.fetch('/items', { selector: jsonSelector })
+      .then(setItems);
+  }, [client]);
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
+};
+```
+
+### POST Data
+
+```tsx
+import { useCallback } from 'react';
+import { useHttpClient } from '@equinor/fusion-framework-react-app/http';
+
+const CreateItem = () => {
+  const client = useHttpClient('my-api');
+
+  const handleSubmit = useCallback(async (name: string) => {
+    await client.fetch('/items', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }, [client]);
+
+  return <button onClick={() => handleSubmit('New item')}>Create</button>;
+};
+```
+
+## Response Selectors
+
+The `selectors` sub-path provides typed helpers for parsing HTTP responses:
+
+| Selector             | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `jsonSelector`       | Parses response as JSON with type inference     |
+| `blobSelector`       | Returns response as a `Blob`                   |
+| `createSseSelector`  | Creates a selector for Server-Sent Events streams |
+
+These are re-exported from `@equinor/fusion-framework-module-http/selectors`.
+
+## Prerequisites
+
+- HTTP clients must be configured in your app's configurator before calling `useHttpClient`
+- Authentication scopes are attached automatically based on the client configuration
+- For detailed HTTP module configuration, see the [`@equinor/fusion-framework-module-http` documentation](../../modules/http/README.md)

--- a/packages/react/app/docs/http.md
+++ b/packages/react/app/docs/http.md
@@ -25,9 +25,9 @@ The `selectors` sub-path re-exports response selectors (`jsonSelector`, `blobSel
 Register a named client in your app's configuration callback:
 
 ```ts
-import type { AppConfigurator } from '@equinor/fusion-framework-react-app';
+import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
 
-export const configure = (configurator: AppConfigurator) => {
+export const configure: AppModuleInitiator = (configurator) => {
   configurator.configureHttpClient('my-api', {
     baseUri: 'https://api.example.com',
     defaultScopes: ['api://my-api/.default'],
@@ -56,7 +56,6 @@ function useHttpClient(name: string): IHttpClient;
 ```tsx
 import { useEffect, useState } from 'react';
 import { useHttpClient } from '@equinor/fusion-framework-react-app/http';
-import { jsonSelector } from '@equinor/fusion-framework-react-app/http/selectors';
 
 type Item = { id: string; name: string };
 
@@ -65,7 +64,7 @@ const ItemList = () => {
   const [items, setItems] = useState<Item[]>([]);
 
   useEffect(() => {
-    client.fetch('/items', { selector: jsonSelector })
+    client.json<Item[]>('/items')
       .then(setItems);
   }, [client]);
 
@@ -106,7 +105,7 @@ The `selectors` sub-path provides typed helpers for parsing HTTP responses:
 
 | Selector             | Description                                    |
 | -------------------- | ---------------------------------------------- |
-| `jsonSelector`       | Parses response as JSON with type inference     |
+| `jsonSelector`       | Parses response as JSON; use a typed call (e.g. `client.json<T>(...)`) to get a typed result |
 | `blobSelector`       | Returns response as a `Blob`                   |
 | `createSseSelector`  | Creates a selector for Server-Sent Events streams |
 
@@ -116,4 +115,4 @@ These are re-exported from `@equinor/fusion-framework-module-http/selectors`.
 
 - HTTP clients must be configured in your app's configurator before calling `useHttpClient`
 - Authentication scopes are attached automatically based on the client configuration
-- For detailed HTTP module configuration, see the [`@equinor/fusion-framework-module-http` documentation](../../modules/http/README.md)
+- For detailed HTTP module configuration, see the [`@equinor/fusion-framework-module-http` documentation](../../../modules/http/README.md)


### PR DESCRIPTION
## Description

Add `docs/http.md` to `packages/react/app/` covering the `useHttpClient` hook and the `selectors` sub-path for making authenticated HTTP calls in Fusion apps.

### What's included

- **Client configuration**: how to register a named HTTP client in the app configurator
- **useHttpClient**: signature, error behavior, and memoisation
- **Examples**: fetch JSON, POST data
- **Response selectors**: `jsonSelector`, `blobSelector`, `createSseSelector` reference
- **Prerequisites**: client configuration requirement, auth scope handling

Closes equinor/fusion-core-tasks#866