### PR TITLE
docs(react-app): document root entry point hooks

### DIFF
--- a/packages/react/app/docs/app.md
+++ b/packages/react/app/docs/app.md
@@ -1,0 +1,140 @@
+# App (Root Entry Point)
+
+Core bootstrapping and module access hooks for Fusion React applications.
+
+**Import:**
+
+```ts
+import { renderApp, useAppModule, useAppModules, useAppEnvironmentVariables } from '@equinor/fusion-framework-react-app';
+```
+
+## renderApp
+
+The standard bootstrap function for Fusion React apps. Wraps your root component and an optional configuration callback into a render function that the Fusion portal calls to mount your app.
+
+**Signature:**
+
+```ts
+function renderApp(
+  Component: React.ComponentType,
+  configure?: (configurator: IAppConfigurator) => void,
+): (el: HTMLElement, args: ComponentRenderArgs) => RenderTeardown;
+```
+
+**Returns:** A mount function the portal calls with a DOM element and render args. The returned `RenderTeardown` callback unmounts the app.
+
+### How to Use
+
+Export `renderApp` as your app's `render` entrypoint:
+
+```ts
+// main.ts
+import { renderApp } from '@equinor/fusion-framework-react-app';
+import { App } from './App';
+import { configure } from './config';
+
+export const render = renderApp(App, configure);
+export default render;
+```
+
+The `configure` callback receives an `IAppConfigurator` where you register modules (HTTP clients, context, navigation, etc.):
+
+```ts
+// config.ts
+import type { IAppConfigurator } from '@equinor/fusion-framework-react-app';
+
+export const configure = (configurator: IAppConfigurator) => {
+  configurator.configureHttpClient('my-api', {
+    baseUri: 'https://api.example.com',
+    defaultScopes: ['api://my-api/.default'],
+  });
+};
+```
+
+## useAppModule
+
+Retrieves a single typed module instance from the application scope. Throws if the module is not registered.
+
+**Signature:**
+
+```ts
+function useAppModule<TType>(module: string): ModuleType<TType>;
+```
+
+**Example:**
+
+```tsx
+import { useAppModule } from '@equinor/fusion-framework-react-app';
+
+const MyComponent = () => {
+  const auth = useAppModule('auth');
+  // auth is typed based on the registered module
+  return <button onClick={() => auth.acquireAccessToken()}>Get token</button>;
+};
+```
+
+## useAppModules
+
+Returns the full set of initialised application-scoped modules. Use this when you need to inspect or access multiple modules at once — prefer `useAppModule` for single-module access.
+
+**Signature:**
+
+```ts
+function useAppModules<T>(): AppModulesInstance<T>;
+```
+
+**Example:**
+
+```tsx
+import { useAppModules } from '@equinor/fusion-framework-react-app';
+
+const DebugPanel = () => {
+  const modules = useAppModules();
+  return <pre>{Object.keys(modules).join(', ')}</pre>;
+};
+```
+
+## useAppEnvironmentVariables
+
+Returns the app's environment variables as an observable state. The value is loaded asynchronously from the app configuration, so you should handle `complete` and `error` states.
+
+**Signature:**
+
+```ts
+function useAppEnvironmentVariables<TEnvironmentVariables>(): ObservableStateReturnType<TEnvironmentVariables>;
+```
+
+**Returns:**
+
+| Property   | Type                         | Description                                          |
+| ---------- | ---------------------------- | ---------------------------------------------------- |
+| `value`    | `TEnvironmentVariables`      | The resolved environment variables                   |
+| `complete` | `boolean`                    | `true` when loading is finished                      |
+| `error`    | `unknown`                    | Error if loading failed, otherwise `undefined`       |
+
+**Example:**
+
+```tsx
+import { useAppEnvironmentVariables } from '@equinor/fusion-framework-react-app';
+
+type MyEnv = {
+  apiUrl: string;
+  featureFlags: Record<string, boolean>;
+};
+
+const MyComponent = () => {
+  const env = useAppEnvironmentVariables<MyEnv>();
+
+  if (!env.complete) return <p>Loading environment…</p>;
+  if (env.error) return <p>Failed to load environment</p>;
+
+  return <p>API URL: {env.value.apiUrl}</p>;
+};
+```
+
+## Deprecated APIs
+
+> [!CAUTION]
+> `createComponent` and `makeComponent` are **deprecated**. Use `renderApp` instead.
+
+These older bootstrapping functions are still exported for backward compatibility but should not be used in new apps.

--- a/packages/react/app/docs/app.md
+++ b/packages/react/app/docs/app.md
@@ -16,10 +16,12 @@ The standard bootstrap function for Fusion React apps. Wraps your root component
 
 ```ts
 function renderApp(
-  Component: React.ComponentType,
-  configure?: (configurator: IAppConfigurator) => void,
+  Component: React.ElementType,
+  configure?: AppModuleInitiator,
 ): (el: HTMLElement, args: ComponentRenderArgs) => RenderTeardown;
 ```
+
+`AppModuleInitiator` receives `(configurator, { fusion, env })` and may return `Promise<void>` for async setup.
 
 **Returns:** A mount function the portal calls with a DOM element and render args. The returned `RenderTeardown` callback unmounts the app.
 
@@ -37,13 +39,13 @@ export const render = renderApp(App, configure);
 export default render;
 ```
 
-The `configure` callback receives an `IAppConfigurator` where you register modules (HTTP clients, context, navigation, etc.):
+The `configure` callback is an `AppModuleInitiator` — it receives `(configurator, { fusion, env })` and may be async:
 
 ```ts
 // config.ts
-import type { IAppConfigurator } from '@equinor/fusion-framework-react-app';
+import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
 
-export const configure = (configurator: IAppConfigurator) => {
+export const configure: AppModuleInitiator = (configurator) => {
   configurator.configureHttpClient('my-api', {
     baseUri: 'https://api.example.com',
     defaultScopes: ['api://my-api/.default'],
@@ -58,8 +60,14 @@ Retrieves a single typed module instance from the application scope. Throws if t
 **Signature:**
 
 ```ts
-function useAppModule<TType>(module: string): ModuleType<TType>;
+// Key-based inference (no explicit generic needed for known modules):
+function useAppModule(module: 'auth' | 'context' | ...): InferredModuleType;
+
+// Explicit generic for custom/unknown module keys:
+function useAppModule<TType extends AnyModule>(module: string): ModuleType<TType>;
 ```
+
+When called with a known string literal key (e.g. `'auth'`), the return type is inferred automatically. Pass an explicit generic only when using a custom or unrecognised key.
 
 **Example:**
 
@@ -108,9 +116,9 @@ function useAppEnvironmentVariables<TEnvironmentVariables>(): ObservableStateRet
 
 | Property   | Type                         | Description                                          |
 | ---------- | ---------------------------- | ---------------------------------------------------- |
-| `value`    | `TEnvironmentVariables`      | The resolved environment variables                   |
-| `complete` | `boolean`                    | `true` when loading is finished                      |
-| `error`    | `unknown`                    | Error if loading failed, otherwise `undefined`       |
+| `value`    | `TEnvironmentVariables \| undefined` | The resolved environment variables, or `undefined` before the observable emits |
+| `complete` | `boolean`                           | `true` when loading is finished                                                |
+| `error`    | `unknown \| null`                   | Error if loading failed, `null` otherwise                                      |
 
 **Example:**
 
@@ -135,6 +143,6 @@ const MyComponent = () => {
 ## Deprecated APIs
 
 > [!CAUTION]
-> `createComponent` and `makeComponent` are **deprecated**. Use `renderApp` instead.
+> `createComponent` is **deprecated**. Use `renderApp` instead.
 
 These older bootstrapping functions are still exported for backward compatibility but should not be used in new apps.


### PR DESCRIPTION
## Description

Add `docs/app.md` to `packages/react/app/` covering the root entry point hooks and bootstrapping API.

### What's included

- **renderApp**: standard bootstrap function with configuration callback
- **useAppModule**: typed single-module access hook
- **useAppModules**: full module set accessor
- **useAppEnvironmentVariables**: async environment variable hook with observable state
- **Deprecated APIs**: `createComponent` and `makeComponent` deprecation notice

Closes equinor/fusion-core-tasks#868