### PR TITLE
docs(react): add deprecation README to legacy-interopt

### DIFF
--- a/packages/react/legacy-interopt/README.md
+++ b/packages/react/legacy-interopt/README.md
@@ -1,0 +1,14 @@
+# @equinor/fusion-framework-react-legacy-interopt
+
+> [!CAUTION]
+> **Deprecated — Do not use.**
+>
+> This package is a vestigial stub with no exports, no `package.json`, and no functionality. It exists only as a historical artifact and will be removed in a future cleanup.
+
+## Status
+
+This directory contains only a generated `version.ts` file. It is not published to npm, has no documented exports, and serves no purpose for application developers or framework consumers.
+
+## Migration
+
+There is no migration path because the package has no functionality. If you have an import referencing `@equinor/fusion-framework-react-legacy-interopt`, remove it — it does not provide anything.

--- a/packages/react/legacy-interopt/README.md
+++ b/packages/react/legacy-interopt/README.md
@@ -7,7 +7,7 @@
 
 ## Status
 
-This directory contains only a generated `version.ts` file. It is not published to npm, has no documented exports, and serves no purpose for application developers or framework consumers.
+This directory contains only `src/version.ts` (a generated version file). It is not published to npm, has no documented exports, and serves no purpose for application developers or framework consumers.
 
 ## Migration
 


### PR DESCRIPTION
## Description

Add a deprecation README to `packages/react/legacy-interopt`.

### Context

The `legacy-interopt` package is a vestigial stub containing only a generated `version.ts`. It has no `package.json`, no CHANGELOG, and no exports. The README makes its deprecated status unambiguous.

Closes equinor/fusion-core-tasks#875