### PR TITLE
docs(react-module-http): add README and @packageDocumentation TSDoc

### DIFF
--- a/packages/react/modules/http/README.md
+++ b/packages/react/modules/http/README.md
@@ -1,0 +1,56 @@
+# @equinor/fusion-framework-react-module-http
+
+React integration layer for the Fusion HTTP module. Provides the `useHttpClient` hook for making authenticated HTTP requests from React components.
+
+## What This Package Exports
+
+| Export              | Type     | Description                                                   |
+| ------------------- | -------- | ------------------------------------------------------------- |
+| `useHttpClient`     | Hook     | Returns a configured `IHttpClient` instance by name           |
+| `IHttpClient`       | Type     | HTTP client interface with `fetch`, `json`, `blob` methods    |
+| `HttpClientMsal`    | Class    | MSAL-authenticated HTTP client implementation                 |
+| `FetchRequestInit`  | Type     | Extended fetch init type with selector support                |
+| `HttpResponseError` | Class    | Error thrown for non-ok HTTP responses                        |
+| `HttpJsonResponseError` | Class | Error thrown for failed JSON response parsing                |
+
+**Import:**
+
+```ts
+import { useHttpClient } from '@equinor/fusion-framework-react-module-http';
+```
+
+## When to Use This vs `react-app/http`
+
+| Scenario                                 | Import from                                        |
+| ---------------------------------------- | -------------------------------------------------- |
+| Building a Fusion app (most common)      | `@equinor/fusion-framework-react-app/http`         |
+| Building a reusable library or module    | `@equinor/fusion-framework-react-module-http`      |
+| Building a portal or host application    | `@equinor/fusion-framework-react-module-http`      |
+
+The `react-app/http` sub-path re-exports `useHttpClient` from this package. App developers should prefer the `react-app` import for consistency. Use this package directly when building framework-level code, shared libraries, or portal shells.
+
+## useHttpClient
+
+Creates a memoised HTTP client instance from a named configuration. Throws if no client is configured for the given name.
+
+**Signature:**
+
+```ts
+function useHttpClient(name: string): IHttpClient;
+```
+
+**Example:**
+
+```tsx
+import { useHttpClient } from '@equinor/fusion-framework-react-module-http';
+
+const DataFetcher = () => {
+  const client = useHttpClient('my-api');
+  // client.fetch('/endpoint'), client.json('/data'), etc.
+};
+```
+
+## Related
+
+- [`@equinor/fusion-framework-module-http`](../../modules/http/README.md) — the underlying HTTP module with full configuration documentation
+- [`@equinor/fusion-framework-react-app/http`](../app/docs/http.md) — app-developer-facing wrapper

--- a/packages/react/modules/http/README.md
+++ b/packages/react/modules/http/README.md
@@ -52,5 +52,5 @@ const DataFetcher = () => {
 
 ## Related
 
-- [`@equinor/fusion-framework-module-http`](../../modules/http/README.md) — the underlying HTTP module with full configuration documentation
-- [`@equinor/fusion-framework-react-app/http`](../app/docs/http.md) — app-developer-facing wrapper
+- [`@equinor/fusion-framework-module-http`](../../../modules/http/README.md) — the underlying HTTP module with full configuration documentation
+- [`@equinor/fusion-framework-react-app/http`](../../app/README.md#http-requests) — app-developer-facing wrapper

--- a/packages/react/modules/http/src/index.ts
+++ b/packages/react/modules/http/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * React integration for the Fusion HTTP module.
+ *
+ * Re-exports the {@link useHttpClient} hook for making authenticated HTTP requests
+ * from React components, plus core HTTP types and error classes from the
+ * underlying `@equinor/fusion-framework-module-http` module.
+ *
+ * @packageDocumentation
+ */
 export {
   IHttpClient,
   HttpClientMsal,


### PR DESCRIPTION
## Description

Add README and `@packageDocumentation` TSDoc to `packages/react/modules/http`.

### What's included

- **README**: exports table, when to use this vs `react-app/http`, `useHttpClient` signature
- **TSDoc**: `@packageDocumentation` block in `src/index.ts` for IDE hover documentation

Closes equinor/fusion-core-tasks#876