### PR TITLE
docs(react-module-event): add README and @packageDocumentation TSDoc

### DIFF
--- a/.changeset/fusion-framework-react-module-event_docs-review-fix.md
+++ b/.changeset/fusion-framework-react-module-event_docs-review-fix.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-module-event": patch
+---
+
+Clarify the React event module README by updating `useEventHandler` and `useEventStream` signatures to match the real generic types, and fixing the broken relative link to the underlying event module.

--- a/packages/react/modules/event/README.md
+++ b/packages/react/modules/event/README.md
@@ -1,0 +1,81 @@
+# @equinor/fusion-framework-react-module-event
+
+React integration for the Fusion event module. Provides hooks and components for subscribing to and dispatching framework events from React components.
+
+**Import:**
+
+```ts
+import { useEventHandler, useEventStream, EventConsumer, EventProvider } from '@equinor/fusion-framework-react-module-event';
+```
+
+## Exports
+
+| Export                   | Type      | Description                                                     |
+| ------------------------ | --------- | --------------------------------------------------------------- |
+| `useEventHandler`        | Hook      | Subscribe to a named framework event with a callback            |
+| `useEventStream`         | Hook      | Get an RxJS observable stream for a named event                 |
+| `useEventProvider`       | Hook      | Access the event module provider directly                       |
+| `useModulesEventProvider` | Hook     | Access the event provider from the module scope                 |
+| `EventConsumer`          | Component | React context consumer for the event provider                   |
+| `EventProvider`          | Component | React context provider for injecting an event provider          |
+
+All types from `@equinor/fusion-framework-module-event` are also re-exported.
+
+## useEventHandler
+
+Subscribe to a framework event by name. The callback is registered on mount and cleaned up on unmount.
+
+**Signature:**
+
+```ts
+function useEventHandler(key: string, cb: FrameworkEventHandler): void;
+```
+
+**Example:**
+
+```tsx
+import { useCallback } from 'react';
+import { useEventHandler } from '@equinor/fusion-framework-react-module-event';
+
+const ContextChangeListener = () => {
+  useEventHandler(
+    'onCurrentContextChanged',
+    useCallback((event) => {
+      console.log('Context changed:', event.detail);
+    }, [])
+  );
+
+  return <div>Listening for context changes…</div>;
+};
+```
+
+## useEventStream
+
+Returns an RxJS observable stream filtered to a specific event. Useful when you need to compose event streams with RxJS operators.
+
+**Signature:**
+
+```ts
+function useEventStream<TKey>(key: TKey, operator?: OperatorFunction): Observable;
+```
+
+> [!NOTE]
+> The `operator` parameter must be memoised to avoid re-creating the stream on every render.
+
+**Example:**
+
+```tsx
+import { useEventStream } from '@equinor/fusion-framework-react-module-event';
+import { useObservableState } from '@equinor/fusion-observable/react';
+
+const EventCounter = () => {
+  const events$ = useEventStream('onCurrentContextChanged');
+  const { value: lastEvent } = useObservableState(events$);
+
+  return <p>Last event: {JSON.stringify(lastEvent?.detail)}</p>;
+};
+```
+
+## Related
+
+- [`@equinor/fusion-framework-module-event`](../../modules/event/README.md) — the underlying event module with full API documentation

--- a/packages/react/modules/event/README.md
+++ b/packages/react/modules/event/README.md
@@ -28,7 +28,10 @@ Subscribe to a framework event by name. The callback is registered on mount and 
 **Signature:**
 
 ```ts
-function useEventHandler(key: string, cb: FrameworkEventHandler): void;
+function useEventHandler<TKey extends keyof FrameworkEventMap>(
+  key: TKey,
+  cb: FrameworkEventHandler<FrameworkEventMap[TKey]>,
+): void;
 ```
 
 **Example:**
@@ -56,7 +59,10 @@ Returns an RxJS observable stream filtered to a specific event. Useful when you 
 **Signature:**
 
 ```ts
-function useEventStream<TKey>(key: TKey, operator?: OperatorFunction): Observable;
+function useEventStream<
+  TKey extends keyof FrameworkEventMap,
+  TData = FrameworkEventMap[TKey],
+>(key: TKey, operator?: OperatorFunction<FrameworkEventMap[TKey], TData>): Observable<TData>;
 ```
 
 > [!NOTE]
@@ -78,4 +84,4 @@ const EventCounter = () => {
 
 ## Related
 
-- [`@equinor/fusion-framework-module-event`](../../modules/event/README.md) — the underlying event module with full API documentation
+- [`@equinor/fusion-framework-module-event`](../../../modules/event/README.md) — the underlying event module with full API documentation

--- a/packages/react/modules/event/src/index.ts
+++ b/packages/react/modules/event/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * React integration for the Fusion event module.
+ *
+ * Provides hooks ({@link useEventHandler}, {@link useEventStream}) and
+ * React context components ({@link EventConsumer}, {@link EventProvider})
+ * for subscribing to and dispatching framework events from React components.
+ *
+ * @packageDocumentation
+ */
 export * from '@equinor/fusion-framework-module-event';
 
 export { EventConsumer, EventProvider } from './eventContext';


### PR DESCRIPTION
## Description

Add README and `@packageDocumentation` TSDoc to `packages/react/modules/event`.

### What's included

- **README**: exports table, `useEventHandler` and `useEventStream` with examples
- **TSDoc**: `@packageDocumentation` block in `src/index.ts`

Closes equinor/fusion-core-tasks#877