### PR TITLE
docs(react-module-context): add README and @packageDocumentation TSDoc

### DIFF
--- a/.changeset/fusion-framework-react-module-context_docs-review-fix.md
+++ b/.changeset/fusion-framework-react-module-context_docs-review-fix.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-module-context": patch
+---
+
+Clarify the React context module README by documenting all package exports and linking to the existing app-scoped context wrapper documentation.

--- a/packages/react/modules/context/README.md
+++ b/packages/react/modules/context/README.md
@@ -1,0 +1,78 @@
+# @equinor/fusion-framework-react-module-context
+
+React hooks for the Fusion context module. Provides hooks to read the current context, set context, and query available contexts from React components.
+
+**Import:**
+
+```ts
+import { useCurrentContext, useQueryContext, enableContext } from '@equinor/fusion-framework-react-module-context';
+```
+
+## Exports
+
+| Export                      | Type     | Description                                                    |
+| --------------------------- | -------- | -------------------------------------------------------------- |
+| `useCurrentContext`         | Hook     | Read and set the current context (requires a provider argument) |
+| `useModuleCurrentContext`   | Hook     | Read and set the current context from the closest module scope |
+| `useQueryContext`           | Hook     | Search available contexts with debounce (requires a provider)  |
+| `useModuleQueryContext`     | Hook     | Search available contexts from the closest module scope        |
+| `enableContext`             | Function | Enable the context module in a configurator                    |
+| `ContextModule`             | Type     | Context module type definition                                 |
+| `ContextItem`               | Type     | A single context entry (project, facility, etc.)               |
+| `IContextProvider`          | Type     | Context provider interface                                     |
+
+## This Package vs `react-app/context`
+
+| Scenario                                | Import from                                          |
+| --------------------------------------- | ---------------------------------------------------- |
+| Building a Fusion app (most common)     | `@equinor/fusion-framework-react-app/context`        |
+| Building a reusable library or module   | `@equinor/fusion-framework-react-module-context`     |
+| Building a portal or host application   | `@equinor/fusion-framework-react-module-context`     |
+
+The `react-app/context` sub-path wraps these hooks with app-scoped convenience. Use this package directly when building framework-level code or shared libraries that need explicit provider injection.
+
+## useCurrentContext / useModuleCurrentContext
+
+Returns the currently selected context and a setter function.
+
+```tsx
+import { useModuleCurrentContext } from '@equinor/fusion-framework-react-module-context';
+
+const ContextInfo = () => {
+  const { currentContext, setCurrentContext } = useModuleCurrentContext();
+
+  if (!currentContext) return <p>No context selected</p>;
+
+  return (
+    <div>
+      <p>{currentContext.title}</p>
+      <button onClick={() => setCurrentContext(null)}>Clear</button>
+    </div>
+  );
+};
+```
+
+## useQueryContext / useModuleQueryContext
+
+Search for available contexts with built-in debounce (default 500ms).
+
+```tsx
+import { useModuleQueryContext } from '@equinor/fusion-framework-react-module-context';
+
+const ContextSearch = () => {
+  const { value: results, querying, query } = useModuleQueryContext();
+
+  return (
+    <div>
+      <input onChange={(e) => query(e.target.value)} placeholder="Search contexts…" />
+      {querying && <span>Searching…</span>}
+      <ul>{results?.map((ctx) => <li key={ctx.id}>{ctx.title}</li>)}</ul>
+    </div>
+  );
+};
+```
+
+## Related
+
+- [`@equinor/fusion-framework-module-context`](../../modules/context/README.md) — the underlying context module
+- [`@equinor/fusion-framework-react-app/context`](../app/docs/context.md) — app-developer-facing wrapper

--- a/packages/react/modules/context/README.md
+++ b/packages/react/modules/context/README.md
@@ -19,7 +19,10 @@ import { useCurrentContext, useQueryContext, enableContext } from '@equinor/fusi
 | `enableContext`             | Function | Enable the context module in a configurator                    |
 | `ContextModule`             | Type     | Context module type definition                                 |
 | `ContextItem`               | Type     | A single context entry (project, facility, etc.)               |
+| `ContextItemType`           | Type     | Context item type discriminator                                |
 | `IContextProvider`          | Type     | Context provider interface                                     |
+| `IContextModuleConfigurator` | Type     | Configurator interface for enabling the context module         |
+| `FusionContextSearchError`  | Error    | Error thrown when context search fails                         |
 
 ## This Package vs `react-app/context`
 
@@ -75,4 +78,4 @@ const ContextSearch = () => {
 ## Related
 
 - [`@equinor/fusion-framework-module-context`](../../modules/context/README.md) — the underlying context module
-- [`@equinor/fusion-framework-react-app/context`](../app/docs/context.md) — app-developer-facing wrapper
+- [`@equinor/fusion-framework-react-app/context`](../../app/README.md#context) — app-developer-facing wrapper

--- a/packages/react/modules/context/src/index.ts
+++ b/packages/react/modules/context/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * React integration for the Fusion context module.
+ *
+ * Provides hooks for reading the current context ({@link useCurrentContext},
+ * {@link useModuleCurrentContext}) and querying available contexts
+ * ({@link useQueryContext}, {@link useModuleQueryContext}).
+ *
+ * @packageDocumentation
+ */
 export {
   enableContext,
   ContextModule,


### PR DESCRIPTION
## Description

Add README and `@packageDocumentation` TSDoc to `packages/react/modules/context`.

### What's included

- **README**: exports table, context hooks with examples, distinction from `react-app/context`
- **TSDoc**: `@packageDocumentation` block in `src/index.ts`

Closes equinor/fusion-core-tasks#878