### PR TITLE
docs(modules): add @packageDocumentation TSDoc to bookmark, event, feature-flag, module

### DIFF
--- a/packages/modules/bookmark/src/index.ts
+++ b/packages/modules/bookmark/src/index.ts
@@ -1,3 +1,14 @@
+/**
+ * Bookmark module for the Fusion Framework.
+ *
+ * Provides bookmark management (create, update, delete, favourite) with
+ * application-scoped payloads and event-driven state updates.
+ *
+ * @see {@link enableBookmark} to enable the module in a configurator.
+ * @see {@link BookmarkProvider} for the runtime provider API.
+ *
+ * @packageDocumentation
+ */
 export { BookmarkModuleConfigurator } from './BookmarkConfigurator';
 
 export type {

--- a/packages/modules/event/src/index.ts
+++ b/packages/modules/event/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Event module for the Fusion Framework.
+ *
+ * Provides a typed, observable event system for cross-module communication.
+ * Modules dispatch {@link FrameworkEvent} instances through the
+ * {@link IEventModuleProvider} and consumers subscribe with type-safe handlers.
+ *
+ * @see {@link EventModule} for the module definition.
+ * @see {@link filterEvent} to filter event streams by type.
+ *
+ * @packageDocumentation
+ */
 export { FrameworkEvent } from './event';
 export type {
   IFrameworkEvent,

--- a/packages/modules/feature-flag/src/index.ts
+++ b/packages/modules/feature-flag/src/index.ts
@@ -1,3 +1,14 @@
+/**
+ * Feature-flag module for the Fusion Framework.
+ *
+ * Enables runtime feature toggling with typed flag definitions.
+ * Flags are configured at build time via {@link FeatureFlagConfigurator}
+ * and read at runtime through {@link FeatureFlagProvider}.
+ *
+ * @see {@link enableFeatureFlagging} to enable the module in a configurator.
+ *
+ * @packageDocumentation
+ */
 export * from './types';
 
 export { type IFeatureFlagConfigurator, FeatureFlagConfigurator } from './FeatureFlagConfigurator';

--- a/packages/modules/module/src/index.ts
+++ b/packages/modules/module/src/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Core module system for the Fusion Framework.
+ *
+ * Defines the base types, interfaces, and utilities for creating and
+ * initializing framework modules. All Fusion modules implement the
+ * {@link Module} interface and are wired together via
+ * {@link initializeModules}.
+ *
+ * @see {@link ModuleConfigBuilder} for building module configuration.
+ * @see {@link SemanticVersion} for version utilities.
+ *
+ * @packageDocumentation
+ */
 export type {
   AnyModule,
   AnyModuleInstance,

--- a/packages/modules/module/src/index.ts
+++ b/packages/modules/module/src/index.ts
@@ -6,7 +6,7 @@
  * {@link Module} interface and are wired together via
  * {@link initializeModules}.
  *
- * @see {@link ModuleConfigBuilder} for building module configuration.
+ * @see {@link BaseConfigBuilder} for building module configuration.
  * @see {@link SemanticVersion} for version utilities.
  *
  * @packageDocumentation


### PR DESCRIPTION
## Description

Add `@packageDocumentation` TSDoc blocks to `src/index.ts` for four modules that had READMEs but no inline API docs.

### What's included

- `packages/modules/bookmark/src/index.ts` — bookmark module description + `@see` links
- `packages/modules/event/src/index.ts` — event module description + `@see` links
- `packages/modules/feature-flag/src/index.ts` — feature-flag module description + `@see` links
- `packages/modules/module/src/index.ts` — core module system description + `@see` links

Closes equinor/fusion-core-tasks#879