### PR TITLE
docs(cookbooks): improve poc-portal and portal READMEs

### DIFF
--- a/cookbooks/poc-portal/README.md
+++ b/cookbooks/poc-portal/README.md
@@ -1,49 +1,48 @@
 # POC Portal Cookbook
 
-> [!NOTE]
-> This application is a proof of concept for a portal as an application from a static hosted site.
-
 > [!WARNING]
-> This is **NOT** an example of a production ready application. This is a proof of concept and should **NOT** be used as a reference for production applications.
-
-## Overview
-
-This cookbook demonstrates a proof of concept for hosting a portal as an application from a static site. It explores the boundaries and capabilities of the Fusion Framework portal system.
+> This is a **proof of concept** — not a production-ready application. Use it to learn portal initialization patterns, not as a template.
 
 ## Purpose
 
-This POC is designed to:
-- Test portal functionality in a static hosting environment
-- Explore integration patterns for portal applications
-- Validate architectural concepts
+This cookbook demonstrates how to **bootstrap a Fusion portal from a statically hosted site**. It validates that a portal can:
 
-## What This Is
+1. Receive framework modules from the host environment
+2. Create a `FrameworkProvider` and configure portal-level modules (app, HTTP)
+3. Load and render child applications inside the portal shell
 
-- A working example of portal concepts
-- An experimental implementation
-- A learning resource
+Study this cookbook to understand the portal bootstrapping lifecycle before building a real portal host.
 
-## What This Is Not
+## Key Concepts
 
-- **NOT** a production-ready application
-- **NOT** a recommended pattern for production use
-- **NOT** fully tested or supported
+### Portal entry point (`src/index.tsx`)
 
-## Getting Started
+The portal exports a `render(el, modules)` function that receives an HTML element and the host's pre-initialized modules. This is the contract between the static host and the portal shell.
 
-\`\`\`bash
-# Install dependencies
+### Framework provider (`src/Framework.tsx`)
+
+`createFrameworkProvider` wraps the portal in a Fusion framework context. Inside, the configurator:
+
+- Enables the **app module** (`enableAppModule`) so the portal can discover and load child apps
+- Configures an HTTP client for the app proxy endpoint
+- Sets the current app on initialization
+
+### App list (`src/AppList.tsx`)
+
+Renders the list of discoverable applications, demonstrating how a portal enumerates and presents available apps.
+
+## How to Run
+
+```bash
 pnpm install
-
-# Start development server
 pnpm dev
-\`\`\`
+```
 
-## Important Notes
+## What to Look At
 
-This proof of concept should be used only for:
-- Understanding portal concepts
-- Experimentation
-- Testing ideas
-
-Do **NOT** use this as a template for production applications.
+| File               | What it demonstrates                                    |
+| ------------------ | ------------------------------------------------------- |
+| `src/index.tsx`    | Portal render contract — `render(el, modules)`          |
+| `src/Framework.tsx`| `createFrameworkProvider` + app module configuration     |
+| `src/AppList.tsx`  | Listing and rendering child apps inside a portal        |
+| `src/config.ts`    | Application-level module configurator lifecycle hooks    |

--- a/cookbooks/poc-portal/README.md
+++ b/cookbooks/poc-portal/README.md
@@ -42,6 +42,7 @@ pnpm dev
 
 | File               | What it demonstrates                                    |
 | ------------------ | ------------------------------------------------------- |
+| `src/portal/bootloader.ts` | Static-host side — initializes modules and calls `render(el, ref)` |
 | `src/index.tsx`    | Portal render contract — `render(el, modules)`          |
 | `src/Framework.tsx`| `createFrameworkProvider` + app module configuration     |
 | `src/AppList.tsx`  | Listing and rendering child apps inside a portal        |

--- a/cookbooks/portal/README.md
+++ b/cookbooks/portal/README.md
@@ -1,54 +1,46 @@
 # Portal Cookbook
 
-This cookbook demonstrates the basic portal framework for building widget-based applications.
+A minimal portal shell built with the Fusion Framework CLI. Demonstrates the simplest possible portal bootstrap — a standalone React render without framework module wiring.
 
-## What This Shows
+## Purpose
 
-This cookbook illustrates a simple portal implementation that provides a foundation for widget-based architectures.
+This cookbook shows **how a portal entry point is structured** when using the Fusion CLI dev server. Unlike a Fusion *app* (which receives its framework context from a hosting portal), a portal *is* the host. It owns the root render and decides which modules, apps, and layout to provide.
 
-## Code Example
+## How It Differs from an App Cookbook
 
-```typescript
-import { createElement } from 'react';
-import { createRoot } from 'react-dom/client';
-import { Portal } from './Portal';
+| Aspect           | App cookbook                          | Portal cookbook                        |
+| ---------------- | ------------------------------------ | ------------------------------------- |
+| Entry export     | `configure` + component              | `render(el)` — owns the DOM root      |
+| Framework context| Provided by the portal host          | Created by the portal itself          |
+| Module setup     | Receives pre-configured modules      | Configures and initializes modules    |
+| Typical use      | Feature inside a portal              | The shell that hosts features         |
 
+## Key Concept: The Render Contract
+
+A portal exports a `render` function that the CLI dev server calls with a DOM element:
+
+```ts
 export const render = (el: HTMLElement) => {
   createRoot(el).render(createElement(Portal));
 };
 ```
 
-## Portal Component
+In production, this same contract is used by the static host to mount the portal.
 
-```typescript
-export const Portal = () => {
-  return (
-    <div style={{
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '100vh',
-      backgroundColor: '#cfd2d3',
-    }}>
-      <div style={{
-        maxHeight: '90%',
-        backgroundColor: 'white',
-        borderRadius: '8px',
-        padding: '20px',
-        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
-        textAlign: 'center',
-      }}>
-        <h1>Welcome to the CLI Demo Portal</h1>
-        <p>This is a sample portal application.</p>
-      </div>
-    </div>
-  );
-};
+## How to Run
+
+```bash
+pnpm install
+pnpm dev
 ```
 
-## When to Use Portals
+## What to Look At
 
-Use portals for:
-- Widget-based application architecture
-- Hosting multiple apps in cabinets
-- Building workspaces with multiple tools
+| File            | What it demonstrates                          |
+| --------------- | --------------------------------------------- |
+| `src/index.tsx` | Portal render contract — `render(el)`         |
+| `src/Portal.tsx`| Minimal portal shell component                |
+
+## Next Steps
+
+For a more complete portal example with framework modules, app loading, and HTTP configuration, see the [poc-portal cookbook](../poc-portal/README.md).

--- a/cookbooks/portal/README.md
+++ b/cookbooks/portal/README.md
@@ -1,18 +1,18 @@
 # Portal Cookbook
 
-A minimal portal shell built with the Fusion Framework CLI. Demonstrates the simplest possible portal bootstrap — a standalone React render without framework module wiring.
+A minimal portal shell built with the Fusion Framework CLI (`ffc`). Demonstrates the simplest possible portal bootstrap — a standalone React render without framework module wiring.
 
 ## Purpose
 
-This cookbook shows **how a portal entry point is structured** when using the Fusion CLI dev server. Unlike a Fusion *app* (which receives its framework context from a hosting portal), a portal *is* the host. It owns the root render and decides which modules, apps, and layout to provide.
+This cookbook shows **how a portal entry point is structured** when using the Fusion Framework CLI dev server. Unlike a Fusion *app* (which receives its framework context from a hosting portal), a portal *is* the host. It owns the root render and decides which modules, apps, and layout to provide.
 
 ## How It Differs from an App Cookbook
 
 | Aspect           | App cookbook                          | Portal cookbook                        |
 | ---------------- | ------------------------------------ | ------------------------------------- |
-| Entry export     | `configure` + component              | `render(el)` — owns the DOM root      |
+| Entry export     | `renderApp(el, args)` — default export | `render(el)` — owns the DOM root      |
 | Framework context| Provided by the portal host          | Created by the portal itself          |
-| Module setup     | Receives pre-configured modules      | Configures and initializes modules    |
+| Module setup     | `configure` in `src/config.ts`       | Configures and initializes modules    |
 | Typical use      | Feature inside a portal              | The shell that hosts features         |
 
 ## Key Concept: The Render Contract


### PR DESCRIPTION
## Description

Rewrite `poc-portal` and `portal` cookbook READMEs to explain what each demonstrates and guide developers through the code.

### What's included

- **poc-portal**: Purpose, key concepts (entry point, framework provider, app list), file-by-file guide
- **portal**: Purpose, portal vs app comparison table, render contract explanation, next-steps link

Closes equinor/fusion-core-tasks#881