### PR TITLE
fix(vite-plugin-spa): Preserve HTTP method and body in service worker request forwarding

### DIFF
--- a/.changeset/free-games-visit.md
+++ b/.changeset/free-games-visit.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Forward request method and body to service worker fetch calls

--- a/packages/vite-plugins/spa/src/html/sw.ts
+++ b/packages/vite-plugins/spa/src/html/sw.ts
@@ -192,12 +192,13 @@ self.addEventListener('message', async (event: ExtendableMessageEvent) => {
 
 // Handle fetch events
 self.addEventListener('fetch', (event: FetchEvent) => {
-  const url = new URL(event.request.url);
+  const request = event.request.clone();
+  const url = new URL(request.url);
   const matchedConfig = getMatchingConfig(url.toString());
 
   // only handle requests that match the config
   if (matchedConfig) {
-    const requestHeaders = new Headers(event.request.headers);
+    const requestHeaders = new Headers(request.headers);
     const handleRequest = async () => {
       // if the matched config has scopes, append the token to the request
       if (matchedConfig.scopes) {
@@ -210,8 +211,18 @@ self.addEventListener('fetch', (event: FetchEvent) => {
         url.pathname = url.pathname.replace(matchedConfig?.url, matchedConfig.rewrite);
       }
 
-      // fetch the request with the modified url and headers
-      return fetch(url, { headers: requestHeaders });
+      // Consume the ReadableStream body and convert to text
+      // ReadableStreams can only be consumed once, so we extract the content here
+      // request.text() resolves to empty string when the request has no body
+      const body = await request.text();
+
+      // fetch the request with the modified url and headers, preserving the original HTTP method and body
+      // This ensures OPTIONS, PATCH, DELETE and other methods are forwarded correctly
+      return fetch(url, {
+        method: request.method,
+        headers: requestHeaders,
+        body: body || undefined,
+      });
     };
     event.respondWith(handleRequest());
   }


### PR DESCRIPTION
## Why is this change needed?

The SPA Vite plugin service worker intercepts and rewrites matching requests before forwarding them through `fetch`. When forwarding these rewritten requests, the service worker must preserve both the original HTTP method and request body to ensure proxy behavior matches the caller's intent.

## What was the problem?

The service worker was forwarding rewritten requests with only the modified URL and headers. Without the original HTTP method and body, the browser would default proxied requests to `GET`, breaking non-`GET` traffic such as `OPTIONS`, `PATCH`, `DELETE`, and `POST` requests.

## What changed?

The service worker now forwards:
- `event.request.method` – preserves the original HTTP method
- `request.text()` body – preserves the original request body

URL rewriting and header forwarding behavior remain unchanged. All requests are now semantic-preserving through the service worker proxy.

## Invariant

Service worker request rewriting must not change the HTTP method or body of the original request. A `PATCH`, `DELETE`, `OPTIONS`, `POST`, or any other method must be forwarded with that same method after URL rewrite and header preparation.

## Impact

- **Breaking changes**: None
- **Version bump**: Patch (via `.changeset/free-games-visit.md`)
- **Package affected**: `@equinor/fusion-framework-vite-plugin-spa`
- **Consumer impact**: Non-`GET` requests through the SPA Vite plugin service worker now forward with the correct HTTP method and body

## Review focus

Verify that the forwarded `fetch` call:
1. ✓ Preserves existing URL rewrite behavior
2. ✓ Preserves existing header forwarding
3. ✓ Adds the original request method
4. ✓ Adds the original request body
5. ✓ Correctly handles empty bodies

---

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [ ] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

