### PR TITLE
fix(module-msal): avoid ~10-20s iframe timeout when refresh token is revoked

### DIFF
--- a/.changeset/fusion-framework-module-msal_fix-cache-lookup-policy.md
+++ b/.changeset/fusion-framework-module-msal_fix-cache-lookup-policy.md
@@ -1,0 +1,23 @@
+---
+"@equinor/fusion-framework-module-msal": patch
+---
+
+Fix silent token acquisition hanging ~10–20 s when refresh token is revoked.
+
+When a refresh token is revoked, MSAL's default cache lookup policy (`Default`) falls back to a hidden iframe (`SilentIframeClient`) after the token endpoint returns `invalid_grant`. The iframe loads the app URL, fails to authenticate (no valid session), and times out — throwing `monitor_window_timeout` before eventually triggering an interactive redirect. This causes the visible "iframe crash + page reload" symptom.
+
+The configurator now defaults `cacheLookupPolicy` to `CacheLookupPolicy.AccessTokenAndRefreshToken`, which skips the iframe step entirely. A revoked refresh token now immediately throws `InteractionRequiredAuthError`, and the app falls back to interactive login without the delay.
+
+**Configuration:**
+
+The policy is fully configurable via `MsalConfigurator.setCacheLookupPolicy`. To restore MSAL's original waterfall (cache → refresh token → iframe):
+
+```typescript
+import { CacheLookupPolicy } from '@azure/msal-browser';
+
+configurator.setCacheLookupPolicy(CacheLookupPolicy.Default);
+```
+
+Per-request `cacheLookupPolicy` on `SilentRequest` still takes precedence over the instance default.
+
+Fixes: https://github.com/equinor/fusion-core-tasks/issues/1234

--- a/packages/modules/msal/src/MsalClient.ts
+++ b/packages/modules/msal/src/MsalClient.ts
@@ -1,5 +1,6 @@
 import {
   PublicClientApplication,
+  type CacheLookupPolicy,
   type SilentRequest,
   type Configuration,
   type EndSessionRequest,
@@ -40,6 +41,23 @@ export type MsalClientConfig = Configuration & {
     /** Optional tenant identifier for Azure AD tenant */
     tenantId?: string;
   };
+  /**
+   * Cache lookup policy applied to every `acquireTokenSilent` call.
+   *
+   * Controls whether MSAL falls back to a hidden iframe when the refresh token
+   * fails. When `undefined`, MSAL's built-in default applies (cache → refresh
+   * token → iframe). Set to `CacheLookupPolicy.AccessTokenAndRefreshToken` to
+   * skip the iframe step and fail immediately with `InteractionRequiredAuthError`
+   * when the refresh token is revoked — avoiding the ~10–20 s
+   * `monitor_window_timeout` delay.
+   *
+   * When using {@link MsalConfigurator}, this defaults to
+   * `CacheLookupPolicy.AccessTokenAndRefreshToken`. When constructing `MsalClient`
+   * directly, the field is optional and defaults to `undefined` (MSAL default).
+   *
+   * Per-request `cacheLookupPolicy` on `SilentRequest` takes precedence over this value.
+   */
+  cacheLookupPolicy?: CacheLookupPolicy;
 };
 
 /**
@@ -65,6 +83,7 @@ export type MsalClientConfig = Configuration & {
 export class MsalClient extends PublicClientApplication implements IMsalClient {
   #tenantId?: string;
   #clientId?: string;
+  #cacheLookupPolicy?: CacheLookupPolicy;
 
   /**
    * Creates a new MSAL client instance.
@@ -75,6 +94,7 @@ export class MsalClient extends PublicClientApplication implements IMsalClient {
     super(config);
     this.#tenantId = config.auth?.tenantId;
     this.#clientId = config.auth?.clientId;
+    this.#cacheLookupPolicy = config.cacheLookupPolicy;
   }
 
   /**
@@ -257,7 +277,11 @@ export class MsalClient extends PublicClientApplication implements IMsalClient {
             'Attempting to acquire token silently',
             request.correlationId || FUSION_CORRELATION_ID,
           );
-          return await this.acquireTokenSilent(request as SilentRequest);
+          return await this.acquireTokenSilent({
+            // Instance-level policy is the default; request-level cacheLookupPolicy takes precedence
+            cacheLookupPolicy: this.#cacheLookupPolicy,
+            ...(request as SilentRequest),
+          });
         } catch {
           // Silent acquisition failed - fall back to interactive
           this.getLogger().warning(

--- a/packages/modules/msal/src/MsalConfigurator.ts
+++ b/packages/modules/msal/src/MsalConfigurator.ts
@@ -45,7 +45,11 @@ const MsalConfigSchema = z.object({
   redirectUri: z.string().optional(),
   loginHint: z.string().optional(),
   authCode: z.string().optional(),
-  cacheLookupPolicy: z.custom<CacheLookupPolicy>().optional(),
+  cacheLookupPolicy: z
+    .custom<CacheLookupPolicy>(
+      (val) => typeof val === 'number' && Object.values(CacheLookupPolicy).includes(val as CacheLookupPolicy),
+    )
+    .optional(),
   version: z.string().transform((x: string) => String(semver.coerce(x))),
   telemetry: TelemetryConfigSchema,
 });
@@ -100,7 +104,7 @@ export class MsalConfigurator extends BaseConfigBuilder<MsalConfig> {
       }
     });
     // Default cache lookup policy to AccessTokenAndRefreshToken to avoid iframe fallback delays
-    this._set('cacheLookupPolicy', async () => CacheLookupPolicy.AccessTokenAndRefreshToken); 
+    this._set('cacheLookupPolicy', async () => CacheLookupPolicy.AccessTokenAndRefreshToken);
   }
 
   /**

--- a/packages/modules/msal/src/MsalConfigurator.ts
+++ b/packages/modules/msal/src/MsalConfigurator.ts
@@ -47,7 +47,9 @@ const MsalConfigSchema = z.object({
   authCode: z.string().optional(),
   cacheLookupPolicy: z
     .custom<CacheLookupPolicy>(
-      (val) => typeof val === 'number' && Object.values(CacheLookupPolicy).includes(val as CacheLookupPolicy),
+      (val) =>
+        typeof val === 'number' &&
+        Object.values(CacheLookupPolicy).includes(val as CacheLookupPolicy),
     )
     .optional(),
   version: z.string().transform((x: string) => String(semver.coerce(x))),

--- a/packages/modules/msal/src/MsalConfigurator.ts
+++ b/packages/modules/msal/src/MsalConfigurator.ts
@@ -8,7 +8,7 @@ import {
 } from '@equinor/fusion-framework-module-telemetry';
 import { MsalClient, type MsalClientConfig, type IMsalClient } from './MsalClient';
 import { createClientLogCallback } from './create-client-log-callback';
-import { LogLevel } from '@azure/msal-browser';
+import { CacheLookupPolicy, LogLevel } from '@azure/msal-browser';
 import { version } from './version';
 
 /**
@@ -45,6 +45,7 @@ const MsalConfigSchema = z.object({
   redirectUri: z.string().optional(),
   loginHint: z.string().optional(),
   authCode: z.string().optional(),
+  cacheLookupPolicy: z.custom<CacheLookupPolicy>().optional(),
   version: z.string().transform((x: string) => String(semver.coerce(x))),
   telemetry: TelemetryConfigSchema,
 });
@@ -98,6 +99,8 @@ export class MsalConfigurator extends BaseConfigBuilder<MsalConfig> {
         return telemetry;
       }
     });
+    // Default cache lookup policy to AccessTokenAndRefreshToken to avoid iframe fallback delays
+    this._set('cacheLookupPolicy', async () => CacheLookupPolicy.AccessTokenAndRefreshToken); 
   }
 
   /**
@@ -122,6 +125,34 @@ export class MsalConfigurator extends BaseConfigBuilder<MsalConfig> {
    */
   setClientConfig(config?: MsalClientConfig): this {
     this.#msalConfig = config;
+    return this;
+  }
+
+  /**
+   * Sets the cache lookup policy used for every silent token acquisition.
+   *
+   * Controls whether MSAL falls back to a hidden iframe when the refresh token
+   * fails. Defaults to `CacheLookupPolicy.AccessTokenAndRefreshToken`, which skips
+   * the iframe step and fails immediately with `InteractionRequiredAuthError` when
+   * the refresh token is revoked — avoiding the ~10–20 s `monitor_window_timeout`
+   * delay caused by MSAL's built-in iframe fallback.
+   *
+   * Set to `CacheLookupPolicy.Default` to restore MSAL's full waterfall:
+   * cache → refresh token → iframe.
+   *
+   * @param policy - Cache lookup policy to apply
+   * @returns The configurator instance for method chaining
+   *
+   * @example
+   * ```typescript
+   * import { CacheLookupPolicy } from '@azure/msal-browser';
+   *
+   * // Restore MSAL's built-in iframe fallback (not recommended for most apps)
+   * configurator.setCacheLookupPolicy(CacheLookupPolicy.Default);
+   * ```
+   */
+  setCacheLookupPolicy(policy: CacheLookupPolicy | undefined): this {
+    this._set('cacheLookupPolicy', async () => policy);
     return this;
   }
 
@@ -346,6 +377,11 @@ export class MsalConfigurator extends BaseConfigBuilder<MsalConfig> {
           },
         };
       }
+      // Apply silent cache lookup policy if configured
+      if (config.cacheLookupPolicy !== undefined) {
+        clientConfig.cacheLookupPolicy = config.cacheLookupPolicy;
+      }
+
       // Instantiate MSAL client with fully configured options
       config.client = new MsalClient(clientConfig);
     }

--- a/packages/modules/msal/src/__tests__/MsalConfigurator.test.ts
+++ b/packages/modules/msal/src/__tests__/MsalConfigurator.test.ts
@@ -1,4 +1,5 @@
 import type { ConfigBuilderCallbackArgs } from '@equinor/fusion-framework-module';
+import { CacheLookupPolicy } from '@azure/msal-browser';
 import { describe, expect, it, vi } from 'vitest';
 import type { IMsalClient } from '../MsalClient.interface';
 import { type MsalConfig, MsalConfigurator } from '../MsalConfigurator';
@@ -71,5 +72,45 @@ describe('MsalConfigurator', () => {
     );
 
     expect(config.client).toBeUndefined();
+  });
+
+  describe('cacheLookupPolicy', () => {
+    it('defaults to CacheLookupPolicy.AccessTokenAndRefreshToken', async () => {
+      const configurator = new MsalConfigurator();
+      configurator.setClient(createClient());
+
+      const config = await configurator.createConfigAsync(
+        createConfigCallbackArgs(),
+        createInitialConfig(),
+      );
+
+      expect(config.cacheLookupPolicy).toBe(CacheLookupPolicy.AccessTokenAndRefreshToken);
+    });
+
+    it('setCacheLookupPolicy(undefined) clears the policy so MSAL default applies', async () => {
+      const configurator = new MsalConfigurator();
+      configurator.setClient(createClient());
+      configurator.setCacheLookupPolicy(undefined);
+
+      const config = await configurator.createConfigAsync(
+        createConfigCallbackArgs(),
+        createInitialConfig(),
+      );
+
+      expect(config.cacheLookupPolicy).toBeUndefined();
+    });
+
+    it('setCacheLookupPolicy overrides the default', async () => {
+      const configurator = new MsalConfigurator();
+      configurator.setClient(createClient());
+      configurator.setCacheLookupPolicy(CacheLookupPolicy.Default);
+
+      const config = await configurator.createConfigAsync(
+        createConfigCallbackArgs(),
+        createInitialConfig(),
+      );
+
+      expect(config.cacheLookupPolicy).toBe(CacheLookupPolicy.Default);
+    });
   });
 });


### PR DESCRIPTION
**Why is this change needed?**

When a user's refresh token is revoked (e.g. admin revoke, password change, session expiry), the MSAL silent token acquisition hangs for ~10–20 s before the page reloads and recovers. This causes a visible "iframe crash" in the portal.

**What is the current behavior?**

`acquireTokenSilent` receives `invalid_grant` from the token endpoint when the refresh token is revoked. MSAL's default `CacheLookupPolicy` (`Default = 0`) internally falls back to a hidden `SilentIframeClient` — it opens a hidden iframe, loads the app URL, waits for a valid SSO session cookie, and only throws `InteractionRequiredAuthError` (error code `monitor_window_timeout`) after the iframe times out (~10–20 s). This blocks the user with a frozen/crashed iframe experience before the redirect recovery kicks in.

**What is the new behavior?**

`MsalConfigurator` now sets `cacheLookupPolicy` to `CacheLookupPolicy.AccessTokenAndRefreshToken` by default. This instructs MSAL to try cache + refresh token only — skipping the iframe fallback entirely. A revoked refresh token immediately throws `InteractionRequiredAuthError`, and the existing fallback to `acquireTokenRedirect` fires without delay.

**What is the intended behavior or invariant?**

When silent token acquisition fails due to a revoked or expired refresh token, the app must fall back to interactive login immediately — not after a ~10–20 s iframe timeout. The iframe fallback is only useful when third-party cookies are enabled and a valid identity-provider SSO session exists, which is increasingly rare in modern browsers.

**Does this PR introduce a breaking change?**

No. The default policy is changed but is fully overridable:

```typescript
import { CacheLookupPolicy } from '@azure/msal-browser';

// Restore MSAL's original iframe fallback waterfall
configurator.setCacheLookupPolicy(CacheLookupPolicy.Default);
```

Per-request `cacheLookupPolicy` on `SilentRequest` still takes precedence over the instance default.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Visible UX improvement — revoked tokens now trigger immediate re-login instead of a ~10–20 s hang. Consumers relying on the iframe SSO fallback must opt back in via `setCacheLookupPolicy(CacheLookupPolicy.Default)`.
- Downstream impact: `@equinor/fusion-framework-module-msal` only

**Review guidance:**

- [MsalConfigurator.ts](packages/modules/msal/src/MsalConfigurator.ts): Constructor sets `cacheLookupPolicy` default; `setCacheLookupPolicy` method exposes it. `_processConfig` passes it through to `MsalClientConfig`.
- [MsalClient.ts](packages/modules/msal/src/MsalClient.ts): `#cacheLookupPolicy` stored from config; applied as the base in `acquireTokenSilent` spread (request-level value wins via spread order).
- Key invariant: `cacheLookupPolicy` in the spread comes _before_ `...(request as SilentRequest)` so a per-request value always takes precedence.

**Additional context**

- MSAL-js issue tracking the root behavior: [#4104](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4104), [#5110](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/5110)
- `CacheLookupPolicy.AccessTokenAndRefreshToken` was introduced in `msal-browser@2.29` (PR [#5014](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/5014)) specifically to address this scenario. The framework was already on a version that supports it.

**Related issues**

closes equinor/fusion-core-tasks#1235
ref: equinor/fusion-core-tasks#1230

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [ ] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
