### PR TITLE
docs(module): document configurator lifecycle and module system

### DIFF
--- a/.changeset/fusion-framework-docs_module-plugin-docs.md
+++ b/.changeset/fusion-framework-docs_module-plugin-docs.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Document module configurator plugins, including `registerPlugin`, `createPlugin`, plugin teardown behavior, lifecycle ordering, and VuePress navigation updates.

--- a/.changeset/fusion-framework-module_docs-configurator-lifecycle.md
+++ b/.changeset/fusion-framework-module_docs-configurator-lifecycle.md
@@ -1,0 +1,20 @@
+---
+"@equinor/fusion-framework-module": patch
+"@equinor/fusion-framework-docs": patch
+---
+
+Document the `@equinor/fusion-framework-module` configurator and lifecycle.
+
+Adds structured `docs/` pages covering:
+
+- **concepts** — module system overview, roles, and mental model
+- **lifecycle** — configure → initialize → post-initialize → dispose phase sequence
+- **configuration** — how to register modules and use `addConfig` / `configure`
+- **cross-module deps** — `requireInstance` pattern for inter-module dependencies
+- **events** — `event$` observable and event naming conventions
+- **authoring modules** — step-by-step guide for creating a custom module
+- **common mistakes** — FAQ-style pitfalls and how to avoid them
+
+All pages are structured for retrieval (chunked sections, import paths, copy-pasteable examples) to improve Fusion Knowledge / Azure AI Search answer quality.
+
+Closes: equinor/fusion-core-tasks#1258

--- a/.changeset/fusion-framework-module_register-plugin.md
+++ b/.changeset/fusion-framework-module_register-plugin.md
@@ -5,7 +5,7 @@
 
 Add `registerPlugin` to `IModulesConfigurator` and `ModulesConfigurator` for application-level side effects that run after modules are initialized and before application render.
 
-Plugins receive the initialized module map through `FrameworkPluginArgs` and may return a teardown callback that runs during `dispose`. Plugin-related types and the `createPlugin(name, callback)` helper are available from the dedicated `@equinor/fusion-framework-module/plugins` entrypoint. Plugin registration and teardown failures are isolated so one failing plugin does not block other plugins or module disposal.
+Plugins receive the initialized module map through `FrameworkPluginArgs` and may return a teardown callback that runs during `dispose`. Plugin-related types and the `createPlugin(name, callback)` helper are available from the dedicated `@equinor/fusion-framework-module/plugins` entrypoint. Plugin registration and teardown failures are isolated so one failing plugin does not block other plugins or module disposal. `ModuleConfiguratorEventName` and `ModuleConfiguratorEventBaseName` are available from the `@equinor/fusion-framework-module/configurator` entrypoint for filtering `ModuleConfigurator.{name}.{state}` lifecycle events without hard-coded strings.
 
 ```typescript
 import { createPlugin } from '@equinor/fusion-framework-module/plugins';

--- a/packages/modules/module/README.md
+++ b/packages/modules/module/README.md
@@ -17,6 +17,7 @@ A `Module` is a plain object that declares a name, an optional configuration fac
 1. **Configure** – each module's `configure()` factory creates a config builder; registered callbacks mutate it; `postConfigure()` hooks run.
 2. **Initialize** – modules are initialized concurrently; cross-module dependencies are resolved through `requireInstance()`.
 3. **Post-initialize** – `postInitialize()` hooks and `onInitialized` callbacks run.
+4. **Plugins** – registered plugins connect host-level side effects after every module is ready.
 
 The result is a sealed `ModulesInstance` whose property names match the module keys and whose values are the initialized providers.
 
@@ -36,6 +37,7 @@ Abstract base class for module providers (the runtime instances returned by `ini
 | [Lifecycle](./docs/lifecycle.md) | Configure → initialize → post-initialize → dispose phase sequence |
 | [Configuration](./docs/configuration.md) | How to register modules and use `addConfig` / `configure` |
 | [Cross-Module Dependencies](./docs/cross-module-deps.md) | `requireInstance` pattern for inter-module dependencies |
+| [Plugins](./docs/plugins.md) | `registerPlugin`, `createPlugin`, plugin teardown, and host-level side effects |
 | [Events](./docs/events.md) | `event$` observable and event naming conventions |
 | [Authoring Modules](./docs/authoring-modules.md) | Step-by-step guide for creating a custom module |
 | [Common Mistakes](./docs/common-mistakes.md) | FAQ-style pitfalls and how to avoid them |
@@ -104,7 +106,7 @@ export const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurat
 | Export | Kind | Description |
 |---|---|---|
 | `Module` | type | Interface describing a module's structure and lifecycle hooks |
-| `ModulesConfigurator` | class | Orchestrates configure → initialize → dispose for a set of modules |
+| `ModulesConfigurator` | class | Orchestrates configure → initialize → plugin → dispose for a set of modules |
 | `IModulesConfigurator` | interface | Public contract for the modules configurator |
 | `IModuleConfigurator` | interface | Descriptor for registering a single module with lifecycle hooks |
 | `BaseConfigBuilder` | class | Abstract config builder with dot-path targeting and observable pipelines |
@@ -116,6 +118,25 @@ export const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurat
 | `ModuleConsoleLogger` | class | Styled console logger with module-name formatting |
 | `IModuleConsoleLogger` | interface | Logger interface with `formatModuleName` |
 | `DotPath`, `DotPathType`, `DotPathUnion` | types | Recursive dot-notation path utilities |
+
+### Configurator Sub-path (`@equinor/fusion-framework-module/configurator`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `ModuleConfiguratorEventBaseName` | const | Shared `ModuleConfigurator` base segment for configurator lifecycle event names |
+| `ModuleConfiguratorEventName` | object | Map of `ModuleConfigurator.{name}.{state}` event names for filtering `event$` without hard-coded strings |
+
+### Plugins Sub-path (`@equinor/fusion-framework-module/plugins`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `createPlugin` | function | Creates a named plugin callback for stable lifecycle diagnostics |
+| `FrameworkPluginArgs` | type | Arguments passed to inline plugin callbacks: initialized modules and optional ref |
+| `FrameworkPluginCallback` | type | Callback accepted by `IModulesConfigurator.registerPlugin` |
+| `FrameworkPluginTeardown` | type | Cleanup callback or disposable object returned by a plugin |
+| `FrameworkPluginRegistration` | type | Plugin return type: teardown or `undefined` |
+| `FrameworkPlugin` | interface | Named plugin callback returned by `createPlugin` |
+| `FrameworkPluginInitializer` | type | Developer-facing callback signature used by `createPlugin` |
 
 ### Provider Sub-path (`@equinor/fusion-framework-module/provider`)
 
@@ -138,6 +159,8 @@ export const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurat
 ├──────────┼──────────────────────────┼────────────────┤
 │ Init     │ module.initialize()      │                │
 │          │ module.postInitialize()  │ onInitialized()│
+├──────────┼──────────────────────────┼────────────────┤
+│ Plugin   │                          │ registerPlugin │
 ├──────────┼──────────────────────────┼────────────────┤
 │ Dispose  │ module.dispose()         │ instance.      │
 │          │                          │  dispose()     │
@@ -172,6 +195,25 @@ postInitialize: async ({ instance, modules }) => {
 ```
 
 `configure` and `initialize` are the two required hooks. `postConfigure`, `postInitialize`, and `dispose` are optional.
+
+### Plugins and host-level side effects
+
+Use `registerPlugin` for application-owned wiring that needs the complete module instance before render. Plugins run after `postInitialize` and `onInitialized`, but before `initialize()` resolves. Return a teardown callback to clean up subscriptions, global listeners, timers, or telemetry bindings during dispose.
+
+```typescript
+import { createPlugin } from '@equinor/fusion-framework-module/plugins';
+
+const contextTelemetryPlugin = createPlugin<[typeof eventModule, typeof telemetryModule]>(
+  'contextTelemetry',
+  (modules) => modules.event.addEventListener('context:changed', (event) => {
+    modules.telemetry.track('context.changed', event.detail);
+  }),
+);
+
+configurator.registerPlugin(contextTelemetryPlugin);
+```
+
+See [Plugins](./docs/plugins.md) for teardown rules, failure behavior, and API reference.
 
 Events are emitted on `configurator.event$` throughout the lifecycle for telemetry and debugging.
 

--- a/packages/modules/module/README.md
+++ b/packages/modules/module/README.md
@@ -28,6 +28,18 @@ An abstract class for building module configuration declaratively. Subclasses ex
 
 Abstract base class for module providers (the runtime instances returned by `initialize()`). It manages a `Subscription` container for automatic teardown and exposes a `SemanticVersion` for compatibility checks.
 
+## Documentation
+
+| Topic | Description |
+|---|---|
+| [Concepts](./docs/concepts.md) | Module system overview, roles, and mental model |
+| [Lifecycle](./docs/lifecycle.md) | Configure → initialize → post-initialize → dispose phase sequence |
+| [Configuration](./docs/configuration.md) | How to register modules and use `addConfig` / `configure` |
+| [Cross-Module Dependencies](./docs/cross-module-deps.md) | `requireInstance` pattern for inter-module dependencies |
+| [Events](./docs/events.md) | `event$` observable and event naming conventions |
+| [Authoring Modules](./docs/authoring-modules.md) | Step-by-step guide for creating a custom module |
+| [Common Mistakes](./docs/common-mistakes.md) | FAQ-style pitfalls and how to avoid them |
+
 ## Installation
 
 ```sh

--- a/packages/modules/module/docs/authoring-modules.md
+++ b/packages/modules/module/docs/authoring-modules.md
@@ -1,0 +1,294 @@
+# Authoring Modules — @equinor/fusion-framework-module
+
+This guide walks through creating a complete Fusion Framework module from scratch. By the end you will have a typed module definition, a config builder that consumers can call, and a provider that the framework returns after initialization.
+
+## When to author a module
+
+Write a new module when you need to package a runtime capability — a client, a service, a store — in a way that:
+
+- can be configured independently by each consumer
+- can depend on other modules through the standard dependency resolution mechanism
+- can be reused across multiple applications without bundling application-specific configuration
+
+If you just need a utility function or a shared class, you do not need a module.
+
+## The three pieces
+
+Every module is made up of three separate artifacts: a **module definition** (plain object with lifecycle hooks), a **config builder** (collects consumer configuration), and a **provider** (the live runtime object). Keeping them separate means you can test each one independently — a config builder test does not need a running provider.
+
+---
+
+## Step 1 — Define the resolved config shape
+
+Start by thinking about what your module needs to know at runtime. Write a plain TypeScript interface for it. This is the shape that `initialize` receives — not the shape consumers set, but the shape the module itself reads.
+
+```typescript
+// The fully-resolved config the module reads at initialize time.
+// Keep this a plain interface; no classes, no observables.
+interface GreeterConfig {
+  greeting: string;
+  punctuation: string;
+}
+```
+
+---
+
+## Step 2 — Create the config builder
+
+The config builder is what consumers interact with in their `configure` callback. Extend `BaseConfigBuilder<YourConfig>` and expose one setter per configurable value. Each setter accepts a `ConfigBuilderCallback` — a function that receives the current partial config and returns the new value. This allows async configuration and per-key override chaining.
+
+```typescript
+import { BaseConfigBuilder, type ConfigBuilderCallback } from '@equinor/fusion-framework-module';
+
+class GreeterConfigurator extends BaseConfigBuilder<GreeterConfig> {
+  /**
+   * Set the greeting word. Defaults to 'Hello' if not called.
+   */
+  setGreeting(cb: ConfigBuilderCallback<string>): void {
+    this._set('greeting', cb);
+  }
+
+  /**
+   * Set the punctuation. Defaults to '!' if not called.
+   */
+  setPunctuation(cb: ConfigBuilderCallback<string>): void {
+    this._set('punctuation', cb);
+  }
+}
+```
+
+`_set(key, callback)` registers the callback under the given dot-path key. When `createConfigAsync` is called during initialization, all registered callbacks are resolved in registration order and merged into the final config object.
+
+**Tip:** Add defaults inside the module's `configure()` factory (step 4), not inside the setter. This lets consumers override defaults simply by calling the setter — no special "reset" path needed.
+
+---
+
+## Step 3 — Create the provider
+
+The provider is the live runtime object. It is what consumers get when they access `modules.greeter`. Extend `BaseModuleProvider` to inherit version tracking, a managed `Subscription` container, and a `dispose()` hook.
+
+```typescript
+import { BaseModuleProvider, type BaseModuleProviderCtorArgs } from '@equinor/fusion-framework-module/provider';
+
+class GreeterProvider extends BaseModuleProvider {
+  readonly #greeting: string;
+  readonly #punctuation: string;
+
+  constructor(args: BaseModuleProviderCtorArgs & { config: GreeterConfig }) {
+    super(args);
+    this.#greeting = args.config.greeting;
+    this.#punctuation = args.config.punctuation;
+  }
+
+  greet(name: string): string {
+    return `${this.#greeting}, ${name}${this.#punctuation}`;
+  }
+}
+```
+
+If your provider sets up subscriptions or timers, add them to `this.subscription` so they are cancelled automatically when the framework calls `dispose`:
+
+```typescript
+constructor(args: BaseModuleProviderCtorArgs & { config: GreeterConfig; feed$: Observable<string> }) {
+  super(args);
+  this.#greeting = args.config.greeting;
+  this.#punctuation = args.config.punctuation;
+
+  // Automatically cancelled when dispose() is called.
+  this.subscription.add(
+    args.feed$.subscribe((msg) => console.log(msg)),
+  );
+}
+```
+
+---
+
+## Step 4 — Declare the module
+
+Tie everything together in the module definition. The four generic parameters — `'greeter'`, `GreeterProvider`, `GreeterConfigurator`, `[]` — are the source of truth for the type system. Get them right once and everything else flows.
+
+```typescript
+import { type Module } from '@equinor/fusion-framework-module';
+
+export type GreeterModule = Module<'greeter', GreeterProvider, GreeterConfigurator>;
+
+export const greeterModule: GreeterModule = {
+  name: 'greeter',
+
+  // Create a fresh config builder for each initialization.
+  // Set defaults here so consumers can override them with setters.
+  configure: () => {
+    const builder = new GreeterConfigurator();
+    builder.setGreeting(() => 'Hello');
+    builder.setPunctuation(() => '!');
+    return builder;
+  },
+
+  // Build the provider from the resolved config.
+  initialize: async ({ config }) => {
+    const resolved = await config.createConfigAsync({
+      config: {},
+      hasModule: () => false,
+      requireInstance: async () => { throw new Error('no modules'); },
+    });
+    return new GreeterProvider({ version: '1.0.0', config: resolved });
+  },
+};
+```
+
+**Exporting the module type** (`GreeterModule`) as a named type lets other modules declare it as a dependency in their `TDeps` generic.
+
+---
+
+## Step 5 — Write an enable function (optional but recommended)
+
+Convention in Fusion Framework is to ship an `enableXxx` function alongside the module. This gives consumers a one-liner API and a single place to express configuration:
+
+```typescript
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+export function enableGreeter(
+  configurator: IModulesConfigurator<any, any>,
+  configure?: (builder: GreeterConfigurator) => void,
+): void {
+  configurator.addConfig({
+    module: greeterModule,
+    configure,
+  });
+}
+```
+
+Consumers can then write:
+
+```typescript
+enableGreeter(configurator, (builder) => {
+  builder.setGreeting(() => 'Hei');
+});
+```
+
+---
+
+## Step 6 — Add optional lifecycle hooks
+
+Add only the hooks you actually need. Each hook is optional.
+
+### `postConfigure` — inspect the full config map
+
+Use this when your module's defaults depend on what another module configured. For example, an HTTP module might read the base URL from a service-discovery config:
+
+```typescript
+postConfigure: async (configMap) => {
+  // configMap contains the resolved configs of ALL modules.
+  const discoveryConfig = configMap['serviceDiscovery'];
+  if (discoveryConfig && !configMap['greeter'].greeting) {
+    configMap['greeter'].greeting = discoveryConfig.defaultGreeting;
+  }
+},
+```
+
+### `postInitialize` — wire providers together
+
+Use this when your module needs a live reference to another provider. At this point every module in the system has finished initializing:
+
+```typescript
+postInitialize: async ({ instance, modules }) => {
+  // Subscribe to another module's event stream using the live provider.
+  const sub = modules.event.on('localeChanged', (locale) => {
+    instance.updateLocale(locale);
+  });
+  instance.subscription.add(sub);
+},
+```
+
+### `dispose` — release resources
+
+The framework calls this when `configurator.dispose(instance)` is called. If you extend `BaseModuleProvider` and add subscriptions to `this.subscription`, you do not need to do anything extra — `dispose()` calls `this.subscription.unsubscribe()` automatically:
+
+```typescript
+dispose: async ({ instance }) => {
+  // BaseModuleProvider.dispose() handles this.subscription automatically.
+  // Only add this hook if you have additional teardown logic.
+  await instance.closeConnections();
+},
+```
+
+---
+
+## Complete example
+
+```typescript
+import {
+  type Module,
+  BaseConfigBuilder,
+  type ConfigBuilderCallback,
+} from '@equinor/fusion-framework-module';
+import {
+  BaseModuleProvider,
+  type BaseModuleProviderCtorArgs,
+} from '@equinor/fusion-framework-module/provider';
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+interface GreeterConfig {
+  greeting: string;
+  punctuation: string;
+}
+
+class GreeterConfigurator extends BaseConfigBuilder<GreeterConfig> {
+  setGreeting(cb: ConfigBuilderCallback<string>): void {
+    this._set('greeting', cb);
+  }
+  setPunctuation(cb: ConfigBuilderCallback<string>): void {
+    this._set('punctuation', cb);
+  }
+}
+
+class GreeterProvider extends BaseModuleProvider {
+  readonly #greeting: string;
+  readonly #punctuation: string;
+
+  constructor(args: BaseModuleProviderCtorArgs & { config: GreeterConfig }) {
+    super(args);
+    this.#greeting = args.config.greeting;
+    this.#punctuation = args.config.punctuation;
+  }
+
+  greet(name: string): string {
+    return `${this.#greeting}, ${name}${this.#punctuation}`;
+  }
+}
+
+export type GreeterModule = Module<'greeter', GreeterProvider, GreeterConfigurator>;
+
+export const greeterModule: GreeterModule = {
+  name: 'greeter',
+  configure: () => {
+    const builder = new GreeterConfigurator();
+    builder.setGreeting(() => 'Hello');
+    builder.setPunctuation(() => '!');
+    return builder;
+  },
+  initialize: async ({ config }) => {
+    const resolved = await config.createConfigAsync({
+      config: {},
+      hasModule: () => false,
+      requireInstance: async () => { throw new Error('no modules'); },
+    });
+    return new GreeterProvider({ version: '1.0.0', config: resolved });
+  },
+};
+
+export function enableGreeter(
+  configurator: IModulesConfigurator<any, any>,
+  configure?: (builder: GreeterConfigurator) => void,
+): void {
+  configurator.addConfig({ module: greeterModule, configure });
+}
+```
+
+---
+
+## Next Steps
+
+- [Configuration](./configuration.md) — deep dive into `BaseConfigBuilder` and config callbacks
+- [Cross-Module Dependencies](./cross-module-deps.md) — `requireInstance` and `postInitialize` patterns
+- [Common Mistakes](./common-mistakes.md) — pitfalls to avoid when authoring modules

--- a/packages/modules/module/docs/common-mistakes.md
+++ b/packages/modules/module/docs/common-mistakes.md
@@ -1,0 +1,216 @@
+# Common Mistakes — @equinor/fusion-framework-module
+
+A collection of mistakes that come up repeatedly when authoring or consuming modules. Each entry explains what goes wrong, why, and the correct approach.
+
+---
+
+## 1. Accessing `modules` inside `initialize`
+
+**Wrong**
+```typescript
+initialize: async ({ config }) => {
+  const auth = modules.auth; // ❌ modules doesn't exist here
+  return new MyProvider(config, auth);
+},
+```
+
+**Why it breaks:** `initialize` runs concurrently with all other modules. There is no `modules` map yet. The variable `modules` would be `undefined` or would reference the stale map from a previous run.
+
+**Correct:** Use `requireInstance` for construction-time dependencies, or move the wiring to `postInitialize`.
+
+```typescript
+initialize: async ({ config, requireInstance, hasModule }) => {
+  const resolved = await config.createConfigAsync({ config: {}, hasModule, requireInstance });
+  const auth = await requireInstance('auth', 5_000); // ✓
+  return new MyProvider(resolved, auth);
+},
+```
+
+---
+
+## 2. Forgetting `await` on `requireInstance`
+
+**Wrong**
+```typescript
+initialize: async ({ config, requireInstance }) => {
+  const auth = requireInstance('auth', 5_000); // ❌ missing await
+  return new MyProvider(config, auth); // auth is a Promise, not a provider
+},
+```
+
+**Why it breaks:** `requireInstance` returns a `Promise`. Without `await`, the provider receives a Promise object instead of the resolved provider instance. This typically causes a null-pointer or a "not a function" error at runtime, often in a place far removed from the initialization code.
+
+**Correct:**
+```typescript
+const auth = await requireInstance('auth', 5_000); // ✓
+```
+
+---
+
+## 3. Circular `requireInstance` calls
+
+**Wrong**
+```typescript
+// Module A
+initialize: async ({ requireInstance }) => {
+  const b = await requireInstance('b'); // ❌ waits for B
+  return new ProviderA(b);
+},
+
+// Module B
+initialize: async ({ requireInstance }) => {
+  const a = await requireInstance('a'); // ❌ waits for A
+  return new ProviderB(a);
+},
+```
+
+**Why it breaks:** A waits for B. B waits for A. Both promises hang forever — a classic deadlock. The framework does not detect or break cycles.
+
+**Correct:** Break the cycle by moving one direction of the wiring to `postInitialize`. By that point, both providers exist:
+
+```typescript
+// Module A — constructs without B
+initialize: async ({ config }) => new ProviderA(config),
+
+// Module B — constructs with A's provider
+initialize: async ({ requireInstance, config }) => {
+  const a = await requireInstance('a', 5_000); // ✓ A initializes without waiting
+  return new ProviderB(config, a);
+},
+
+// Wire B back into A after everything is ready
+// Option 1: in A's postInitialize
+postInitialize: async ({ instance, modules }) => {
+  instance.setB(modules.b); // ✓ inject lazily
+},
+```
+
+---
+
+## 4. Heavy async work in `configure`
+
+**Wrong**
+```typescript
+configure: async (ref) => {
+  const builder = new MyConfigurator();
+  const data = await fetch('/api/slow-config'); // ❌ blocks configure phase for all modules
+  builder.setData(() => data.json());
+  return builder;
+},
+```
+
+**Why it breaks:** The framework awaits every module's `configure()` factory sequentially before starting consumer callbacks. Heavy async work here serialises the configure phase across all modules and slows down startup for everyone.
+
+**Correct:** Move the async work into the `ConfigBuilderCallback` itself (runs after all configure factories) or into `initialize` (where it runs concurrently):
+
+```typescript
+configure: () => {
+  const builder = new MyConfigurator();
+  builder.setData(async () => {
+    const res = await fetch('/api/slow-config'); // ✓ runs in the callback phase
+    return res.json();
+  });
+  return builder; // synchronous factory
+},
+```
+
+---
+
+## 5. Cross-module wiring in `initialize` instead of `postInitialize`
+
+**Wrong**
+```typescript
+initialize: async ({ requireInstance }) => {
+  const event = await requireInstance('event', 5_000);
+  const provider = new MyProvider();
+
+  // Subscribing here works, but if 'event' finishes before other modules,
+  // you are wiring to a live stream while other modules are still initializing.
+  // Prefer postInitialize for any multi-module reactive wiring.
+  event.on('contextChanged', (ctx) => provider.update(ctx)); // ⚠ premature wiring
+  return provider;
+},
+```
+
+**Correct:** Use `postInitialize` so all modules are stable before you wire their event streams together:
+
+```typescript
+initialize: async ({ config }) => new MyProvider(config),
+
+postInitialize: async ({ instance, modules }) => {
+  modules.event.on('contextChanged', (ctx) => instance.update(ctx)); // ✓
+},
+```
+
+---
+
+## 6. Not adding subscriptions to `this.subscription`
+
+**Wrong**
+```typescript
+class MyProvider extends BaseModuleProvider {
+  constructor(args: BaseModuleProviderCtorArgs) {
+    super(args);
+    someObservable$.subscribe((v) => this.handle(v)); // ❌ leaked subscription
+  }
+}
+```
+
+**Why it breaks:** When `dispose()` is called, the subscription is not cancelled. The callback continues running on a disposed provider, potentially causing memory leaks, stale state updates, or errors.
+
+**Correct:** Always add subscriptions to `this.subscription`:
+
+```typescript
+class MyProvider extends BaseModuleProvider {
+  constructor(args: BaseModuleProviderCtorArgs) {
+    super(args);
+    this.subscription.add( // ✓ cancelled automatically on dispose()
+      someObservable$.subscribe((v) => this.handle(v)),
+    );
+  }
+}
+```
+
+---
+
+## 7. Registering the same module object twice expecting additive config
+
+**Wrong**
+```typescript
+configurator.addConfig({ module: httpModule, configure: (b) => b.setBaseUrl(() => '/default') });
+configurator.addConfig({ module: httpModule, configure: (b) => b.setBaseUrl(() => '/override') }); // second addConfig replaces the first
+```
+
+**Why it bites you:** The second `addConfig` call for the same module replaces the first registration entirely — including its `configure` callback. If you intended both callbacks to run (for example, to layer defaults and then consumer overrides), only the last one does.
+
+**Correct:** If you need multiple configure callbacks for the same module, chain them in a single `configure` function or use `postConfigure`. If you genuinely need two independent instances, create two separate module objects with different `name` values.
+
+---
+
+## 8. Accessing `modules` in a consumer's `onConfigured` callback
+
+**Wrong**
+```typescript
+configurator.onConfigured((configMap) => {
+  const provider = modules.http; // ❌ modules doesn't exist yet — onConfigured runs before initialize
+  provider.setDefaultHeader('X-Config', configMap.http.someValue);
+});
+```
+
+**Why it breaks:** `onConfigured` runs at the end of the configure phase, before any module has initialized. `modules` is not available.
+
+**Correct:** Use `onInitialized` for wiring that needs live providers, or use `addConfig({ afterInit })` for per-module post-init wiring.
+
+```typescript
+configurator.onInitialized((modules) => {
+  modules.http.setDefaultHeader('X-Config', 'value'); // ✓ providers are ready
+});
+```
+
+---
+
+## Next Steps
+
+- [Lifecycle](./lifecycle.md) — understand what is available at each phase
+- [Cross-Module Dependencies](./cross-module-deps.md) — correct patterns for peer dependencies
+- [Authoring Modules](./authoring-modules.md) — full guide to writing a module

--- a/packages/modules/module/docs/concepts.md
+++ b/packages/modules/module/docs/concepts.md
@@ -21,6 +21,7 @@ After initialization, providers are collected into a `ModulesInstance` object. T
 - Collects module registrations via `addConfig`.
 - Runs the configure → initialize → dispose pipeline.
 - Resolves cross-module dependencies through `requireInstance`.
+- Registers host-level plugins via `registerPlugin` after modules are initialized.
 - Emits structured lifecycle events on `event$`.
 
 You create one configurator, register your modules, and call `initialize()`. From that point on the configurator and the resulting `ModulesInstance` are the only things you need to keep a reference to.
@@ -201,5 +202,6 @@ export function enableHttpModule(
 ## Next Steps
 
 - [Lifecycle](./lifecycle.md) — the full configure → initialize → dispose pipeline
+- [Plugins](./plugins.md) — application-level side effects that run after modules initialize
 - [Authoring Modules](./authoring-modules.md) — step-by-step guide to creating a module
 - [Configuration](./configuration.md) — how `BaseConfigBuilder` and config callbacks work

--- a/packages/modules/module/docs/concepts.md
+++ b/packages/modules/module/docs/concepts.md
@@ -1,0 +1,205 @@
+# Concepts — @equinor/fusion-framework-module
+
+This document explains the core mental model behind the Fusion Framework module system: what a module is, how the pieces relate to each other, and how the type system connects everything.
+
+## What Is a Module?
+
+A **module** is a plain TypeScript object that owns one capability at runtime. It could be an HTTP client, an authentication provider, a context selector, a feature-flag store — any single responsibility that other parts of an application need. Modules are the building blocks of a Fusion application.
+
+Modules are intentionally plain objects, not classes. This keeps them lightweight, easy to tree-shake, and straightforward to test. The framework drives the lifecycle; the module just declares what to do at each step.
+
+## What Is a Provider?
+
+When `initialize()` runs, each module produces a **provider** — the live runtime object that the rest of the application interacts with. Providers are typically class instances (often extending `BaseModuleProvider`) that expose the module's public API: methods, observables, event streams, and so on.
+
+After initialization, providers are collected into a `ModulesInstance` object. The keys are the module names; the values are the provider instances. If you registered an `http` module and an `auth` module, you get back `{ http: HttpClient, auth: AuthProvider }`.
+
+## What Is the Configurator?
+
+`ModulesConfigurator` (implementing `IModulesConfigurator`) is the host that drives the module lifecycle. It:
+
+- Collects module registrations via `addConfig`.
+- Runs the configure → initialize → dispose pipeline.
+- Resolves cross-module dependencies through `requireInstance`.
+- Emits structured lifecycle events on `event$`.
+
+You create one configurator, register your modules, and call `initialize()`. From that point on the configurator and the resulting `ModulesInstance` are the only things you need to keep a reference to.
+
+## How the Pieces Fit Together
+
+```mermaid
+classDiagram
+    class Module {
+        +string name
+        +SemanticVersion? version
+        +configure(ref?) ConfigBuilder
+        +postConfigure(configMap) void
+        +initialize(args) Provider
+        +postInitialize(args) void
+        +dispose(args) void
+    }
+    class ConfigBuilder {
+        <<extends BaseConfigBuilder>>
+        +setXxx(cb) void
+        +createConfigAsync(args) Config
+    }
+    class Provider {
+        <<extends BaseModuleProvider>>
+        +SemanticVersion version
+        +Subscription subscription
+        +dispose() void
+    }
+
+    Module --> ConfigBuilder : configure() creates
+    Module --> Provider : initialize() returns
+    ConfigBuilder --> Provider : resolved config passed to
+```
+
+The three pieces of a module are deliberately separate:
+
+- **Module definition** — declares the lifecycle hooks. Exported as a constant, usually named after the capability (`httpModule`, `authModule`).
+- **Config builder** — receives consumer configuration during the configure phase. Subclass of `BaseConfigBuilder`. Exposes typed setter methods. Consumers call these inside their `addConfig({ configure })` callback.
+- **Provider** — the live runtime object. Returned by `initialize`. Subclass of `BaseModuleProvider` for automatic subscription tracking and dispose support.
+
+Keeping these three separate means you can unit-test the config builder without an HTTP server, and unit-test the provider without a real configurator.
+
+## The Configuration Flow
+
+This is the part that trips up most developers. Configuration involves three different actors doing three different jobs, in sequence. Understanding who does what is key.
+
+```mermaid
+sequenceDiagram
+    participant M as Module
+    participant C as ModulesConfigurator
+    participant App as Consumer
+
+    Note over C,M: Step 1 - Module creates the builder
+    C->>M: module.configure()
+    M-->>C: new DemoConfigurator() - empty builder
+
+    Note over C,App: Step 2 - Consumer fills it in
+    C->>App: addConfig configure callback
+    App->>App: builder.setFoo
+    App->>App: builder.setBar
+    App-->>C: callbacks queued, nothing resolved yet
+
+    Note over C,M: Step 3 - Module resolves config at init time
+    C->>M: module.initialize
+    M->>M: config.createConfigAsync
+    Note over M: runs callbacks, awaits promises, merges results
+    M-->>M: resolved config object
+    M-->>C: new DemoProvider
+```
+
+### Step 1 — The module creates a fresh config builder
+
+When `initialize()` is called, the framework first calls `module.configure()` on every registered module. Each module returns a fresh instance of its config builder — a blank slate that knows *what* can be configured but holds no values yet.
+
+```typescript
+// Inside the module definition:
+configure() {
+  return new DemoConfigurator(); // empty — no values yet
+},
+```
+
+### Step 2 — The consumer fills in the builder
+
+The framework then calls the consumer's `configure` callback (the one passed to `addConfig`), handing it the builder. This is the only moment where the consumer interacts with module configuration. The consumer calls setter methods on the builder to register callbacks — but the callbacks are **not called yet**. They are queued.
+
+```typescript
+// Consumer code — called by the framework with the builder from step 1:
+configurator.addConfig({
+  module: demoModule,
+  configure(builder) {
+    // These register callbacks — they do NOT run yet.
+    builder.setFoo(async () => 'https://api.example.com');
+    builder.setBar(() => 42);
+  },
+});
+```
+
+### Step 3 — The module resolves config during initialize
+
+During `module.initialize`, the module calls `config.createConfigAsync(args)`. This is when all the queued callbacks are finally executed. Each callback receives `args` (which includes `hasModule`, `requireInstance`, and `ref`) so that async callbacks can access peer providers. The results are merged into a single typed config object, which the module uses to construct the provider.
+
+```typescript
+// Inside the module definition:
+initialize: async (args) => {
+  // This runs all registered callbacks and merges the results.
+  const config = await args.config.createConfigAsync(args, {
+    foo: 'default-value', // optional defaults
+  });
+
+  // config is now fully typed: { foo: string, bar: number }
+  return new DemoProvider(config);
+},
+```
+
+The module author controls the defaults (set in `configure()` or passed as the second argument to `createConfigAsync`). The consumer's callbacks override those defaults. If no consumer callback was registered for a key, the default stands.
+
+### Why callbacks instead of direct values?
+
+Consumer configuration uses callbacks — `builder.setFoo(() => value)` rather than `builder.setFoo(value)` — for two reasons:
+
+1. **Async support**: callbacks can be `async`, which lets you fetch a value or `await requireInstance` inside the callback. The resolution happens at initialize time when async operations are safe.
+2. **Last-write-wins**: the framework queues all callbacks for a given key and runs the last one. This means a higher-level configurator can override a lower-level default simply by calling the same setter after the module was registered.
+
+```typescript
+// Callback that fetches config at initialize time:
+builder.setFoo(async ({ requireInstance }) => {
+  const discovery = await requireInstance('serviceDiscovery');
+  return discovery.resolveUrl('my-api');
+});
+```
+
+## The Generic Parameters
+
+Every module is typed as `Module<TKey, TType, TConfig, TDeps>`. Getting the generics right once means the entire call chain — `addConfig`, `requireInstance`, `ModulesInstance` — flows without any casting.
+
+| Parameter | What it represents | Example |
+|---|---|---|
+| `TKey` | String literal — the module's name, and the key on `ModulesInstance` | `'http'` |
+| `TType` | The provider type returned by `initialize` | `HttpClient` |
+| `TConfig` | The config builder type created by `configure` | `HttpConfigurator` |
+| `TDeps` | Tuple of peer module types this module declares as dependencies | `[AuthModule]` |
+
+`TDeps` is only needed when you call `requireInstance` on a peer. Declaring the dependency in the type narrows the `requireInstance` return type automatically so you do not need to cast.
+
+## Utility Types
+
+Two utility types let you extract the parts of a module type without re-declaring them:
+
+```typescript
+import type { ModuleConfigType, ModuleType } from '@equinor/fusion-framework-module';
+
+// Extract the config builder type from a module
+type HttpConfig = ModuleConfigType<typeof httpModule>; // → HttpConfigurator
+
+// Extract the provider type from a module
+type HttpProvider = ModuleType<typeof httpModule>; // → HttpClient
+```
+
+These are particularly useful when writing helper functions that accept a module as a generic parameter and need to reference its associated types.
+
+## What `IModulesConfigurator` Is For
+
+`IModulesConfigurator` is the public interface contract for the configurator. Framework packages that accept a configurator as an argument type against this interface rather than the concrete `ModulesConfigurator` class. This keeps them decoupled from the implementation.
+
+If you are writing a module that needs to receive a configurator — for example, an enable function that registers sibling modules — accept `IModulesConfigurator<any, any>` rather than `ModulesConfigurator`.
+
+```typescript
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+export function enableHttpModule(
+  configurator: IModulesConfigurator<any, any>,
+  configure?: (builder: HttpConfigurator) => void,
+): void {
+  configurator.addConfig({ module: httpModule, configure });
+}
+```
+
+## Next Steps
+
+- [Lifecycle](./lifecycle.md) — the full configure → initialize → dispose pipeline
+- [Authoring Modules](./authoring-modules.md) — step-by-step guide to creating a module
+- [Configuration](./configuration.md) — how `BaseConfigBuilder` and config callbacks work

--- a/packages/modules/module/docs/configuration.md
+++ b/packages/modules/module/docs/configuration.md
@@ -1,0 +1,193 @@
+# Configuration — @equinor/fusion-framework-module
+
+This document explains how module configuration works in Fusion Framework: how `BaseConfigBuilder` collects and resolves consumer callbacks, how defaults interact with overrides, and patterns for writing clean configurators.
+
+## The Configuration Flow
+
+Every module that accepts consumer configuration exports a **config builder** — a subclass of `BaseConfigBuilder`. The lifecycle runs in this order:
+
+1. `module.configure()` creates a fresh `ConfigBuilder`
+2. The consumer's `configure` callback calls setter methods on it
+3. `module.postConfigure()` applies any cross-module defaults
+4. The framework calls `createConfigAsync()` to resolve all callbacks
+5. The resolved config object is passed to `initialize()`
+
+The consumer never sees the resolved config directly. They only ever interact with the config builder. The resolved config is internal to the module.
+
+## BaseConfigBuilder
+
+`BaseConfigBuilder<TConfig>` is the abstract base for all config builders. It is generic over `TConfig` — the plain object type the module reads at initialize time.
+
+Internally, `BaseConfigBuilder` maintains a registry of dot-path keys mapped to callback arrays. When `createConfigAsync` is called, it runs all registered callbacks in order, resolves any promises, and merges the results into a single `TConfig` object.
+
+```typescript
+import { BaseConfigBuilder, type ConfigBuilderCallback } from '@equinor/fusion-framework-module';
+
+interface HttpConfig {
+  baseUrl: string;
+  timeout: number;
+  defaultHeaders: Record<string, string>;
+}
+
+class HttpConfigurator extends BaseConfigBuilder<HttpConfig> {
+  setBaseUrl(cb: ConfigBuilderCallback<string>): void {
+    this._set('baseUrl', cb);
+  }
+
+  setTimeout(cb: ConfigBuilderCallback<number>): void {
+    this._set('timeout', cb);
+  }
+
+  addDefaultHeader(name: string, cb: ConfigBuilderCallback<string>): void {
+    // Dot-path keys allow targeting nested properties.
+    this._set(`defaultHeaders.${name}`, cb);
+  }
+}
+```
+
+### `_set(key, callback)`
+
+`_set` is the only method you need in a config builder subclass. It:
+
+- Accepts a dot-path string (e.g. `'baseUrl'`, `'auth.clientId'`) and a `ConfigBuilderCallback`.
+- Registers the callback in the internal pipeline for that key.
+- **Appends** — calling `_set` twice for the same key means the second callback's return value wins (last-write-wins within a single builder).
+
+### ConfigBuilderCallback
+
+A `ConfigBuilderCallback<T>` is a function with the signature:
+
+```typescript
+type ConfigBuilderCallback<T> = (
+  args: ConfigBuilderCallbackArgs,
+) => T | Promise<T>;
+```
+
+`ConfigBuilderCallbackArgs` gives the callback access to:
+
+- `config` — the partial config object built so far (can inspect previously set keys)
+- `hasModule(name)` — check if a given module is registered
+- `requireInstance(name)` — await a live provider at config time (use sparingly)
+- `ref` — the reference object passed to `initialize(ref?)`
+
+Most callbacks just return a static value. The async capability is there for cases where you need to fetch a value from a server or await a provider before config resolves.
+
+```typescript
+// Simple static value
+builder.setBaseUrl(() => 'https://api.example.com');
+
+// Async — fetches value at config time
+builder.setBaseUrl(async () => {
+  const res = await fetch('/api/config');
+  return (await res.json()).baseUrl;
+});
+
+// Reads another key already set on this config
+builder.setTimeout(({ config }) => {
+  return config.baseUrl?.includes('localhost') ? 60_000 : 5_000;
+});
+```
+
+---
+
+## Setting Defaults
+
+Set defaults inside `module.configure()`, before the consumer's callback runs. This way the consumer only needs to call a setter if they want to override the default — no `||` fallbacks or special "unset" sentinels:
+
+```typescript
+export const httpModule: HttpModule = {
+  name: 'http',
+  configure: () => {
+    const builder = new HttpConfigurator();
+    // These run before any consumer configure callback.
+    builder.setBaseUrl(() => '/');
+    builder.setTimeout(() => 10_000);
+    return builder;
+  },
+  initialize: async ({ config }) => { /* … */ },
+};
+```
+
+If the consumer calls `builder.setBaseUrl(() => 'https://api.example.com')`, their callback runs after the default and its return value wins.
+
+---
+
+## Reading Config in initialize
+
+`module.initialize` receives the fully resolved config via `config.createConfigAsync(args)`. You call this once and destructure what you need:
+
+```typescript
+initialize: async ({ config, requireInstance, hasModule, ref }) => {
+  const resolved = await config.createConfigAsync({
+    config: {},
+    hasModule,
+    requireInstance,
+    ref,
+  });
+
+  // resolved is typed as HttpConfig — full autocomplete, no casting.
+  return new HttpClient({
+    baseUrl: resolved.baseUrl,
+    timeout: resolved.timeout,
+    defaultHeaders: resolved.defaultHeaders,
+  });
+},
+```
+
+Pass the `hasModule` and `requireInstance` functions through so that callbacks that need them (like async ones that fetch a peer provider) work correctly.
+
+---
+
+## Patterns
+
+### Guarded defaults from peer modules
+
+Sometimes you want a default that depends on whether another module is present. Use `hasModule` inside the default callback:
+
+```typescript
+configure: () => {
+  const builder = new HttpConfigurator();
+  builder.setBaseUrl(async ({ hasModule, requireInstance }) => {
+    if (hasModule('serviceDiscovery')) {
+      const discovery = await requireInstance('serviceDiscovery');
+      return discovery.resolveUrl('api');
+    }
+    return '/';
+  });
+  return builder;
+},
+```
+
+### Exposing builder methods on an enable function
+
+When you ship an `enableXxx` function, expose the common setters as direct parameters to avoid making consumers import the builder type just to call one method:
+
+```typescript
+export function enableHttp(
+  configurator: IModulesConfigurator<any, any>,
+  options?: {
+    baseUrl?: string;
+    timeout?: number;
+  },
+): void {
+  configurator.addConfig({
+    module: httpModule,
+    configure: (builder) => {
+      if (options?.baseUrl) builder.setBaseUrl(() => options.baseUrl!);
+      if (options?.timeout) builder.setTimeout(() => options.timeout!);
+    },
+  });
+}
+```
+
+### Separating public and private configuration
+
+If your module has config that should only be set by the module itself (not by consumers), do not expose a setter for it. Set it directly in `module.configure()` or `module.postConfigure()`. The builder is just an object — you are not forced to expose every key.
+
+---
+
+## Next Steps
+
+- [Authoring Modules](./authoring-modules.md) — full step-by-step guide
+- [Cross-Module Dependencies](./cross-module-deps.md) — using `requireInstance` inside config callbacks
+- [Common Mistakes](./common-mistakes.md) — pitfalls with configuration

--- a/packages/modules/module/docs/cross-module-deps.md
+++ b/packages/modules/module/docs/cross-module-deps.md
@@ -1,0 +1,205 @@
+# Cross-Module Dependencies — @equinor/fusion-framework-module
+
+This document explains how modules depend on each other at runtime: how `requireInstance` works, when to use `postInitialize` instead, and how to avoid common dependency pitfalls.
+
+## The Core Problem
+
+All modules initialize concurrently. There is no predefined order. If module A needs something from module B, it cannot simply call `modules.b` inside `initialize` — `modules.b` does not exist yet.
+
+The framework solves this with two complementary mechanisms:
+
+- **`requireInstance(name, timeout?)`** — await a single peer's provider during `initialize`.
+- **`postInitialize({ instance, modules })`** — receive the full `modules` map after everyone has finished.
+
+```mermaid
+sequenceDiagram
+    participant Cfg as ModulesConfigurator
+    participant Auth as auth module
+    participant Http as http module
+
+    par concurrent initialization
+        Cfg->>Auth: initialize()
+        Auth-->>Cfg: AuthProvider ✓
+    and
+        Cfg->>Http: initialize()
+        Http->>Cfg: requireInstance('auth', 5000)
+        Cfg-->>Http: AuthProvider (waits if needed)
+        Http-->>Cfg: HttpClient ✓
+    end
+    Note over Cfg: All modules ready — postInitialize runs
+    Cfg->>Http: postInitialize({ instance: HttpClient, modules })
+    Cfg->>Auth: postInitialize({ instance: AuthProvider, modules })
+```
+
+---
+
+## `requireInstance`
+
+Use `requireInstance(name, timeout?)` inside `initialize` when you need a peer's provider to **construct your own provider**. The promise resolves as soon as that peer's `initialize` call resolves — without waiting for everything else.
+
+```typescript
+import { type Module } from '@equinor/fusion-framework-module';
+import type { AuthModule } from '@equinor/fusion-framework-module-auth';
+
+export const httpModule: Module<'http', HttpClient, HttpConfigurator, [AuthModule]> = {
+  name: 'http',
+  initialize: async ({ config, requireInstance, hasModule }) => {
+    const resolved = await config.createConfigAsync({ config: {}, hasModule, requireInstance });
+
+    // Wait for the auth provider — resolves immediately if auth is already done.
+    const auth = await requireInstance('auth', 5_000);
+
+    return new HttpClient(resolved, auth);
+  },
+};
+```
+
+### Timeout
+
+The second argument is a timeout in milliseconds. If the peer does not finish initializing within that window, `requireInstance` rejects. **Always set a timeout.** Without one, a slow or missing peer silently hangs your application forever.
+
+### Optional dependencies
+
+If the dependency is optional — you can work without it — check `hasModule(name)` before calling `requireInstance`:
+
+```typescript
+initialize: async ({ config, requireInstance, hasModule }) => {
+  const resolved = await config.createConfigAsync({ config: {}, hasModule, requireInstance });
+
+  let auth: AuthProvider | undefined;
+  if (hasModule('auth')) {
+    auth = await requireInstance('auth', 5_000);
+  }
+
+  return new HttpClient(resolved, auth);
+},
+```
+
+### Circular dependencies
+
+`requireInstance` does not detect circular dependencies. If module A waits for B and B waits for A, both promises hang forever. Design your dependency graph as a DAG — directed, acyclic.
+
+If you find yourself needing a circular reference, move the wiring to `postInitialize` instead. By that point both providers exist; no waiting required.
+
+---
+
+## `postInitialize`
+
+`postInitialize` runs after **all** modules have finished initializing. Use it for:
+
+- Subscribing to another module's event stream.
+- Injecting a reference to a peer provider into your own provider.
+- Any wiring that needs the complete `modules` map.
+
+`postInitialize` is the right place for cross-module wiring. `initialize` is for constructing your own provider. `requireInstance` bridges the gap only when construction genuinely depends on a peer.
+
+```typescript
+export const analyticsModule: Module<'analytics', AnalyticsProvider, AnalyticsConfigurator> = {
+  name: 'analytics',
+  initialize: async ({ config }) => {
+    const resolved = await config.createConfigAsync({ config: {}, hasModule: () => false, requireInstance: async () => { throw new Error('no modules'); } });
+    return new AnalyticsProvider(resolved);
+  },
+
+  postInitialize: async ({ instance, modules }) => {
+    // All modules are available at this point — safe to access any provider.
+
+    // Track context changes
+    const sub = modules.context.changed$.subscribe((ctx) => {
+      instance.trackContextChange(ctx.id);
+    });
+
+    // Track navigation
+    const navSub = modules.navigation.currentPath$.subscribe((path) => {
+      instance.trackPageView(path);
+    });
+
+    // Add to the provider's subscription so they are cancelled on dispose.
+    instance.subscription.add(sub);
+    instance.subscription.add(navSub);
+  },
+};
+```
+
+---
+
+## Declaring Dependencies in the Type
+
+The fourth generic parameter on `Module<TKey, TType, TConfig, TDeps>` declares this module's peers as a tuple:
+
+```typescript
+import type { AuthModule } from '@equinor/fusion-framework-module-auth';
+import type { EventModule } from '@equinor/fusion-framework-module-event';
+
+export type HttpModule = Module<'http', HttpClient, HttpConfigurator, [AuthModule, EventModule]>;
+```
+
+Declaring deps in `TDeps` narrows the return type of `requireInstance` automatically — `requireInstance('auth')` returns `AuthProvider` without casting. It also enables the `modules` parameter in `postInitialize` to be typed correctly.
+
+---
+
+## Patterns
+
+### Inject peer lazily
+
+If you need a peer reference in your provider but it is not strictly needed for construction, inject it lazily via a setter instead of blocking `initialize`:
+
+```typescript
+class HttpClient extends BaseModuleProvider {
+  #auth: AuthProvider | undefined;
+
+  setAuth(auth: AuthProvider): void {
+    this.#auth = auth;
+  }
+
+  async fetch(url: string): Promise<Response> {
+    const headers: Record<string, string> = {};
+    if (this.#auth) {
+      headers['Authorization'] = await this.#auth.getToken();
+    }
+    return fetch(url, { headers });
+  }
+}
+
+// In the module:
+postInitialize: async ({ instance, modules }) => {
+  if ('auth' in modules) {
+    instance.setAuth(modules.auth);
+  }
+},
+```
+
+This pattern avoids blocking `HttpClient`'s initialization on auth being ready, which can improve startup time.
+
+### React to peer events in postInitialize
+
+```typescript
+postInitialize: async ({ instance, modules }) => {
+  instance.subscription.add(
+    modules.auth.tokenExpired$.subscribe(() => {
+      instance.clearCache();
+    }),
+  );
+},
+```
+
+Adding the subscription to `instance.subscription` ensures it is cancelled when the framework calls `dispose()`.
+
+---
+
+## Decision Guide
+
+| Situation | Use |
+|---|---|
+| You need a peer's provider **to construct your own provider** | `requireInstance` inside `initialize` |
+| You need to **react to a peer's events** or **wire providers together** | `postInitialize` |
+| The peer dependency is **optional** | `hasModule` check + conditional `requireInstance` or `postInitialize` |
+| You need to **read a peer's config** (not its provider) | `module.postConfigure(configMap)` |
+| Two modules need references to each other | Inject one lazily in `postInitialize` — avoid circular `requireInstance` |
+
+---
+
+## Next Steps
+
+- [Lifecycle](./lifecycle.md) — full phase ordering and what is available when
+- [Common Mistakes](./common-mistakes.md) — pitfalls with `requireInstance` and circular deps

--- a/packages/modules/module/docs/events.md
+++ b/packages/modules/module/docs/events.md
@@ -1,0 +1,173 @@
+# Events and Observability — @equinor/fusion-framework-module
+
+Every `ModulesConfigurator` emits structured lifecycle events on its `event$` observable. This is the primary hook for telemetry, debugging, progress tracking, and error monitoring — without reaching into private internals.
+
+## The event$ observable
+
+`configurator.event$` is an `Observable<ModuleEvent>`. It is backed by a `ReplaySubject` that buffers the last 100 events. This means a subscriber that attaches _after_ `initialize()` has already started will still receive all previously emitted events — useful for telemetry systems that connect late.
+
+```typescript
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+
+const configurator = new ModulesConfigurator();
+
+// Subscribe before initialize() to capture all events.
+// Subscribing after is also fine — the replay buffer covers you.
+configurator.event$.subscribe((event) => {
+  console.log(`[${event.level}] ${event.name}: ${event.message}`);
+});
+
+const modules = await configurator.initialize();
+```
+
+---
+
+## ModuleEvent shape
+
+Every event is a `ModuleEvent` object:
+
+```typescript
+type ModuleEvent = {
+  /** Severity: 'error' | 'warning' | 'info' | 'debug' */
+  level: ModuleEventLevel;
+
+  /** Machine-readable event name, e.g. 'moduleConfigAdded', 'initializeStart' */
+  name: string;
+
+  /** Human-readable description */
+  message: string;
+
+  /** Structured metadata — content varies by event */
+  properties?: Record<string, unknown>;
+};
+```
+
+`ModuleEventLevel` is a string enum with four values: `'error'`, `'warning'`, `'info'`, and `'debug'`. Use `filter` to select the severity level you care about.
+
+---
+
+## Common event names
+
+| Event name | Level | When it fires |
+|---|---|---|
+| `moduleConfigAdded` | `debug` | A module is registered via `addConfig` |
+| `configureStart` | `info` | The configure phase begins |
+| `configureEnd` | `info` | The configure phase completes |
+| `initializeStart` | `info` | The initialize phase begins |
+| `initializeModuleStart` | `debug` | A single module's `initialize` is called |
+| `initializeModuleEnd` | `debug` | A single module's `initialize` resolves |
+| `initializeEnd` | `info` | All modules have initialized |
+| `disposeStart` | `info` | Dispose begins |
+| `disposeEnd` | `info` | Dispose completes |
+
+The framework emits many `debug`-level events during normal operation. Filter to `info` and `error` in production telemetry to keep volume manageable.
+
+---
+
+## Filtering by level or name
+
+Use RxJS `filter` to select the events you care about:
+
+```typescript
+import { filter } from 'rxjs/operators';
+import { ModuleEventLevel } from '@equinor/fusion-framework-module';
+
+// Only errors
+configurator.event$.pipe(
+  filter((e) => e.level === ModuleEventLevel.Error),
+).subscribe((e) => {
+  errorTracker.captureException(new Error(e.message), { extra: e.properties });
+});
+
+// Measure initialize duration
+configurator.event$.pipe(
+  filter((e) => e.name === 'initializeStart' || e.name === 'initializeEnd'),
+).subscribe((e) => {
+  telemetry.mark(e.name);
+});
+```
+
+---
+
+## Forwarding to Application Insights / OpenTelemetry
+
+A common pattern in Fusion apps is to forward lifecycle events to a tracing backend. Because `event$` is a plain RxJS observable, you can pipe it into any sink:
+
+```typescript
+import { tap } from 'rxjs/operators';
+
+configurator.event$.pipe(
+  tap((e) => {
+    appInsights.trackEvent({
+      name: `fusion.module.${e.name}`,
+      properties: {
+        level: e.level,
+        message: e.message,
+        ...e.properties,
+      },
+    });
+  }),
+).subscribe();
+```
+
+Alternatively, subscribe inside `onInitialized` so the subscription is automatically associated with the module instance lifetime:
+
+```typescript
+configurator.onInitialized(() => {
+  const sub = configurator.event$.subscribe((e) => forwardToTelemetry(e));
+  // Remember to unsubscribe on dispose if you want clean teardown.
+});
+```
+
+---
+
+## Emitting events from your own module
+
+Module authors can emit events directly through the `registerEvent` function passed to each phase function. This is an internal API used by the phase implementations. Consumer modules should not emit events into the configurator's stream directly — use your provider's own observable properties instead.
+
+If you need to expose an event stream from your module, add it as an observable property on your provider:
+
+```typescript
+class MyProvider extends BaseModuleProvider {
+  readonly #subject = new Subject<MyEvent>();
+
+  /** Stream of events emitted by this provider. */
+  readonly event$ = this.#subject.asObservable();
+
+  constructor(args: BaseModuleProviderCtorArgs) {
+    super(args);
+    this.subscription.add(() => this.#subject.complete());
+  }
+
+  doSomething(): void {
+    this.#subject.next({ type: 'somethingDone', timestamp: Date.now() });
+  }
+}
+```
+
+Consumers subscribe to `modules.myModule.event$` — a clean, typed stream that does not bleed through the configurator.
+
+---
+
+## Debugging with ModuleConsoleLogger
+
+`ModuleConsoleLogger` is a styled console logger shipped with this package. It wraps `console.log/warn/error` with a coloured module-name prefix so events from different modules are visually distinguishable in the browser console.
+
+```typescript
+import { ModuleConsoleLogger } from '@equinor/fusion-framework-module';
+
+const logger = new ModuleConsoleLogger('MyModule');
+
+logger.debug('Provider initialized');   // [MyModule] Provider initialized
+logger.warn('Missing optional config'); // ⚠ [MyModule] Missing optional config
+logger.error('Failed to connect', err); // ✖ [MyModule] Failed to connect
+```
+
+Use it inside your module's `initialize` or provider constructor for development-time diagnostics. Gate it behind a debug flag in production.
+
+---
+
+## Next Steps
+
+- [Lifecycle](./lifecycle.md) — when each event fires in the pipeline
+- [Common Mistakes](./common-mistakes.md) — observable subscription pitfalls

--- a/packages/modules/module/docs/events.md
+++ b/packages/modules/module/docs/events.md
@@ -31,7 +31,7 @@ type ModuleEvent = {
   /** Severity: 'error' | 'warning' | 'info' | 'debug' */
   level: ModuleEventLevel;
 
-  /** Machine-readable event name, e.g. 'moduleConfigAdded', 'initializeStart' */
+  /** Machine-readable event name, e.g. 'ModuleConfigurator.initialize.complete' */
   name: string;
 
   /** Human-readable description */
@@ -48,17 +48,50 @@ type ModuleEvent = {
 
 ## Common event names
 
+Use `ModuleConfiguratorEventName` instead of hard-coded strings when filtering known configurator events. Configurator event names use `ModuleConfigurator.{name}.{state}` as their base shape:
+
+```typescript
+import { ModuleConfiguratorEventName } from '@equinor/fusion-framework-module/configurator';
+import { filter } from 'rxjs/operators';
+
+configurator.event$.pipe(
+  filter((event) => event.name.endsWith(ModuleConfiguratorEventName.Initialize)),
+).subscribe((event) => {
+  telemetry.mark(event.name);
+});
+```
+
+`ModuleConfiguratorEventBaseName` is the shared base segment. `ModulesConfigurator` prefixes emitted names with `ModulesConfigurator::` at runtime, so the actual event stream contains names like `ModulesConfigurator::ModuleConfigurator.initialize.complete`. The map stores the unprefixed event name so subclasses can apply their own configurator class prefix.
+
 | Event name | Level | When it fires |
 |---|---|---|
-| `moduleConfigAdded` | `debug` | A module is registered via `addConfig` |
-| `configureStart` | `info` | The configure phase begins |
-| `configureEnd` | `info` | The configure phase completes |
-| `initializeStart` | `info` | The initialize phase begins |
-| `initializeModuleStart` | `debug` | A single module's `initialize` is called |
-| `initializeModuleEnd` | `debug` | A single module's `initialize` resolves |
-| `initializeEnd` | `info` | All modules have initialized |
-| `disposeStart` | `info` | Dispose begins |
-| `disposeEnd` | `info` | Dispose completes |
+| `ModuleConfigurator.module.configAdded` | `debug` | A module is registered via `addConfig` |
+| `ModuleConfigurator.onConfigured.added` | `debug` | An `onConfigured` callback is registered |
+| `ModuleConfigurator.onInitialized.added` | `debug` | An `onInitialized` callback is registered |
+| `ModuleConfigurator.plugin.added` | `debug` | A plugin callback is registered |
+| `ModuleConfigurator.config.loaded` | `debug` | Module configuration completes |
+| `ModuleConfigurator.instance.initialized` | `debug` | Module initialization completes |
+| `ModuleConfigurator.initialize.complete` | `info` | The configure and initialize phases have completed |
+| `ModuleConfigurator.module.initializing` | `debug` | A single module's `initialize` is called |
+| `ModuleConfigurator.module.initialized` | `debug` | A single module's `initialize` resolves |
+| `ModuleConfigurator.module.initializeError` | `error` | Module initialization fails |
+| `ModuleConfigurator.requireInstance.awaitingModule` | `debug` | `requireInstance` starts waiting for a dependency |
+| `ModuleConfigurator.requireInstance.moduleResolved` | `debug` | `requireInstance` resolves a dependency |
+| `ModuleConfigurator.requireInstance.timeout` | `error` | `requireInstance` times out |
+| `ModuleConfigurator.postInitialize.started` | `debug` | Post-initialize processing begins |
+| `ModuleConfigurator.postInitialize.complete` | `debug` | Post-initialize processing completes |
+| `ModuleConfigurator.plugins.registering` | `debug` | Plugin registration begins after post-initialize callbacks settle |
+| `ModuleConfigurator.plugin.registered` | `debug` | A single plugin callback resolves and any teardown is captured |
+| `ModuleConfigurator.plugin.registerError` | `warning` | A plugin callback throws or rejects during registration |
+| `ModuleConfigurator.plugins.registered` | `debug` | All registered plugins have settled |
+| `ModuleConfigurator.dispose.started` | `debug` | Dispose begins |
+| `ModuleConfigurator.plugins.disposing` | `debug` | Plugin teardowns begin during dispose |
+| `ModuleConfigurator.plugin.disposed` | `debug` | A plugin teardown completes successfully |
+| `ModuleConfigurator.plugin.disposeError` | `warning` | A plugin teardown throws or rejects during dispose |
+| `ModuleConfigurator.modules.disposing` | `debug` | Module dispose hooks begin |
+| `ModuleConfigurator.module.disposed` | `debug` | A module dispose hook completes successfully |
+| `ModuleConfigurator.module.disposeError` | `warning` | A module dispose hook throws or rejects |
+| `ModuleConfigurator.modules.disposed` | `debug` | Module dispose hooks have settled |
 
 The framework emits many `debug`-level events during normal operation. Filter to `info` and `error` in production telemetry to keep volume manageable.
 
@@ -170,4 +203,5 @@ Use it inside your module's `initialize` or provider constructor for development
 ## Next Steps
 
 - [Lifecycle](./lifecycle.md) — when each event fires in the pipeline
+- [Plugins](./plugins.md) — plugin registration and teardown behavior
 - [Common Mistakes](./common-mistakes.md) — observable subscription pitfalls

--- a/packages/modules/module/docs/lifecycle.md
+++ b/packages/modules/module/docs/lifecycle.md
@@ -1,0 +1,133 @@
+# Lifecycle — @equinor/fusion-framework-module
+
+This document describes the full module lifecycle: what phases exist, what runs in each phase, what order things happen, and how to hook into each phase as a module author or as a consumer.
+
+## Overview
+
+Calling `ModulesConfigurator.initialize()` runs a deterministic five-phase pipeline. The key ordering guarantee is:
+
+> **Every module's configure phase completes before any module's initialize phase begins.**
+
+This means it is always safe to inspect another module's config inside `postConfigure`, and always safe to access another module's provider inside `postInitialize`. The framework enforces these boundaries so you do not have to reason about timing.
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Cfg as ModulesConfigurator
+    participant Mod as Module (each)
+
+    App->>Cfg: addConfig({ module, configure?, afterConfig?, afterInit? })
+    App->>Cfg: onConfigured(cb) / onInitialized(cb)
+    App->>Cfg: initialize(ref?)
+
+    Note over Cfg,Mod: ── Phase 1 — Configure ──
+    Cfg->>Mod: module.configure(ref?) → ConfigBuilder
+    Cfg->>App: configure(configBuilder, ref?)  [addConfig callback]
+    Cfg->>Mod: module.postConfigure(configMap)
+    Cfg->>App: afterConfig(configBuilder)       [addConfig callback]
+    Cfg->>App: onConfigured(configMap)           [global callback]
+
+    Note over Cfg,Mod: ── Phase 2 — Initialize (concurrent) ──
+    Cfg->>Mod: module.initialize({ config, requireInstance, ref })
+    Mod-->>Cfg: provider instance
+    Cfg->>Mod: module.postInitialize({ instance, modules, ref })
+    Cfg->>App: afterInit(provider)               [addConfig callback]
+    Cfg->>App: onInitialized(modulesInstance)    [global callback]
+
+    Cfg-->>App: ModulesInstance { [module.name]: provider }
+
+    Note over Cfg,Mod: ── Phase 3 — Dispose (on demand) ──
+    App->>Cfg: dispose(instance, ref?)
+    Cfg->>Mod: module.dispose({ instance, modules, ref })
+```
+
+---
+
+## Phase 1 — Configure
+
+The configure phase builds config for every module before anything initializes. The framework calls `module.configure(ref?)` to create a fresh `ConfigBuilder` for each module, then invites consumers to mutate it.
+
+### What runs and in what order
+
+1. **`module.configure(ref?)`** — The module creates and returns a new config builder instance. This is a synchronous factory call. The `ref` parameter carries whatever was passed to `initialize(ref)` — typically a parent framework instance.
+
+2. **`addConfig({ configure })` callback** — The consumer's callback receives the config builder and can call typed setter methods on it (`builder.setBaseUrl(...)`, `builder.setCredentials(...)`, etc.). This is where application-level configuration lives.
+
+3. **`module.postConfigure(configMap)`** — Runs after all consumer `configure` callbacks have settled. Receives the full map of all modules' resolved configs. Use this to apply defaults that depend on what other modules configured, or to validate your own config.
+
+4. **`addConfig({ afterConfig })` callback** — Consumer hook that runs after `postConfigure`. Rarely needed; most configuration belongs in step 2.
+
+5. **`onConfigured(cb)` callback** — Global hook that runs once all per-module configure phases are done. Use it to inspect the full config map, log configuration, or run cross-module config validation.
+
+### When to put configuration here
+
+Put **everything the module needs to know before it can create a provider** in the configure phase. URLs, credentials, feature flags, timeouts — all of these belong in config builder setters called inside the `configure` callback.
+
+Do not put async work that depends on the network or on other providers here. That belongs in `initialize`.
+
+---
+
+## Phase 2 — Initialize
+
+Once all modules are configured, the framework initializes them **concurrently**. Every module's `initialize` starts at roughly the same time. This maximises startup speed, but it requires care when modules depend on each other.
+
+### What runs
+
+1. **`module.initialize({ config, requireInstance, hasModule, ref })`** — The module receives its resolved config and creates the provider. Use `requireInstance(name, timeout?)` to await a peer module's provider. See [Cross-Module Dependencies](./cross-module-deps.md).
+
+2. **`module.postInitialize({ instance, modules, ref })`** — Runs after the module's own `initialize` resolves AND after all other modules have initialized. The full `modules` map is available here. Use this for cross-module wiring — subscribing to event streams, injecting references, setting up reactive pipelines between providers.
+
+3. **`addConfig({ afterInit })` callback** — Consumer hook that runs after `postInitialize`. Useful for one-shot wiring that the framework does not know about.
+
+4. **`onInitialized(cb)` callback** — Global hook that runs once all modules have fully initialized. The `ModulesInstance` is complete at this point.
+
+5. **`initialize()` resolves** — The promise returned by `configurator.initialize()` resolves with the sealed `ModulesInstance`.
+
+### The `ref` parameter
+
+`initialize(ref?)` accepts an optional `ref` object that the framework threads through every lifecycle hook. In Fusion Framework, `ref` is typically the parent framework instance — it gives modules a back-reference to the environment they are running inside. Module authors should type `ref` as `unknown` or a narrow interface and treat it as optional.
+
+---
+
+## Phase 3 — Dispose
+
+Dispose is **not** called automatically. It is your responsibility to call `configurator.dispose(instance, ref?)` when the application tears down — for example, when a React application unmounts, or when a service worker is replaced.
+
+The framework calls `module.dispose({ instance, modules, ref })` for each registered module. This is the right place to cancel subscriptions, close WebSocket connections, clear caches, and release any other resources the provider holds.
+
+`BaseModuleProvider` exposes a `subscription: Subscription` property (RxJS `Subscription`) that collects disposables. Adding to `this.subscription` inside `initialize` means they are automatically cleaned up when the provider's `dispose()` method is called — you do not need to track them separately.
+
+```typescript
+class MyProvider extends BaseModuleProvider {
+  constructor(args: BaseModuleProviderCtorArgs) {
+    super(args);
+    // Any RxJS subscription added here is automatically cancelled on dispose.
+    this.subscription.add(
+      someObservable$.subscribe((value) => this.#handleValue(value)),
+    );
+  }
+}
+```
+
+---
+
+## Hook Reference
+
+| Hook | Where it lives | Called by | When |
+|---|---|---|---|
+| `module.configure(ref?)` | Module definition | Framework | Start of configure phase, once per module |
+| `addConfig({ configure })` | Consumer | Framework | After `module.configure()`, before `postConfigure` |
+| `module.postConfigure(configMap)` | Module definition | Framework | After all consumer configure callbacks settle |
+| `addConfig({ afterConfig })` | Consumer | Framework | After `module.postConfigure()` |
+| `onConfigured(cb)` | Consumer | Framework | After all modules' configure phases complete |
+| `module.initialize(args)` | Module definition | Framework | Start of initialize phase, concurrently |
+| `module.postInitialize(args)` | Module definition | Framework | After all modules have initialized |
+| `addConfig({ afterInit })` | Consumer | Framework | After `module.postInitialize()` |
+| `onInitialized(cb)` | Consumer | Framework | After all modules' initialize phases complete |
+| `module.dispose(args)` | Module definition | Framework | On `configurator.dispose(instance)` |
+
+## Next Steps
+
+- [Authoring Modules](./authoring-modules.md) — implement each hook step by step
+- [Cross-Module Dependencies](./cross-module-deps.md) — how `requireInstance` and `postInitialize` work together
+- [Events](./events.md) — observe the lifecycle with `event$`

--- a/packages/modules/module/docs/lifecycle.md
+++ b/packages/modules/module/docs/lifecycle.md
@@ -4,7 +4,7 @@ This document describes the full module lifecycle: what phases exist, what runs 
 
 ## Overview
 
-Calling `ModulesConfigurator.initialize()` runs a deterministic five-phase pipeline. The key ordering guarantee is:
+Calling `ModulesConfigurator.initialize()` runs a deterministic lifecycle pipeline. The key ordering guarantee is:
 
 > **Every module's configure phase completes before any module's initialize phase begins.**
 
@@ -34,10 +34,14 @@ sequenceDiagram
     Cfg->>App: afterInit(provider)               [addConfig callback]
     Cfg->>App: onInitialized(modulesInstance)    [global callback]
 
+    Note over Cfg,App: -- Phase 3 - Plugins --
+    Cfg->>App: registerPlugin({ modules, ref })
+
     Cfg-->>App: ModulesInstance { [module.name]: provider }
 
-    Note over Cfg,Mod: ── Phase 3 — Dispose (on demand) ──
+    Note over Cfg,Mod: -- Phase 4 - Dispose (on demand) --
     App->>Cfg: dispose(instance, ref?)
+    Cfg->>App: plugin teardown
     Cfg->>Mod: module.dispose({ instance, modules, ref })
 ```
 
@@ -81,7 +85,7 @@ Once all modules are configured, the framework initializes them **concurrently**
 
 4. **`onInitialized(cb)` callback** — Global hook that runs once all modules have fully initialized. The `ModulesInstance` is complete at this point.
 
-5. **`initialize()` resolves** — The promise returned by `configurator.initialize()` resolves with the sealed `ModulesInstance`.
+5. **Plugin phase begins** — The configurator runs `registerPlugin` callbacks before resolving `initialize()`.
 
 ### The `ref` parameter
 
@@ -89,11 +93,36 @@ Once all modules are configured, the framework initializes them **concurrently**
 
 ---
 
-## Phase 3 — Dispose
+## Phase 3 - Plugins
+
+The plugin phase runs after `postInitialize`, `afterInit`, and `onInitialized` callbacks have settled, but before `initialize()` resolves. Plugins are registered with `IModulesConfigurator.registerPlugin` and receive the sealed module instance map plus the optional `ref` object.
+
+Use plugins for host-level side effects that need multiple initialized providers, such as telemetry bridges, global listeners, feature instrumentation, or subscriptions owned by the application shell.
+
+```typescript
+import { createPlugin } from '@equinor/fusion-framework-module/plugins';
+
+const telemetryPlugin = createPlugin<[typeof eventModule, typeof telemetryModule]>(
+  'contextTelemetry',
+  (modules) => modules.event.addEventListener('context:changed', (event) => {
+    modules.telemetry.track('context.changed', event.detail);
+  }),
+);
+
+configurator.registerPlugin(telemetryPlugin);
+```
+
+Plugins can return a teardown function or an object with a `dispose()` method. Those teardowns run during `configurator.dispose()` before module `dispose` hooks. Plugin registration and teardown failures are isolated and reported as warning events, so one failing plugin does not prevent the remaining lifecycle work from running.
+
+After plugins have settled, the promise returned by `configurator.initialize()` resolves with the sealed `ModulesInstance`.
+
+---
+
+## Phase 4 — Dispose
 
 Dispose is **not** called automatically. It is your responsibility to call `configurator.dispose(instance, ref?)` when the application tears down — for example, when a React application unmounts, or when a service worker is replaced.
 
-The framework calls `module.dispose({ instance, modules, ref })` for each registered module. This is the right place to cancel subscriptions, close WebSocket connections, clear caches, and release any other resources the provider holds.
+The framework first runs plugin teardowns returned by `registerPlugin` callbacks. It then calls `module.dispose({ instance, modules, ref })` for each registered module. This is the right place to cancel subscriptions, close WebSocket connections, clear caches, and release any other resources the provider holds.
 
 `BaseModuleProvider` exposes a `subscription: Subscription` property (RxJS `Subscription`) that collects disposables. Adding to `this.subscription` inside `initialize` means they are automatically cleaned up when the provider's `dispose()` method is called — you do not need to track them separately.
 
@@ -124,10 +153,13 @@ class MyProvider extends BaseModuleProvider {
 | `module.postInitialize(args)` | Module definition | Framework | After all modules have initialized |
 | `addConfig({ afterInit })` | Consumer | Framework | After `module.postInitialize()` |
 | `onInitialized(cb)` | Consumer | Framework | After all modules' initialize phases complete |
+| `registerPlugin(cb)` | Consumer | Framework | After post-initialize callbacks, before `initialize()` resolves |
+| plugin teardown | Consumer | Framework | During `configurator.dispose(instance)`, before module dispose hooks |
 | `module.dispose(args)` | Module definition | Framework | On `configurator.dispose(instance)` |
 
 ## Next Steps
 
 - [Authoring Modules](./authoring-modules.md) — implement each hook step by step
 - [Cross-Module Dependencies](./cross-module-deps.md) — how `requireInstance` and `postInitialize` work together
+- [Plugins](./plugins.md) — register host-level side effects after modules are initialized
 - [Events](./events.md) — observe the lifecycle with `event$`

--- a/packages/modules/module/docs/plugins.md
+++ b/packages/modules/module/docs/plugins.md
@@ -1,0 +1,97 @@
+# Plugins - @equinor/fusion-framework-module
+
+Configurator plugins are application-level side effects that run after all modules are initialized and before `ModulesConfigurator.initialize()` resolves. Use plugins when wiring needs the complete `ModulesInstance`, such as telemetry bridges, global browser listeners, feature instrumentation, or subscriptions that connect multiple providers.
+
+Plugins are registered with `IModulesConfigurator.registerPlugin`. A plugin receives `FrameworkPluginArgs` with the initialized module map and optional `ref` object. It can return `undefined` when no cleanup is needed, or a `FrameworkPluginTeardown` callback/object that runs during `configurator.dispose()`.
+
+## When to use plugins
+
+Use a plugin when the work is owned by the application or framework host rather than by one module provider.
+
+| Need | Prefer |
+|---|---|
+| A module must finish its own setup after all providers exist | `module.postInitialize` |
+| A consumer wants to inspect the finished module instance once | `onInitialized` |
+| The host app needs long-lived side effects connected to initialized providers | `registerPlugin` |
+| A provider owns subscriptions or sockets internally | `BaseModuleProvider.subscription` and provider `dispose` |
+
+The plugin phase runs after `postInitialize`, `afterInit`, and `onInitialized` callbacks have settled. `initialize()` does not resolve until plugin registration completes, so render-time consumers receive a module instance whose host-level side effects are already connected.
+
+## Register a named plugin
+
+Use `createPlugin(name, callback)` from `@equinor/fusion-framework-module/plugins` when you want lifecycle events to show a stable plugin name. The callback receives the module map directly.
+
+```typescript
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+import { createPlugin } from '@equinor/fusion-framework-module/plugins';
+
+const configurator = new ModulesConfigurator([eventModule, telemetryModule]);
+
+const contextTelemetryPlugin = createPlugin<[typeof eventModule, typeof telemetryModule]>(
+  'contextTelemetry',
+  (modules) => {
+    const teardown = modules.event.addEventListener('context:changed', (event) => {
+      modules.telemetry.track('context.changed', event.detail);
+    });
+
+    return teardown;
+  },
+);
+
+configurator.registerPlugin(contextTelemetryPlugin);
+```
+
+The `name` passed to `createPlugin` is used in plugin lifecycle events such as `ModuleConfigurator.plugin.registered`. `createPlugin` throws when the name is empty or whitespace, which helps keep diagnostics readable.
+
+## Register an inline plugin
+
+Inline callbacks are useful for small one-off integrations. They receive the lower-level `FrameworkPluginArgs` object.
+
+```typescript
+import type { FrameworkPluginArgs, FrameworkPluginRegistration } from '@equinor/fusion-framework-module/plugins';
+
+function connectResizeTelemetry({
+  modules,
+}: FrameworkPluginArgs<[typeof telemetryModule]>): FrameworkPluginRegistration {
+  const handleResize = (): void => {
+    modules.telemetry.track('window.resized', {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  window.addEventListener('resize', handleResize);
+
+  return () => window.removeEventListener('resize', handleResize);
+}
+
+configurator.registerPlugin(connectResizeTelemetry);
+```
+
+Return a teardown whenever the plugin creates subscriptions, event listeners, timers, or other long-lived resources. Teardowns may be functions or objects with a `dispose()` method, and they may complete synchronously or return a promise.
+
+## Failure and teardown behavior
+
+Plugin registration is isolated. If one plugin throws or rejects, `ModulesConfigurator` emits a warning event named `ModuleConfigurator.plugin.registerError` and continues running the remaining plugins. The failed plugin does not block `initialize()` unless your surrounding code chooses to react to that warning.
+
+During `configurator.dispose(instance, ref?)`, plugin teardowns run before module `dispose` hooks. Teardown failures are reported as warning events and do not prevent other plugin teardowns or module disposal from running. After teardown, the internal teardown registry is cleared so repeated dispose calls do not run the same plugin cleanup twice.
+
+## Plugin API reference
+
+| Export | Package entrypoint | Purpose |
+|---|---|---|
+| `FrameworkPluginArgs` | `@equinor/fusion-framework-module/plugins` | Arguments passed to inline plugin callbacks: `{ modules, ref }` |
+| `FrameworkPluginCallback` | `@equinor/fusion-framework-module/plugins` | Callback type accepted by `IModulesConfigurator.registerPlugin` |
+| `FrameworkPluginTeardown` | `@equinor/fusion-framework-module/plugins` | Cleanup callback or disposable object returned by a plugin |
+| `FrameworkPluginRegistration` | `@equinor/fusion-framework-module/plugins` | Plugin return type: teardown or `undefined` |
+| `FrameworkPlugin` | `@equinor/fusion-framework-module/plugins` | Named plugin callback returned by `createPlugin` |
+| `FrameworkPluginInitializer` | `@equinor/fusion-framework-module/plugins` | Developer-facing callback signature used by `createPlugin` |
+| `createPlugin` | `@equinor/fusion-framework-module/plugins` | Creates a named plugin callback for stable diagnostics |
+
+The same plugin types and `createPlugin` helper are also available from the `@equinor/fusion-framework-module/configurator` secondary entrypoint for consumers that already import configurator APIs there.
+
+## Next Steps
+
+- [Lifecycle](./lifecycle.md) - see where the plugin phase runs in the configure -> initialize -> dispose pipeline
+- [Events](./events.md) - observe plugin registration and teardown events through `event$`
+- [Authoring Modules](./authoring-modules.md) - decide whether setup belongs in a module hook or in a host-level plugin

--- a/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { AnyModule } from '../../types.js';
 import { ModulesConfigurator } from '../../lib/configurator/ModulesConfigurator.js';
+import { ModuleConfiguratorEventName } from '../../lib/configurator/events.js';
 import { createPlugin } from '../../lib/plugin/index.js';
 import { createMockModule, createMinimalModule, collectEvents } from '../helpers.js';
 
@@ -50,13 +51,15 @@ describe('ModulesConfigurator', () => {
       expect(afterInitSpy).toHaveBeenCalledOnce();
     });
 
-    it('emits a moduleConfigAdded event', () => {
+    it('emits a module config added event', () => {
       const configurator = new ModulesConfigurator();
       const [events, cleanup] = collectEvents(configurator.event$);
       configurator.addConfig({ module: createMockModule('alpha') });
       cleanup();
       const names = events.map((e) => (e as { name: string }).name);
-      expect(names.some((n) => n.includes('moduleConfigAdded'))).toBe(true);
+      expect(names.some((n) => n.endsWith(ModuleConfiguratorEventName.ModuleConfigAdded))).toBe(
+        true,
+      );
     });
   });
 
@@ -229,7 +232,7 @@ describe('ModulesConfigurator', () => {
 
       expect(events).toContainEqual(
         expect.objectContaining({
-          name: 'ModulesConfigurator::_plugin.pluginRegistered',
+          name: `ModulesConfigurator::${ModuleConfiguratorEventName.PluginRegistered}`,
           properties: expect.objectContaining({ name: 'contextTelemetry' }),
         }),
       );
@@ -358,7 +361,9 @@ describe('ModulesConfigurator', () => {
       await configurator.initialize();
       cleanup();
       const names = events.map((e) => (e as { name: string }).name);
-      expect(names.some((n: string) => n.includes('initialize') && !n.includes('.'))).toBe(true);
+      expect(names.some((n: string) => n.endsWith(ModuleConfiguratorEventName.Initialize))).toBe(
+        true,
+      );
     });
   });
 

--- a/packages/modules/module/src/__tests__/configurator/phases/configure.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/configure.test.ts
@@ -5,6 +5,7 @@ import {
   runPostConfigureHooks,
   type ConfigurePhaseContext,
 } from '../../../lib/configurator/phases/configure.js';
+import { ModuleConfiguratorEventName } from '../../../lib/configurator/events.js';
 import type { AnyModule, ModuleEvent } from '../../../types.js';
 
 function makeCtx(
@@ -78,7 +79,7 @@ describe('configure phase', () => {
       const ctx = makeCtx([mod], { registerEvent });
       await createModuleConfigs(ctx);
       const eventNames = registerEvent.mock.calls.map((args) => (args[0] as ModuleEvent).name);
-      expect(eventNames.some((n) => n.includes('configuratorCreated'))).toBe(true);
+      expect(eventNames).toContain(ModuleConfiguratorEventName.ConfiguratorCreated);
     });
 
     it('emits an error event and rethrows when configure() throws', async () => {

--- a/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
@@ -4,6 +4,7 @@ import {
   runDisposePhase,
   type DisposePhaseContext,
 } from '../../../lib/configurator/phases/dispose.js';
+import { ModuleConfiguratorEventName } from '../../../lib/configurator/events.js';
 import type { AnyModule, ModuleEvent } from '../../../types.js';
 
 function makeCtx(
@@ -205,7 +206,7 @@ describe('dispose phase', () => {
     const ctx = makeCtx([mod], { registerEvent });
     await runDisposePhase(ctx, { alpha: {} });
     const names = registerEvent.mock.calls.map(([e]) => e.name);
-    expect(names.some((n) => n === 'dispose')).toBe(true);
-    expect(names.some((n) => n.includes('moduleDisposed'))).toBe(true);
+    expect(names).toContain(ModuleConfiguratorEventName.Dispose);
+    expect(names).toContain(ModuleConfiguratorEventName.ModuleDisposed);
   });
 });

--- a/packages/modules/module/src/__tests__/configurator/phases/initialize.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/initialize.test.ts
@@ -5,6 +5,7 @@ import {
   createRequireInstance,
   type InitializePhaseContext,
 } from '../../../lib/configurator/phases/initialize.js';
+import { ModuleConfiguratorEventName } from '../../../lib/configurator/events.js';
 import type { AnyModule, ModuleEvent } from '../../../types.js';
 
 function makeCtx(
@@ -184,7 +185,7 @@ describe('initialize phase', () => {
       const ctx = makeCtx([mod], { registerEvent });
       await runInitializePhase(ctx, { alpha: {} });
       const names = registerEvent.mock.calls.map(([e]) => e.name);
-      expect(names.some((n) => n.includes('moduleInitialized'))).toBe(true);
+      expect(names).toContain(ModuleConfiguratorEventName.ModuleInitialized);
     });
   });
 });

--- a/packages/modules/module/src/__tests__/configurator/phases/post-initialize.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/post-initialize.test.ts
@@ -3,6 +3,7 @@ import {
   runPostInitializePhase,
   type PostInitializePhaseContext,
 } from '../../../lib/configurator/phases/post-initialize.js';
+import { ModuleConfiguratorEventName } from '../../../lib/configurator/events.js';
 import type { AnyModule, ModuleEvent } from '../../../types.js';
 
 function makeCtx(
@@ -127,9 +128,7 @@ describe('post-initialize phase', () => {
     const ctx = makeCtx([mod], { registerEvent });
     await runPostInitializePhase(ctx, { alpha: {} });
     const names = registerEvent.mock.calls.map(([e]) => e.name);
-    expect(names.some((n) => n.includes('PostInitialized') || n.includes('postInitialized'))).toBe(
-      true,
-    );
-    expect(names.some((n) => n.includes('complete'))).toBe(true);
+    expect(names).toContain(ModuleConfiguratorEventName.ModulePostInitializeComplete);
+    expect(names).toContain(ModuleConfiguratorEventName.PostInitializeComplete);
   });
 });

--- a/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
@@ -27,6 +27,7 @@ import { runPostInitializePhase } from './phases/post-initialize.js';
 import { runPluginPhase } from './phases/plugin.js';
 import { runDisposePhase } from './phases/dispose.js';
 import { version } from '../../version.js';
+import { ModuleConfiguratorEventName } from './events.js';
 
 /**
  * Core orchestrator that drives the module lifecycle in Fusion Framework.
@@ -205,7 +206,7 @@ export class ModulesConfigurator<
     this._modules.add(module);
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'moduleConfigAdded',
+      name: ModuleConfiguratorEventName.ModuleConfigAdded,
       message: `Module configurator added for ${module.name}`,
       properties: {
         moduleName: module.name,
@@ -236,7 +237,7 @@ export class ModulesConfigurator<
     this._afterConfiguration.push(cb);
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'addOnConfigured',
+      name: ModuleConfiguratorEventName.OnConfiguredAdded,
       message: 'Added onConfigured callback',
       properties: {
         count: this._afterConfiguration.length,
@@ -260,7 +261,7 @@ export class ModulesConfigurator<
     this._afterInit.push(cb);
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'addOnInitialized',
+      name: ModuleConfiguratorEventName.OnInitializedAdded,
       message: 'Added onInitialized callback',
       properties: {
         count: this._afterInit.length,
@@ -297,7 +298,7 @@ export class ModulesConfigurator<
     this._plugins.push(cb as FrameworkPluginCallback<any, TRef>);
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'addPlugin',
+      name: ModuleConfiguratorEventName.PluginAdded,
       message: 'Added plugin callback',
       properties: {
         count: this._plugins.length,
@@ -328,7 +329,7 @@ export class ModulesConfigurator<
 
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'initialize.configLoaded',
+      name: ModuleConfiguratorEventName.InitializeConfigLoaded,
       message: `Modules configured in ${configLoadTime}ms`,
       properties: {
         modules: this.modules.map((m) => m.name).join(', '),
@@ -344,7 +345,7 @@ export class ModulesConfigurator<
 
     this._registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'initialize.instanceInitialized',
+      name: ModuleConfiguratorEventName.InitializeInstanceInitialized,
       message: `Modules initialized in ${instanceLoadTime}ms`,
       properties: {
         modules: this.modules.map((m) => m.name).join(', '),
@@ -357,7 +358,7 @@ export class ModulesConfigurator<
     const totalLoadTime = configLoadTime + instanceLoadTime;
     this._registerEvent({
       level: ModuleEventLevel.Information,
-      name: 'initialize',
+      name: ModuleConfiguratorEventName.Initialize,
       message: `initialize in ${totalLoadTime}ms`,
       properties: {
         modules: this.modules.map((m) => m.name).join(', '),
@@ -384,8 +385,8 @@ export class ModulesConfigurator<
    * Namespaces and emits a lifecycle event into the internal event stream.
    *
    * The event name is prefixed with the configurator class name (e.g.
-   * `"ModulesConfigurator::moduleConfigAdded"`) to prevent name collisions
-   * between nested configurators.
+   * `"ModulesConfigurator::ModuleConfigurator.module.configAdded"`) to prevent
+   * name collisions between nested configurators.
    *
    * @param event - The lifecycle event to emit.
    * @protected

--- a/packages/modules/module/src/lib/configurator/events.ts
+++ b/packages/modules/module/src/lib/configurator/events.ts
@@ -1,0 +1,69 @@
+/** Shared base segment for module configurator lifecycle event names. */
+export const ModuleConfiguratorEventBaseName = 'ModuleConfigurator';
+
+/**
+ * Event names emitted by `ModulesConfigurator` and its lifecycle phase helpers.
+ *
+ * Use this map instead of inline string literals when emitting or filtering
+ * configurator lifecycle events. Each value follows the
+ * `ModuleConfigurator.{name}.{state}` convention. The emitted names are still
+ * prefixed by `ModulesConfigurator::_registerEvent` at runtime.
+ */
+export const ModuleConfiguratorEventName = {
+  ModuleConfigAdded: `${ModuleConfiguratorEventBaseName}.module.configAdded`,
+  OnConfiguredAdded: `${ModuleConfiguratorEventBaseName}.onConfigured.added`,
+  OnInitializedAdded: `${ModuleConfiguratorEventBaseName}.onInitialized.added`,
+  PluginAdded: `${ModuleConfiguratorEventBaseName}.plugin.added`,
+  InitializeConfigLoaded: `${ModuleConfiguratorEventBaseName}.config.loaded`,
+  InitializeInstanceInitialized: `${ModuleConfiguratorEventBaseName}.instance.initialized`,
+  Initialize: `${ModuleConfiguratorEventBaseName}.initialize.complete`,
+
+  ConfiguratorCreated: `${ModuleConfiguratorEventBaseName}.configurator.created`,
+  ConfiguratorFailed: `${ModuleConfiguratorEventBaseName}.configurator.failed`,
+  ModulePostConfigured: `${ModuleConfiguratorEventBaseName}.module.postConfigured`,
+  ModulePostConfigureError: `${ModuleConfiguratorEventBaseName}.module.postConfigureError`,
+  PostConfigureHooks: `${ModuleConfiguratorEventBaseName}.postConfigureHooks.started`,
+  PostConfigureHooksComplete: `${ModuleConfiguratorEventBaseName}.postConfigureHooks.complete`,
+  PostConfigureHooksError: `${ModuleConfiguratorEventBaseName}.postConfigureHooks.error`,
+
+  ModuleInitializeError: `${ModuleConfiguratorEventBaseName}.module.initializeError`,
+  ModuleInitializing: `${ModuleConfiguratorEventBaseName}.module.initializing`,
+  ProviderNotBaseModuleProvider: `${ModuleConfiguratorEventBaseName}.provider.invalidBase`,
+  ProviderVersionWarning: `${ModuleConfiguratorEventBaseName}.provider.versionMissing`,
+  ModuleInitialized: `${ModuleConfiguratorEventBaseName}.module.initialized`,
+  RequireInstanceModuleNotDefined: `${ModuleConfiguratorEventBaseName}.requireInstance.moduleNotDefined`,
+  RequireInstanceModuleAlreadyInitialized: `${ModuleConfiguratorEventBaseName}.requireInstance.moduleAlreadyInitialized`,
+  RequireInstanceAwaitingModule: `${ModuleConfiguratorEventBaseName}.requireInstance.awaitingModule`,
+  RequireInstanceTimeout: `${ModuleConfiguratorEventBaseName}.requireInstance.timeout`,
+  RequireInstanceModuleResolved: `${ModuleConfiguratorEventBaseName}.requireInstance.moduleResolved`,
+  ModuleInitializeComplete: `${ModuleConfiguratorEventBaseName}.modules.initializeComplete`,
+  InitializeComplete: `${ModuleConfiguratorEventBaseName}.initialize.instanceComplete`,
+
+  ConfiguratorPostInitializeStart: `${ModuleConfiguratorEventBaseName}.postInitialize.started`,
+  ModulePostInitializeStart: `${ModuleConfiguratorEventBaseName}.modulePostInitialize.started`,
+  ModulePostInitializeComplete: `${ModuleConfiguratorEventBaseName}.modulePostInitialize.complete`,
+  ModulePostInitializeError: `${ModuleConfiguratorEventBaseName}.modulePostInitialize.error`,
+  PostInitializeComplete: `${ModuleConfiguratorEventBaseName}.postInitialize.complete`,
+  PostInitializeCompleteNoHooks: `${ModuleConfiguratorEventBaseName}.postInitialize.noHooks`,
+  PostInitializeHooks: `${ModuleConfiguratorEventBaseName}.postInitializeHooks.started`,
+  PostInitializeHooksComplete: `${ModuleConfiguratorEventBaseName}.postInitializeHooks.complete`,
+  PostInitializeHooksError: `${ModuleConfiguratorEventBaseName}.postInitializeHooks.error`,
+
+  PluginsRegister: `${ModuleConfiguratorEventBaseName}.plugins.registering`,
+  PluginRegistered: `${ModuleConfiguratorEventBaseName}.plugin.registered`,
+  PluginRegisterError: `${ModuleConfiguratorEventBaseName}.plugin.registerError`,
+  PluginsRegistered: `${ModuleConfiguratorEventBaseName}.plugins.registered`,
+
+  Dispose: `${ModuleConfiguratorEventBaseName}.dispose.started`,
+  PluginsDisposing: `${ModuleConfiguratorEventBaseName}.plugins.disposing`,
+  PluginDisposed: `${ModuleConfiguratorEventBaseName}.plugin.disposed`,
+  PluginDisposeError: `${ModuleConfiguratorEventBaseName}.plugin.disposeError`,
+  ModulesDispose: `${ModuleConfiguratorEventBaseName}.modules.disposing`,
+  ModuleDisposed: `${ModuleConfiguratorEventBaseName}.module.disposed`,
+  ModuleDisposeError: `${ModuleConfiguratorEventBaseName}.module.disposeError`,
+  ModulesDisposed: `${ModuleConfiguratorEventBaseName}.modules.disposed`,
+} as const;
+
+/** Event name value emitted by the module configurator lifecycle. */
+export type ModuleConfiguratorEventName =
+  (typeof ModuleConfiguratorEventName)[keyof typeof ModuleConfiguratorEventName];

--- a/packages/modules/module/src/lib/configurator/index.ts
+++ b/packages/modules/module/src/lib/configurator/index.ts
@@ -24,6 +24,8 @@ export type {
 export { createPlugin } from '../plugin/index.js';
 
 export { RequiredModuleTimeoutError } from './types.js';
+export { ModuleConfiguratorEventBaseName, ModuleConfiguratorEventName } from './events.js';
+export type { ModuleConfiguratorEventName as ModuleConfiguratorEventNameType } from './events.js';
 
 export { ModulesConfigurator } from './ModulesConfigurator.js';
 

--- a/packages/modules/module/src/lib/configurator/phases/configure.ts
+++ b/packages/modules/module/src/lib/configurator/phases/configure.ts
@@ -5,6 +5,7 @@ import { mergeMap, reduce } from 'rxjs/operators';
 
 import { ModuleEventLevel, type AnyModule, type ModuleEvent } from '../../../types.js';
 import type { ModulesConfiguratorConfigCallback } from '../types.js';
+import { ModuleConfiguratorEventName } from '../events.js';
 
 /**
  * Context passed to the configure lifecycle phase.
@@ -66,7 +67,7 @@ export async function createModuleConfigs<TRef>(
         const configLoadTime = Math.round(performance.now() - configStart);
         registerEvent({
           level: ModuleEventLevel.Debug,
-          name: '_createConfig.configuratorCreated',
+          name: ModuleConfiguratorEventName.ConfiguratorCreated,
           message: `Configurator created for ${module.name} in ${configLoadTime}ms`,
           properties: {
             moduleName: module.name,
@@ -79,7 +80,7 @@ export async function createModuleConfigs<TRef>(
       } catch (err) {
         registerEvent({
           level: ModuleEventLevel.Error,
-          name: '_createConfig.configuratorFailed',
+          name: ModuleConfiguratorEventName.ConfiguratorFailed,
           message: `Failed to create configurator for ${module.name}`,
           properties: {
             moduleName: module.name,
@@ -138,7 +139,7 @@ export async function runPostConfigureHooks<TRef>(
           await module.postConfigure?.(config);
           registerEvent({
             level: ModuleEventLevel.Debug,
-            name: '_postConfigure.modulePostConfigured',
+            name: ModuleConfiguratorEventName.ModulePostConfigured,
             message: `Module ${module.name} post-configured successfully`,
             properties: {
               moduleName: module.name,
@@ -149,7 +150,7 @@ export async function runPostConfigureHooks<TRef>(
         } catch (err) {
           registerEvent({
             level: ModuleEventLevel.Warning,
-            name: '_postConfigure.modulePostConfigureError',
+            name: ModuleConfiguratorEventName.ModulePostConfigureError,
             message: `Module ${module.name} post-configure failed`,
             properties: {
               moduleName: module.name,
@@ -169,7 +170,7 @@ export async function runPostConfigureHooks<TRef>(
   try {
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_postConfigure.hooks',
+      name: ModuleConfiguratorEventName.PostConfigureHooks,
       message: `Post configure hooks [${afterConfiguration.length}] called`,
     });
     const postConfigHooksStart = performance.now();
@@ -177,7 +178,7 @@ export async function runPostConfigureHooks<TRef>(
     const postConfigHooksTime = Math.round(performance.now() - postConfigHooksStart);
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_postConfigure.hooksComplete',
+      name: ModuleConfiguratorEventName.PostConfigureHooksComplete,
       message: 'Post configure hooks complete',
       properties: {
         count: afterConfiguration.length,
@@ -188,7 +189,7 @@ export async function runPostConfigureHooks<TRef>(
   } catch (err) {
     registerEvent({
       level: ModuleEventLevel.Warning,
-      name: '_postConfigure.hooksError',
+      name: ModuleConfiguratorEventName.PostConfigureHooksError,
       message: 'Post configure hook failed',
       error: err,
     });

--- a/packages/modules/module/src/lib/configurator/phases/dispose.ts
+++ b/packages/modules/module/src/lib/configurator/phases/dispose.ts
@@ -3,6 +3,7 @@ import type { Subject } from 'rxjs';
 
 import { ModuleEventLevel, type AnyModule, type ModuleEvent } from '../../../types.js';
 import type { FrameworkPluginTeardown } from '../../plugin/index.js';
+import { ModuleConfiguratorEventName } from '../events.js';
 
 function getPluginTeardownName(teardown: FrameworkPluginTeardown): string {
   return typeof teardown === 'function' ? teardown.name || 'anonymous' : 'dispose';
@@ -57,7 +58,7 @@ export async function runDisposePhase(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: 'dispose',
+    name: ModuleConfiguratorEventName.Dispose,
     message: 'Disposing modules instance',
     properties: { modules: Object.keys(instance).join(', ') },
   });
@@ -65,7 +66,7 @@ export async function runDisposePhase(
   if (pluginTeardowns.length) {
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: 'dispose.pluginsDisposing',
+      name: ModuleConfiguratorEventName.PluginsDisposing,
       message: `Disposing plugins [${pluginTeardowns.length}]`,
       properties: { count: pluginTeardowns.length },
     });
@@ -78,14 +79,14 @@ export async function runDisposePhase(
         await runPluginTeardown(teardown);
         registerEvent({
           level: ModuleEventLevel.Debug,
-          name: 'dispose.pluginDisposed',
+          name: ModuleConfiguratorEventName.PluginDisposed,
           message: `Plugin ${name} disposed successfully`,
           properties: { name },
         });
       } catch (err) {
         registerEvent({
           level: ModuleEventLevel.Warning,
-          name: 'dispose.pluginDisposeError',
+          name: ModuleConfiguratorEventName.PluginDisposeError,
           message: `Plugin ${name} dispose failed`,
           properties: { name },
           error: err,
@@ -93,6 +94,13 @@ export async function runDisposePhase(
       }
     }
   }
+
+  registerEvent({
+    level: ModuleEventLevel.Debug,
+    name: ModuleConfiguratorEventName.ModulesDispose,
+    message: 'Disposing modules',
+    properties: { count: modules.length },
+  });
 
   // Dispose all modules concurrently; failures are isolated per module so
   // one bad teardown cannot leave other modules in an inconsistent state.
@@ -109,7 +117,7 @@ export async function runDisposePhase(
           });
           registerEvent({
             level: ModuleEventLevel.Debug,
-            name: 'dispose.moduleDisposed',
+            name: ModuleConfiguratorEventName.ModuleDisposed,
             message: `Module ${module.name} disposed successfully`,
             properties: {
               moduleName: module.name,
@@ -119,7 +127,7 @@ export async function runDisposePhase(
         } catch (err) {
           registerEvent({
             level: ModuleEventLevel.Warning,
-            name: 'dispose.moduleDisposeError',
+            name: ModuleConfiguratorEventName.ModuleDisposeError,
             message: `Module ${module.name} dispose failed`,
             properties: {
               moduleName: module.name,
@@ -130,6 +138,13 @@ export async function runDisposePhase(
         }
       }),
   );
+
+  registerEvent({
+    level: ModuleEventLevel.Debug,
+    name: ModuleConfiguratorEventName.ModulesDisposed,
+    message: 'Module dispose complete',
+    properties: { count: modules.length },
+  });
 
   // Complete the event stream last so all dispose events are captured before
   // any subscriber teardown triggered by completion.

--- a/packages/modules/module/src/lib/configurator/phases/initialize.ts
+++ b/packages/modules/module/src/lib/configurator/phases/initialize.ts
@@ -10,6 +10,7 @@ import {
 
 import { BaseModuleProvider } from '../../provider/index.js';
 import { RequiredModuleTimeoutError } from '../types.js';
+import { ModuleConfiguratorEventName } from '../events.js';
 
 /**
  * Context passed to the initialize lifecycle phase.
@@ -66,7 +67,7 @@ async function initializeModule(
     error.name = 'ModuleInitializeError';
     registerEvent({
       level: ModuleEventLevel.Error,
-      name: '_initialize.moduleInitializeError',
+      name: ModuleConfiguratorEventName.ModuleInitializeError,
       message: error.message,
       properties: {
         moduleName: module.name,
@@ -79,7 +80,7 @@ async function initializeModule(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_initialize.moduleInitializing',
+    name: ModuleConfiguratorEventName.ModuleInitializing,
     message: `Initializing module ${module.name}`,
     properties: {
       moduleName: module.name,
@@ -101,7 +102,7 @@ async function initializeModule(
   if (!(instance instanceof BaseModuleProvider)) {
     registerEvent({
       level: ModuleEventLevel.Warning,
-      name: '_initialize.providerNotBaseModuleProvider',
+      name: ModuleConfiguratorEventName.ProviderNotBaseModuleProvider,
       message: `Provider for module ${module.name} does not extend BaseModuleProvider`,
       properties: {
         moduleName: module.name,
@@ -115,7 +116,7 @@ async function initializeModule(
   if (!maybeVersioned.version) {
     registerEvent({
       level: ModuleEventLevel.Warning,
-      name: '_initialize.providerVersionWarning',
+      name: ModuleConfiguratorEventName.ProviderVersionWarning,
       message: `Provider for module ${module.name} does not expose version`,
       properties: {
         moduleName: module.name,
@@ -127,7 +128,7 @@ async function initializeModule(
   const moduleInitTime = Math.round(performance.now() - moduleInitStart);
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_initialize.moduleInitialized',
+    name: ModuleConfiguratorEventName.ModuleInitialized,
     message: `Module ${module.name} initialized in ${moduleInitTime}ms`,
     properties: {
       moduleName: module.name,
@@ -173,7 +174,7 @@ export function createRequireInstance<T>(
       error.name = 'ModuleNotDefinedError';
       registerEvent({
         level: ModuleEventLevel.Error,
-        name: '_initialize.requireInstance.moduleNotDefined',
+        name: ModuleConfiguratorEventName.RequireInstanceModuleNotDefined,
         message: error.message,
         properties: { moduleName: String(name), wait },
         error,
@@ -185,7 +186,7 @@ export function createRequireInstance<T>(
     if ((instance$.value as Record<string, unknown>)[name]) {
       registerEvent({
         level: ModuleEventLevel.Debug,
-        name: '_initialize.requireInstance.moduleAlreadyInitialized',
+        name: ModuleConfiguratorEventName.RequireInstanceModuleAlreadyInitialized,
         message: `Module [${String(name)}] is already initialized, skipping queue`,
         properties: { moduleName: String(name), wait },
       });
@@ -195,7 +196,7 @@ export function createRequireInstance<T>(
     const requireStart = performance.now();
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_initialize.requireInstance.awaiting',
+      name: ModuleConfiguratorEventName.RequireInstanceAwaitingModule,
       message: `Awaiting module [${String(name)}] initialization, timeout ${wait}s`,
       properties: { moduleName: String(name), wait },
     });
@@ -216,7 +217,7 @@ export function createRequireInstance<T>(
               const error = new RequiredModuleTimeoutError();
               registerEvent({
                 level: ModuleEventLevel.Error,
-                name: '_initialize.requireInstance.timeout',
+                name: ModuleConfiguratorEventName.RequireInstanceTimeout,
                 message: `Module [${String(name)}] initialization timed out after ${wait}s`,
                 properties: { moduleName: String(name), wait },
                 error,
@@ -229,7 +230,7 @@ export function createRequireInstance<T>(
           const requireTime = Math.round(performance.now() - requireStart);
           registerEvent({
             level: ModuleEventLevel.Debug,
-            name: '_initialize.requireInstance.moduleResolved',
+            name: ModuleConfiguratorEventName.RequireInstanceModuleResolved,
             message: `Module [${String(name)}] required in ${requireTime}ms`,
             properties: { moduleName: String(name), wait, requireTime },
             metric: requireTime,
@@ -299,7 +300,7 @@ export async function runInitializePhase<T>(
     error: (err) => {
       registerEvent({
         level: ModuleEventLevel.Error,
-        name: '_initialize.moduleInitializationError',
+        name: ModuleConfiguratorEventName.ModuleInitializeError,
         message: `Failed to initialize module ${err.name || 'unknown'}`,
         error: err,
       });
@@ -309,7 +310,7 @@ export async function runInitializePhase<T>(
       const loadTime = Math.round(performance.now() - initStart);
       registerEvent({
         level: ModuleEventLevel.Debug,
-        name: '_initialize.moduleInitializationComplete',
+        name: ModuleConfiguratorEventName.ModuleInitializeComplete,
         message: `All modules initialized in ${loadTime}ms`,
         properties: {
           modules: Object.keys(instance$.value).join(', '),
@@ -327,7 +328,7 @@ export async function runInitializePhase<T>(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_initialize.complete',
+    name: ModuleConfiguratorEventName.InitializeComplete,
     message: `Modules instance created in ${initTime}ms`,
     properties: {
       modules: Object.keys(instance).join(', '),

--- a/packages/modules/module/src/lib/configurator/phases/plugin.ts
+++ b/packages/modules/module/src/lib/configurator/phases/plugin.ts
@@ -2,7 +2,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ModuleEventLevel, type ModuleEvent } from '../../../types.js';
 import type { FrameworkPluginCallback, FrameworkPluginTeardown } from '../../plugin/index.js';
+import { ModuleConfiguratorEventName } from '../events.js';
 
+/**
+ * Checks whether a plugin return value should be treated as dispose-time cleanup.
+ *
+ * Plugins may return either a plain callback or an object with a `dispose` method.
+ * Any other value is ignored so plugin authors can return `undefined` when no
+ * cleanup is needed.
+ *
+ * @param value - Value returned by a registered plugin callback.
+ * @returns True when the value is a valid plugin teardown registration.
+ */
 function isPluginTeardown(value: unknown): value is FrameworkPluginTeardown {
   return (
     typeof value === 'function' ||
@@ -30,10 +41,16 @@ export interface PluginPhaseContext<TRef = unknown> {
 /**
  * Runs configurator plugins after modules are ready.
  *
- * Executes all registered plugins with the initialized module map. Plugin
- * failures are isolated and emitted as warning events so one failing side
- * effect cannot block application rendering. Returned teardown callbacks are
- * stored for the dispose phase.
+ * The plugin phase is the final initialization step before `initialize()`
+ * resolves. Each plugin receives the sealed module instance map and optional
+ * initialization reference, which makes this phase suitable for application
+ * side effects such as telemetry bridges, global event listeners, and runtime
+ * subscriptions that require multiple initialized module providers.
+ *
+ * Plugin callbacks run concurrently. Failures are isolated and emitted as
+ * warning events so one failing side effect cannot block application rendering.
+ * Returned teardown callbacks are stored for the dispose phase and are invoked
+ * before module `dispose` hooks.
  *
  * @param ctx - The plugin phase context.
  * @param modules - The initialized module instance map.
@@ -51,7 +68,7 @@ export async function runPluginPhase<TRef = unknown>(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_plugin.pluginsRegistering',
+    name: ModuleConfiguratorEventName.PluginsRegister,
     message: `Registering plugins [${plugins.length}]`,
     properties: { count: plugins.length },
   });
@@ -65,7 +82,7 @@ export async function runPluginPhase<TRef = unknown>(
         const pluginTime = Math.round(performance.now() - pluginStart);
         registerEvent({
           level: ModuleEventLevel.Debug,
-          name: '_plugin.pluginRegistered',
+          name: ModuleConfiguratorEventName.PluginRegistered,
           message: `Plugin ${name} registered in ${pluginTime}ms`,
           properties: { name, pluginTime },
           metric: pluginTime,
@@ -74,7 +91,7 @@ export async function runPluginPhase<TRef = unknown>(
       } catch (err) {
         registerEvent({
           level: ModuleEventLevel.Warning,
-          name: '_plugin.pluginRegisterError',
+          name: ModuleConfiguratorEventName.PluginRegisterError,
           message: `Plugin ${name} registration failed`,
           properties: { name },
           error: err,
@@ -92,7 +109,7 @@ export async function runPluginPhase<TRef = unknown>(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_plugin.pluginsRegistered',
+    name: ModuleConfiguratorEventName.PluginsRegistered,
     message: 'Plugin registration complete',
     properties: { count: plugins.length, teardowns: teardowns.length },
   });

--- a/packages/modules/module/src/lib/configurator/phases/post-initialize.ts
+++ b/packages/modules/module/src/lib/configurator/phases/post-initialize.ts
@@ -4,6 +4,7 @@ import { EMPTY, from, lastValueFrom } from 'rxjs';
 import { catchError, defaultIfEmpty, filter, mergeMap, tap } from 'rxjs/operators';
 
 import { ModuleEventLevel, type AnyModule, type ModuleEvent } from '../../../types.js';
+import { ModuleConfiguratorEventName } from '../events.js';
 
 /**
  * Context passed to the post-initialize lifecycle phase.
@@ -46,7 +47,7 @@ export async function runPostInitializePhase(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_postInitialize.modulesPostInitializing',
+    name: ModuleConfiguratorEventName.ConfiguratorPostInitializeStart,
     message: `Post-initializing all modules [${Object.keys(instance).length}]`,
     properties: { modules: Object.keys(instance).join(', ') },
   });
@@ -58,7 +59,7 @@ export async function runPostInitializePhase(
     tap((module) => {
       registerEvent({
         level: ModuleEventLevel.Debug,
-        name: '_postInitialize.modulePostInitializing',
+        name: ModuleConfiguratorEventName.ModulePostInitializeStart,
         message: `Module ${module.name} is being post-initialized`,
         properties: {
           moduleName: module.name,
@@ -79,7 +80,7 @@ export async function runPostInitializePhase(
           const postInitTime = Math.round(performance.now() - postInitStart);
           registerEvent({
             level: ModuleEventLevel.Debug,
-            name: '_postInitialize.modulePostInitialized',
+            name: ModuleConfiguratorEventName.ModulePostInitializeComplete,
             message: `Module ${module.name} has been post-initialized in ${postInitTime}ms`,
             metric: postInitTime,
             properties: {
@@ -93,7 +94,7 @@ export async function runPostInitializePhase(
         catchError((err) => {
           registerEvent({
             level: ModuleEventLevel.Warning,
-            name: '_postInitialize.modulePostInitializeError',
+            name: ModuleConfiguratorEventName.ModulePostInitializeError,
             message: `Module ${module.name} post-initialize failed`,
             properties: {
               moduleName: module.name,
@@ -116,7 +117,7 @@ export async function runPostInitializePhase(
 
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_postInitialize.modulesPostInitializeComplete',
+    name: ModuleConfiguratorEventName.PostInitializeComplete,
     message: `Post-initialization of all modules completed in ${postInitTime}ms`,
     properties: { modules: Object.keys(instance).join(', '), postInitTime },
     metric: postInitTime,
@@ -125,7 +126,7 @@ export async function runPostInitializePhase(
   if (!afterInit.length) {
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_postInitialize.complete',
+      name: ModuleConfiguratorEventName.PostInitializeCompleteNoHooks,
       message: 'Post-initialization complete',
       properties: { modules: Object.keys(instance).join(', '), postInitCompleteTime: postInitTime },
     });
@@ -137,7 +138,7 @@ export async function runPostInitializePhase(
   try {
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_postInitialize.afterInitHooks',
+      name: ModuleConfiguratorEventName.PostInitializeHooks,
       message: `Executing post-initialize hooks [${afterInit.length}]`,
       properties: { hooks: afterInit.map((x) => x.name || 'anonymous').join(', ') },
     });
@@ -146,7 +147,7 @@ export async function runPostInitializePhase(
     const afterInitTime = Math.round(performance.now() - afterInitStart);
     registerEvent({
       level: ModuleEventLevel.Debug,
-      name: '_postInitialize.afterInitHooksComplete',
+      name: ModuleConfiguratorEventName.PostInitializeHooksComplete,
       message: `Post-initialize hooks completed in ${afterInitTime}ms`,
       properties: {
         hooks: afterInit.map((x) => x.name || 'anonymous').join(', '),
@@ -157,7 +158,7 @@ export async function runPostInitializePhase(
   } catch (err) {
     registerEvent({
       level: ModuleEventLevel.Warning,
-      name: '_postInitialize.afterInitHooksError',
+      name: ModuleConfiguratorEventName.PostInitializeHooksError,
       message: 'Post-initialize hooks failed',
       properties: { hooks: afterInit.map((x) => x.name || 'anonymous').join(', ') },
       error: err,
@@ -167,7 +168,7 @@ export async function runPostInitializePhase(
   const postInitCompleteTime = Math.round(performance.now() - postInitStart);
   registerEvent({
     level: ModuleEventLevel.Debug,
-    name: '_postInitialize.complete',
+    name: ModuleConfiguratorEventName.PostInitializeComplete,
     message: 'Post-initialization complete',
     properties: { modules: Object.keys(instance).join(', '), postInitCompleteTime },
   });

--- a/packages/modules/module/src/types.ts
+++ b/packages/modules/module/src/types.ts
@@ -379,7 +379,7 @@ export type ModuleEvent = {
   /** The severity level of the event */
   level: ModuleEventLevel;
 
-  /** A unique identifier for the event type (e.g., 'initialize', 'moduleConfigAdded') */
+  /** A unique identifier for the event type (e.g., 'ModuleConfigurator.initialize.complete') */
   name: string;
 
   /** A human-readable description of what occurred */

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -262,6 +262,41 @@ export default sidebar({
   '/modules/': [
     '',
     {
+      text: 'Module System',
+      prefix: 'module/',
+      link: 'module/',
+      children: [
+        {
+          text: 'Concepts',
+          link: 'docs/concepts.md',
+        },
+        {
+          text: 'Lifecycle',
+          link: 'docs/lifecycle.md',
+        },
+        {
+          text: 'Configuration',
+          link: 'docs/configuration.md',
+        },
+        {
+          text: 'Cross-Module Dependencies',
+          link: 'docs/cross-module-deps.md',
+        },
+        {
+          text: 'Events',
+          link: 'docs/events.md',
+        },
+        {
+          text: 'Authoring Modules',
+          link: 'docs/authoring-modules.md',
+        },
+        {
+          text: 'Common Mistakes',
+          link: 'docs/common-mistakes.md',
+        },
+      ],
+    },
+    {
       text: 'HTTP',
       link: 'http/',
       children: [

--- a/vue-press/src/modules/module/README.md
+++ b/vue-press/src/modules/module/README.md
@@ -1,0 +1,122 @@
+---
+title: Module System
+description: Core module system — contracts, base classes, and orchestration logic for every Fusion Framework module.
+category: Module
+tag:
+  - module
+  - core
+---
+
+<ModuleBadge module="modules/module" package="@equinor/fusion-framework-module" />
+
+Core module system for Fusion Framework. This package defines the contracts, base classes, and orchestration logic that every Fusion Framework module depends on.
+
+A Fusion application is assembled from **modules**. Each module owns a slice of runtime capability — an HTTP client, an auth provider, a context selector — and exposes it through a typed **provider** instance. The **`ModulesConfigurator`** drives the three-phase lifecycle that wires modules together: configure → initialize → dispose.
+
+```mermaid
+graph TD
+    Consumer["Application / Framework"]
+    Configurator["ModulesConfigurator"]
+    ModA["Module A - e.g. http"]
+    ModB["Module B - e.g. auth"]
+    ModC["Module C - e.g. context"]
+    Instance["ModulesInstance"]
+
+    Consumer -->|addConfig| Configurator
+    Configurator -->|configure + initialize| ModA
+    Configurator -->|configure + initialize| ModB
+    Configurator -->|configure + initialize| ModC
+    ModA --> Instance
+    ModB --> Instance
+    ModC --> Instance
+    Instance -->|returned to| Consumer
+```
+
+## Installation
+
+```sh
+pnpm add @equinor/fusion-framework-module
+```
+
+## Quick Start
+
+```typescript
+import {
+  ModulesConfigurator,
+  type Module,
+  BaseConfigBuilder,
+  type ConfigBuilderCallback,
+} from '@equinor/fusion-framework-module';
+import { BaseModuleProvider } from '@equinor/fusion-framework-module/provider';
+
+interface GreeterConfig { greeting: string }
+
+class GreeterConfigurator extends BaseConfigBuilder<GreeterConfig> {
+  setGreeting(cb: ConfigBuilderCallback<string>) { this._set('greeting', cb); }
+}
+
+class GreeterProvider extends BaseModuleProvider {
+  constructor(private config: GreeterConfig, args: ConstructorParameters<typeof BaseModuleProvider>[0]) {
+    super(args);
+  }
+  greet(name: string) { return `${this.config.greeting}, ${name}!`; }
+}
+
+const greeterModule: Module<'greeter', GreeterProvider, GreeterConfigurator> = {
+  name: 'greeter',
+  configure: () => new GreeterConfigurator(),
+  initialize: async ({ config, hasModule, requireInstance, ref }) => {
+    const resolved = await config.createConfigAsync({ config: {}, hasModule, requireInstance, ref });
+    return new GreeterProvider(resolved, { version: '1.0.0' });
+  },
+};
+
+const configurator = new ModulesConfigurator();
+configurator.addConfig({
+  module: greeterModule,
+  configure: (builder) => builder.setGreeting(() => 'Hello'),
+});
+
+const modules = await configurator.initialize();
+console.log(modules.greeter.greet('World')); // Hello, World!
+```
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Concepts](./docs/concepts.md) | Mental model — what a module, provider, and configurator are |
+| [Lifecycle](./docs/lifecycle.md) | The five phases: configure, post-configure, initialize, post-initialize, dispose |
+| [Authoring Modules](./docs/authoring-modules.md) | Step-by-step guide for writing a new module |
+| [Configuration](./docs/configuration.md) | How `BaseConfigBuilder`, `_set`, and `ConfigBuilderCallback` work |
+| [Cross-Module Dependencies](./docs/cross-module-deps.md) | `requireInstance`, `postInitialize`, optional deps, circular dep avoidance |
+| [Events and Observability](./docs/events.md) | `configurator.event$`, `ModuleEvent`, telemetry patterns |
+| [Common Mistakes](./docs/common-mistakes.md) | Pitfalls — accessing modules early, missing `await`, no timeout, circular deps |
+
+## Exports
+
+### Main Entry Point (`@equinor/fusion-framework-module`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `Module` | type | Interface describing a module's structure and lifecycle hooks |
+| `AnyModule` | type | `Module<any, any, any, any>` — used for generic constraints |
+| `ModulesConfigurator` | class | Orchestrates configure → initialize → dispose for a set of modules |
+| `IModulesConfigurator` | interface | Public contract for the modules configurator |
+| `IModuleConfigurator` | interface | Descriptor for registering a single module with lifecycle hooks |
+| `BaseConfigBuilder` | class | Abstract config builder with dot-path targeting and async callbacks |
+| `ConfigBuilderCallback` | type | Callback signature used by config builder setters |
+| `ConfigBuilderCallbackArgs` | type | Arguments passed to config builder callbacks |
+| `ModuleConfigType` | type | Extracts the config builder type from a `Module` |
+| `ModuleType` | type | Extracts the provider type from a `Module` |
+| `initializeModules` | function | Convenience wrapper around `configurator.initialize()` |
+| `SemanticVersion` | class | Extended `SemVer` with a `satisfies()` method |
+| `ModuleConsoleLogger` | class | Styled console logger with module-name prefix |
+
+### Provider Sub-path (`@equinor/fusion-framework-module/provider`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `IModuleProvider` | interface | Contract every module provider must satisfy |
+| `BaseModuleProvider` | class | Abstract base with version, subscription management, and dispose |
+| `BaseModuleProviderCtorArgs` | type | Constructor arguments for `BaseModuleProvider` |

--- a/vue-press/src/modules/module/README.md
+++ b/vue-press/src/modules/module/README.md
@@ -11,7 +11,7 @@ tag:
 
 Core module system for Fusion Framework. This package defines the contracts, base classes, and orchestration logic that every Fusion Framework module depends on.
 
-A Fusion application is assembled from **modules**. Each module owns a slice of runtime capability — an HTTP client, an auth provider, a context selector — and exposes it through a typed **provider** instance. The **`ModulesConfigurator`** drives the three-phase lifecycle that wires modules together: configure → initialize → dispose.
+A Fusion application is assembled from **modules**. Each module owns a slice of runtime capability — an HTTP client, an auth provider, a context selector — and exposes it through a typed **provider** instance. The **`ModulesConfigurator`** drives the lifecycle that wires modules together: configure → initialize → plugin → dispose.
 
 ```mermaid
 graph TD
@@ -90,6 +90,7 @@ console.log(modules.greeter.greet('World')); // Hello, World!
 | [Authoring Modules](./docs/authoring-modules.md) | Step-by-step guide for writing a new module |
 | [Configuration](./docs/configuration.md) | How `BaseConfigBuilder`, `_set`, and `ConfigBuilderCallback` work |
 | [Cross-Module Dependencies](./docs/cross-module-deps.md) | `requireInstance`, `postInitialize`, optional deps, circular dep avoidance |
+| [Plugins](./docs/plugins.md) | `registerPlugin`, `createPlugin`, plugin teardown, and host-level side effects |
 | [Events and Observability](./docs/events.md) | `configurator.event$`, `ModuleEvent`, telemetry patterns |
 | [Common Mistakes](./docs/common-mistakes.md) | Pitfalls — accessing modules early, missing `await`, no timeout, circular deps |
 
@@ -101,7 +102,7 @@ console.log(modules.greeter.greet('World')); // Hello, World!
 |---|---|---|
 | `Module` | type | Interface describing a module's structure and lifecycle hooks |
 | `AnyModule` | type | `Module<any, any, any, any>` — used for generic constraints |
-| `ModulesConfigurator` | class | Orchestrates configure → initialize → dispose for a set of modules |
+| `ModulesConfigurator` | class | Orchestrates configure → initialize → plugin → dispose for a set of modules |
 | `IModulesConfigurator` | interface | Public contract for the modules configurator |
 | `IModuleConfigurator` | interface | Descriptor for registering a single module with lifecycle hooks |
 | `BaseConfigBuilder` | class | Abstract config builder with dot-path targeting and async callbacks |
@@ -113,6 +114,13 @@ console.log(modules.greeter.greet('World')); // Hello, World!
 | `SemanticVersion` | class | Extended `SemVer` with a `satisfies()` method |
 | `ModuleConsoleLogger` | class | Styled console logger with module-name prefix |
 
+### Configurator Sub-path (`@equinor/fusion-framework-module/configurator`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `ModuleConfiguratorEventBaseName` | const | Shared `ModuleConfigurator` base segment for configurator lifecycle event names |
+| `ModuleConfiguratorEventName` | object | Map of `ModuleConfigurator.{name}.{state}` event names for filtering `event$` without hard-coded strings |
+
 ### Provider Sub-path (`@equinor/fusion-framework-module/provider`)
 
 | Export | Kind | Description |
@@ -120,3 +128,15 @@ console.log(modules.greeter.greet('World')); // Hello, World!
 | `IModuleProvider` | interface | Contract every module provider must satisfy |
 | `BaseModuleProvider` | class | Abstract base with version, subscription management, and dispose |
 | `BaseModuleProviderCtorArgs` | type | Constructor arguments for `BaseModuleProvider` |
+
+### Plugins Sub-path (`@equinor/fusion-framework-module/plugins`)
+
+| Export | Kind | Description |
+|---|---|---|
+| `createPlugin` | function | Creates a named plugin callback for stable lifecycle diagnostics |
+| `FrameworkPluginArgs` | type | Arguments passed to inline plugin callbacks: initialized modules and optional ref |
+| `FrameworkPluginCallback` | type | Callback accepted by `IModulesConfigurator.registerPlugin` |
+| `FrameworkPluginTeardown` | type | Cleanup callback or disposable object returned by a plugin |
+| `FrameworkPluginRegistration` | type | Plugin return type: teardown or `undefined` |
+| `FrameworkPlugin` | interface | Named plugin callback returned by `createPlugin` |
+| `FrameworkPluginInitializer` | type | Developer-facing callback signature used by `createPlugin` |

--- a/vue-press/src/modules/module/docs/authoring-modules.md
+++ b/vue-press/src/modules/module/docs/authoring-modules.md
@@ -1,0 +1,11 @@
+---
+title: Authoring Modules
+description: Step-by-step guide for writing a new Fusion Framework module — config builder, provider, module definition, and enable function.
+category: Module
+tag:
+  - module
+  - core
+  - authoring
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/authoring-modules.md -->

--- a/vue-press/src/modules/module/docs/common-mistakes.md
+++ b/vue-press/src/modules/module/docs/common-mistakes.md
@@ -1,0 +1,11 @@
+---
+title: Common Mistakes
+description: Pitfalls when authoring or consuming Fusion Framework modules — accessing modules early, missing await, no timeout, circular deps, and more.
+category: Module
+tag:
+  - module
+  - core
+  - troubleshooting
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/common-mistakes.md -->

--- a/vue-press/src/modules/module/docs/concepts.md
+++ b/vue-press/src/modules/module/docs/concepts.md
@@ -1,0 +1,11 @@
+---
+title: Concepts
+description: Mental model — what a module, provider, and configurator are in Fusion Framework.
+category: Module
+tag:
+  - module
+  - core
+  - concepts
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/concepts.md -->

--- a/vue-press/src/modules/module/docs/configuration.md
+++ b/vue-press/src/modules/module/docs/configuration.md
@@ -1,0 +1,11 @@
+---
+title: Configuration
+description: How BaseConfigBuilder, _set, and ConfigBuilderCallback work — writing and consuming module configuration.
+category: Module
+tag:
+  - module
+  - core
+  - configuration
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/configuration.md -->

--- a/vue-press/src/modules/module/docs/cross-module-deps.md
+++ b/vue-press/src/modules/module/docs/cross-module-deps.md
@@ -1,0 +1,11 @@
+---
+title: Cross-Module Dependencies
+description: Using requireInstance, postInitialize, optional dependencies, and avoiding circular dependency deadlocks.
+category: Module
+tag:
+  - module
+  - core
+  - dependencies
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/cross-module-deps.md -->

--- a/vue-press/src/modules/module/docs/events.md
+++ b/vue-press/src/modules/module/docs/events.md
@@ -1,0 +1,12 @@
+---
+title: Events and Observability
+description: The configurator event$ observable, ModuleEvent shape, filtering, telemetry patterns, and ModuleConsoleLogger.
+category: Module
+tag:
+  - module
+  - core
+  - events
+  - observability
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/events.md -->

--- a/vue-press/src/modules/module/docs/lifecycle.md
+++ b/vue-press/src/modules/module/docs/lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Lifecycle
-description: The five phases of the module lifecycle — configure, post-configure, initialize, post-initialize, and dispose.
+description: The module lifecycle phases: configure, post-configure, initialize, post-initialize, plugins, and dispose.
 category: Module
 tag:
   - module

--- a/vue-press/src/modules/module/docs/lifecycle.md
+++ b/vue-press/src/modules/module/docs/lifecycle.md
@@ -1,0 +1,11 @@
+---
+title: Lifecycle
+description: The five phases of the module lifecycle — configure, post-configure, initialize, post-initialize, and dispose.
+category: Module
+tag:
+  - module
+  - core
+  - lifecycle
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/lifecycle.md -->

--- a/vue-press/src/modules/module/docs/lifecycle.md
+++ b/vue-press/src/modules/module/docs/lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Lifecycle
-description: The module lifecycle phases: configure, post-configure, initialize, post-initialize, plugins, and dispose.
+description: "The module lifecycle phases: configure, post-configure, initialize, post-initialize, plugins, and dispose."
 category: Module
 tag:
   - module

--- a/vue-press/src/modules/module/docs/plugins.md
+++ b/vue-press/src/modules/module/docs/plugins.md
@@ -1,0 +1,11 @@
+---
+title: Plugins
+description: Register application-level module side effects with configurator plugins.
+category: Module
+tag:
+  - module
+  - core
+  - plugins
+---
+
+<!-- @include: ../../../../../packages/modules/module/docs/plugins.md -->


### PR DESCRIPTION
**Why is this change needed?**

`@equinor/fusion-framework-module` had no `docs/` coverage. Developers querying Fusion Knowledge for how the module lifecycle works, how to author a module, or how cross-module dependencies work got no useful answer. The package README linked to nothing.

**What is the current behavior?**

No `docs/` pages exist for the core module package. The VuePress sidebar has no entry for the module system. The README has no links to deeper documentation.

**What is the new behavior?**

Seven structured `docs/` pages added to `packages/modules/module/docs/`:

| Page | Coverage |
|---|---|
| `concepts.md` | Module system overview, roles, mental model |
| `lifecycle.md` | Configure → initialize → post-initialize → dispose phase sequence |
| `configuration.md` | `addConfig`, `configure`, `onConfigured`, `onInitialized` |
| `cross-module-deps.md` | `requireInstance` pattern for inter-module dependencies |
| `events.md` | `event$` observable, event naming conventions |
| `authoring-modules.md` | Step-by-step guide for creating a custom module |
| `common-mistakes.md` | FAQ-style pitfalls and how to avoid them |

All pages are mirrored under `vue-press/src/modules/module/docs/` for the published docs site. A "Module System" section is added to the VuePress sidebar. The package README gains a documentation table linking to each page.

**What is the intended behavior or invariant?**

Each page is structured for retrieval: chunked sections, clear headings, import paths, and copy-pasteable examples. A developer querying Fusion Knowledge for any of the topics above should receive an accurate, source-grounded answer.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`@equinor/fusion-framework-module` + `@equinor/fusion-framework-docs`)
- Consumer impact: Documentation only — no runtime behaviour changes
- Downstream impact: None

**Review guidance:**

Check that each doc page covers what its title promises and that examples compile against the public API. Sidebar link paths should resolve correctly in the VuePress dev server.

**Related issues**

closes: equinor/fusion-core-tasks#1258
ref: equinor/fusion-core-tasks#1256

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [ ] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)