### PR TITLE
feat(module): add plugin registration phase

### DIFF
--- a/.changeset/fusion-framework-module_register-plugin.md
+++ b/.changeset/fusion-framework-module_register-plugin.md
@@ -1,0 +1,25 @@
+---
+"@equinor/fusion-framework-module": minor
+"@equinor/fusion-framework-react-module": patch
+---
+
+Add `registerPlugin` to `IModulesConfigurator` and `ModulesConfigurator` for application-level side effects that run after modules are initialized and before application render.
+
+Plugins receive the initialized module map through `FrameworkPluginArgs` and may return a teardown callback that runs during `dispose`. Plugin-related types and the `createPlugin(name, callback)` helper are available from the dedicated `@equinor/fusion-framework-module/plugins` entrypoint. Plugin registration and teardown failures are isolated so one failing plugin does not block other plugins or module disposal.
+
+```typescript
+import { createPlugin } from '@equinor/fusion-framework-module/plugins';
+
+const contextTelemetryPlugin = createPlugin<[EventModule, TelemetryModule]>(
+	'contextTelemetry',
+	(modules) => modules.event.addEventListener('context:changed', (event) => {
+		modules.telemetry.track('context.changed', event.detail);
+	}),
+);
+
+configurator.registerPlugin(contextTelemetryPlugin);
+```
+
+Align `createModuleProvider` configurator typing with the module configurator reference type so React module package builds against the new plugin callback contract.
+
+Fixes: https://github.com/equinor/fusion-core-tasks/issues/1259

--- a/packages/modules/module/package.json
+++ b/packages/modules/module/package.json
@@ -17,6 +17,10 @@
     "./configurator": {
       "import": "./dist/esm/lib/configurator/index.js",
       "types": "./dist/types/lib/configurator/index.d.ts"
+    },
+    "./plugins": {
+      "import": "./dist/esm/lib/plugin/index.js",
+      "types": "./dist/types/lib/plugin/index.d.ts"
     }
   },
   "typesVersions": {
@@ -29,6 +33,9 @@
       ],
       "configurator": [
         "dist/types/lib/configurator/index.d.ts"
+      ],
+      "plugins": [
+        "dist/types/lib/plugin/index.d.ts"
       ]
     }
   },

--- a/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { AnyModule } from '../../types.js';
 import { ModulesConfigurator } from '../../lib/configurator/ModulesConfigurator.js';
+import { createPlugin } from '../../lib/plugin/index.js';
 import { createMockModule, createMinimalModule, collectEvents } from '../helpers.js';
 
 describe('ModulesConfigurator', () => {
@@ -124,6 +125,98 @@ describe('ModulesConfigurator', () => {
       });
       await configurator.initialize();
       expect(receivedInstance).toHaveProperty('alpha');
+    });
+  });
+
+  describe('registerPlugin', () => {
+    it('runs plugins after post-initialize callbacks before initialize resolves', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const order: string[] = [];
+      configurator.onInitialized(() => {
+        order.push('onInitialized');
+      });
+      configurator.registerPlugin(() => {
+        order.push('registerPlugin');
+      });
+      await configurator.initialize();
+      expect(order).toEqual(['onInitialized', 'registerPlugin']);
+    });
+
+    it('passes initialized modules and ref to plugins', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const plugin = vi.fn();
+      const ref = { parent: true };
+      configurator.registerPlugin(plugin);
+      const instance = await configurator.initialize(ref);
+      expect(plugin).toHaveBeenCalledWith({ modules: instance, ref });
+    });
+
+    it('isolates plugin registration failures', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const goodPlugin = vi.fn();
+      configurator.registerPlugin(() => {
+        throw new Error('plugin failed');
+      });
+      configurator.registerPlugin(goodPlugin);
+      await expect(configurator.initialize()).resolves.toHaveProperty('alpha');
+      expect(goodPlugin).toHaveBeenCalledOnce();
+    });
+
+    it('runs plugin teardowns during dispose', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const teardown = vi.fn();
+      configurator.registerPlugin(() => teardown);
+      const instance = await configurator.initialize();
+      await configurator.dispose(instance as never);
+      expect(teardown).toHaveBeenCalledOnce();
+    });
+
+    it('runs disposable plugin teardowns during dispose', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const disposable = { dispose: vi.fn() };
+      configurator.registerPlugin(() => disposable);
+      const instance = await configurator.initialize();
+      await configurator.dispose(instance as never);
+      expect(disposable.dispose).toHaveBeenCalledOnce();
+    });
+
+    it('uses createPlugin names in plugin lifecycle events', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const [events, cleanup] = collectEvents(configurator.event$);
+
+      function connectContextTelemetry(): void {}
+
+      configurator.registerPlugin(createPlugin('contextTelemetry', connectContextTelemetry));
+
+      await configurator.initialize();
+      cleanup();
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          name: 'ModulesConfigurator::_plugin.pluginRegistered',
+          properties: expect.objectContaining({ name: 'contextTelemetry' }),
+        }),
+      );
+    });
+
+    it('passes modules and ref directly to createPlugin callbacks', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const plugin = vi.fn();
+      const ref = { parent: true };
+
+      configurator.registerPlugin(createPlugin('directArgs', plugin));
+
+      const instance = await configurator.initialize(ref);
+
+      expect(plugin).toHaveBeenCalledWith(instance, ref);
+    });
+
+    it('requires createPlugin names to be non-empty', () => {
+      function connectContextTelemetry(): void {}
+
+      expect(() => createPlugin('   ', connectContextTelemetry)).toThrow(
+        'Framework plugin name must be a non-empty string',
+      );
     });
   });
 

--- a/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/ModulesConfigurator.test.ts
@@ -180,6 +180,42 @@ describe('ModulesConfigurator', () => {
       expect(disposable.dispose).toHaveBeenCalledOnce();
     });
 
+    it('passes a sealed module map to plugins', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      let isPluginModuleMapSealed = false;
+
+      configurator.registerPlugin(({ modules }) => {
+        isPluginModuleMapSealed = Object.isSealed(modules);
+      });
+
+      await configurator.initialize();
+
+      expect(isPluginModuleMapSealed).toBe(true);
+    });
+
+    it('runs plugin teardowns in reverse registration order', async () => {
+      const configurator = new ModulesConfigurator([createMockModule('alpha')]);
+      const order: string[] = [];
+      let releaseFirstPlugin: () => void = () => {};
+      const firstPluginReady = new Promise<void>((resolve) => {
+        releaseFirstPlugin = resolve;
+      });
+
+      configurator.registerPlugin(async () => {
+        await firstPluginReady;
+        return () => order.push('first');
+      });
+      configurator.registerPlugin(() => {
+        releaseFirstPlugin();
+        return () => order.push('second');
+      });
+
+      const instance = await configurator.initialize();
+      await configurator.dispose(instance as never);
+
+      expect(order).toEqual(['second', 'first']);
+    });
+
     it('uses createPlugin names in plugin lifecycle events', async () => {
       const configurator = new ModulesConfigurator([createMockModule('alpha')]);
       const [events, cleanup] = collectEvents(configurator.event$);

--- a/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
@@ -141,6 +141,28 @@ describe('dispose phase', () => {
     expect(mod.dispose).toHaveBeenCalledOnce();
   });
 
+  it('runs plugin teardowns in LIFO order', async () => {
+    const order: string[] = [];
+    const firstTeardown = vi.fn(async () => {
+      order.push('first');
+    });
+    const secondTeardown = vi.fn(async () => {
+      order.push('second');
+    });
+    const mod: AnyModule = {
+      name: 'alpha',
+      initialize: vi.fn(),
+      dispose: vi.fn(async () => {
+        order.push('module');
+      }),
+    };
+    const ctx = makeCtx([mod], { pluginTeardowns: [firstTeardown, secondTeardown] });
+
+    await runDisposePhase(ctx, { alpha: {} });
+
+    expect(order).toEqual(['second', 'first', 'module']);
+  });
+
   it('completes the event$ subject after all modules are disposed', async () => {
     const mod: AnyModule = {
       name: 'alpha',

--- a/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
+++ b/packages/modules/module/src/__tests__/configurator/phases/dispose.test.ts
@@ -89,6 +89,58 @@ describe('dispose phase', () => {
     expect(goodMod.dispose).toHaveBeenCalledOnce();
   });
 
+  it('runs plugin teardowns before module dispose', async () => {
+    const order: string[] = [];
+    const pluginTeardown = vi.fn(async () => {
+      order.push('plugin');
+    });
+    const mod: AnyModule = {
+      name: 'alpha',
+      initialize: vi.fn(),
+      dispose: vi.fn(async () => {
+        order.push('module');
+      }),
+    };
+    const ctx = makeCtx([mod], { pluginTeardowns: [pluginTeardown] });
+    await runDisposePhase(ctx, { alpha: {} });
+    expect(order).toEqual(['plugin', 'module']);
+  });
+
+  it('runs disposable plugin teardowns before module dispose', async () => {
+    const order: string[] = [];
+    const pluginTeardown = {
+      dispose: vi.fn(async () => {
+        order.push('plugin');
+      }),
+    };
+    const mod: AnyModule = {
+      name: 'alpha',
+      initialize: vi.fn(),
+      dispose: vi.fn(async () => {
+        order.push('module');
+      }),
+    };
+    const ctx = makeCtx([mod], { pluginTeardowns: [pluginTeardown] });
+    await runDisposePhase(ctx, { alpha: {} });
+    expect(order).toEqual(['plugin', 'module']);
+  });
+
+  it('isolates plugin teardown failures', async () => {
+    const goodTeardown = vi.fn(async () => {});
+    const badTeardown = vi.fn(async () => {
+      throw new Error('plugin dispose failed');
+    });
+    const mod: AnyModule = {
+      name: 'alpha',
+      initialize: vi.fn(),
+      dispose: vi.fn(async () => {}),
+    };
+    const ctx = makeCtx([mod], { pluginTeardowns: [badTeardown, goodTeardown] });
+    await expect(runDisposePhase(ctx, { alpha: {} })).resolves.toBeUndefined();
+    expect(goodTeardown).toHaveBeenCalledOnce();
+    expect(mod.dispose).toHaveBeenCalledOnce();
+  });
+
   it('completes the event$ subject after all modules are disposed', async () => {
     const mod: AnyModule = {
       name: 'alpha',

--- a/packages/modules/module/src/lib/configurator/IModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/IModulesConfigurator.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../types.js';
 
 import type { IModuleConfigurator } from './IModuleConfigurator.js';
+import type { FrameworkPluginCallback } from '../plugin/index.js';
 
 /**
  * Contract for the top-level module orchestrator in Fusion Framework.
@@ -96,6 +97,33 @@ export interface IModulesConfigurator<
    */
   onInitialized<T extends Array<AnyModule> | unknown>(
     cb: (instance: ModulesInstanceType<CombinedModules<T, TModules>>) => void | Promise<void>,
+  ): void;
+
+  /**
+   * Registers a plugin that connects side effects after modules are ready.
+   *
+   * Plugins run after module initialization and post-initialize hooks, but
+   * before {@link initialize} resolves to the application renderer. Return a
+   * teardown callback to clean up subscriptions or global listeners during
+   * {@link dispose}. Plugin failures are isolated from other plugins.
+   *
+   * @param cb - Plugin callback receiving the initialized module map and optional ref.
+   * @template T - Additional modules to include in the plugin module map.
+   * @example
+   * ```typescript
+   * function connectContextTelemetry(args: FrameworkPluginArgs<[EventModule, TelemetryModule]>) {
+   *   const teardown = args.modules.event.addEventListener('context:changed', (event) => {
+   *     args.modules.telemetry.track('context.changed', event.detail);
+   *   });
+   *
+   *   return teardown;
+   * }
+   *
+   * configurator.registerPlugin(connectContextTelemetry);
+   * ```
+   */
+  registerPlugin<T extends Array<AnyModule> | unknown>(
+    cb: FrameworkPluginCallback<CombinedModules<T, TModules>, TRef>,
   ): void;
 
   /**

--- a/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
@@ -31,10 +31,11 @@ import { version } from '../../version.js';
 /**
  * Core orchestrator that drives the module lifecycle in Fusion Framework.
  *
- * `ModulesConfigurator` manages the full **configure → initialize → plugin → dispose**
- * pipeline for a set of modules. Consumers register modules via {@link addConfig}
- * or {@link configure}, then call {@link initialize} to produce a sealed
- * {@link ModulesInstance} whose properties are the initialized module providers.
+ * `ModulesConfigurator` manages the full **configure → post-configure → initialize →
+ * post-initialize → plugin → dispose** pipeline for a set of modules. Consumers
+ * register modules via {@link addConfig} or {@link configure}, then call
+ * {@link initialize} to produce a sealed {@link ModulesInstance} whose properties
+ * are the initialized module providers.
  *
  * ### Lifecycle phases (in execution order)
  *
@@ -44,7 +45,7 @@ import { version } from '../../version.js';
  * | 2 | **Post-configure** | `_postConfigure` (inside `_configure`) | `postConfigure()` hooks and `onConfigured` callbacks run. |
  * | 3 | **Initialize** | `_initialize` | Modules are initialized concurrently; cross-module dependencies are resolved through `requireInstance`. |
  * | 4 | **Post-initialize** | `_postInitialize` | `postInitialize()` hooks and `onInitialized` callbacks run. |
- * | 5 | **Plugin** | `registerPlugin` | Application plugins connect side effects after modules are ready. |
+ * | 5 | **Plugin** | `_registerPlugins` (inside `initialize`) | Registered application plugins connect side effects after modules are ready. |
  * | 6 | **Dispose** | `dispose` | Plugin teardowns and module `dispose()` hooks run; the event stream is completed. |
  *
  * ### Registering phase callbacks
@@ -369,12 +370,14 @@ export class ModulesConfigurator<
 
     await this._postInitialize<T, R>(instance, ref);
 
-    const modules = Object.assign({}, instance, {
-      dispose: () => this.dispose(instance as unknown as ModulesInstance<TModules>),
-    });
+    const modules = Object.seal(
+      Object.assign({}, instance, {
+        dispose: () => this.dispose(instance as unknown as ModulesInstance<TModules>),
+      }),
+    );
     await this._registerPlugins<T, R>(modules, ref);
 
-    return Object.seal(modules);
+    return modules;
   }
 
   /**

--- a/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
@@ -19,17 +19,19 @@ import type {
   IModulesConfigurator,
   ModulesConfiguratorConfigCallback,
 } from './types.js';
+import type { FrameworkPluginCallback, FrameworkPluginTeardown } from '../plugin/index.js';
 
 import { runConfigurePhase } from './phases/configure.js';
 import { runInitializePhase } from './phases/initialize.js';
 import { runPostInitializePhase } from './phases/post-initialize.js';
+import { runPluginPhase } from './phases/plugin.js';
 import { runDisposePhase } from './phases/dispose.js';
 import { version } from '../../version.js';
 
 /**
  * Core orchestrator that drives the module lifecycle in Fusion Framework.
  *
- * `ModulesConfigurator` manages the full **configure → initialize → dispose**
+ * `ModulesConfigurator` manages the full **configure → initialize → plugin → dispose**
  * pipeline for a set of modules. Consumers register modules via {@link addConfig}
  * or {@link configure}, then call {@link initialize} to produce a sealed
  * {@link ModulesInstance} whose properties are the initialized module providers.
@@ -42,13 +44,15 @@ import { version } from '../../version.js';
  * | 2 | **Post-configure** | `_postConfigure` (inside `_configure`) | `postConfigure()` hooks and `onConfigured` callbacks run. |
  * | 3 | **Initialize** | `_initialize` | Modules are initialized concurrently; cross-module dependencies are resolved through `requireInstance`. |
  * | 4 | **Post-initialize** | `_postInitialize` | `postInitialize()` hooks and `onInitialized` callbacks run. |
- * | 5 | **Dispose** | `dispose` | Each module's `dispose()` hook runs; the event stream is completed. |
+ * | 5 | **Plugin** | `registerPlugin` | Application plugins connect side effects after modules are ready. |
+ * | 6 | **Dispose** | `dispose` | Plugin teardowns and module `dispose()` hooks run; the event stream is completed. |
  *
  * ### Registering phase callbacks
  *
  * - **Per-module callbacks**: use `addConfig({ module, configure, afterConfig, afterInit })`.
  * - **Global post-configure**: use `onConfigured(cb)`.
  * - **Global post-initialize**: use `onInitialized(cb)`.
+ * - **Plugins**: use `registerPlugin(cb)` to connect side effects before render.
  *
  * All lifecycle transitions emit {@link ModuleEvent} entries on the {@link event$}
  * observable for telemetry and debugging.
@@ -123,6 +127,25 @@ export class ModulesConfigurator<
    * @protected
    */
   protected _afterInit: Array<(instance: any) => void | Promise<void>> = [];
+
+  /**
+   * Registered plugin callbacks.
+   *
+   * Plugins run after all modules have initialized and before initialize resolves.
+   * Typed as `any` because callbacks are registered with concrete module maps but
+   * stored erased by the base orchestrator.
+   * @protected
+   */
+  protected _plugins: Array<FrameworkPluginCallback<any, TRef>> = [];
+
+  /**
+   * Teardown callbacks returned by registered plugins.
+   *
+   * Consumed during dispose and cleared after execution so repeated dispose calls
+   * do not run plugin cleanup more than once.
+   * @protected
+   */
+  protected _pluginTeardowns: FrameworkPluginTeardown[] = [];
 
   /**
    * Set of all registered module descriptors.
@@ -246,12 +269,50 @@ export class ModulesConfigurator<
   }
 
   /**
+   * Registers a plugin that connects side effects after modules are initialized.
+   *
+   * The callback runs after `postInitialize` and `onInitialized` callbacks have
+   * settled, but before {@link initialize} resolves. Return a teardown callback
+   * to clean up subscriptions or listeners during {@link dispose}.
+   *
+   * @param cb - Plugin callback receiving the initialized module map and optional ref.
+   * @template T - Additional modules to include in the plugin module map.
+   * @example
+   * ```typescript
+   * function connectContextTelemetry(args: FrameworkPluginArgs<[EventModule, TelemetryModule]>) {
+   *   const teardown = args.modules.event.addEventListener('context:changed', (event) => {
+   *     args.modules.telemetry.track('context.changed', event.detail);
+   *   });
+   *
+   *   return teardown;
+   * }
+   *
+   * configurator.registerPlugin(connectContextTelemetry);
+   * ```
+   */
+  public registerPlugin<T extends Array<AnyModule> | unknown>(
+    cb: FrameworkPluginCallback<CombinedModules<T, TModules>, TRef>,
+  ): void {
+    this._plugins.push(cb as FrameworkPluginCallback<any, TRef>);
+    this._registerEvent({
+      level: ModuleEventLevel.Debug,
+      name: 'addPlugin',
+      message: 'Added plugin callback',
+      properties: {
+        count: this._plugins.length,
+        name: cb.name || 'anonymous',
+      },
+    });
+  }
+
+  /**
    * Runs the full configure → initialize pipeline and returns a sealed module instance.
    *
    * Execution order:
    * 1. {@link _configure} — configure phase (creates config, applies callbacks, post-configure hooks).
    * 2. {@link _initialize} — initialize phase (concurrent module init with `requireInstance`).
    * 3. {@link _postInitialize} — post-initialize phase (`postInitialize` hooks + `onInitialized` callbacks).
+   * 4. {@link _registerPlugins} — plugin phase (`registerPlugin` callbacks connect side effects).
    *
    * @param ref - Optional reference forwarded to all module lifecycle hooks.
    * @returns A promise resolving to the sealed, initialized module instance.
@@ -308,11 +369,12 @@ export class ModulesConfigurator<
 
     await this._postInitialize<T, R>(instance, ref);
 
-    return Object.seal(
-      Object.assign({}, instance, {
-        dispose: () => this.dispose(instance as unknown as ModulesInstance<TModules>),
-      }),
-    );
+    const modules = Object.assign({}, instance, {
+      dispose: () => this.dispose(instance as unknown as ModulesInstance<TModules>),
+    });
+    await this._registerPlugins<T, R>(modules, ref);
+
+    return Object.seal(modules);
   }
 
   /**
@@ -416,6 +478,33 @@ export class ModulesConfigurator<
   }
 
   /**
+   * Runs the plugin lifecycle phase.
+   *
+   * Delegates to {@link runPluginPhase} which calls each registered plugin and
+   * stores returned teardown callbacks for dispose.
+   *
+   * Override this method in a subclass to customize plugin registration.
+   *
+   * @param instance - The sealed module instance from the initialize phase.
+   * @param ref - Optional reference forwarded to each plugin callback.
+   * @protected
+   */
+  protected async _registerPlugins<T, R extends TRef = TRef>(
+    instance: ModulesInstanceType<CombinedModules<T, TModules>>,
+    ref?: R,
+  ): Promise<void> {
+    return runPluginPhase(
+      {
+        plugins: this._plugins,
+        teardowns: this._pluginTeardowns,
+        registerEvent: this._registerEvent.bind(this),
+      },
+      instance,
+      ref,
+    );
+  }
+
+  /**
    * Tears down all modules managed by this configurator.
    *
    * Delegates to {@link runDisposePhase} which calls each module's `dispose`
@@ -432,6 +521,7 @@ export class ModulesConfigurator<
         registerEvent: this._registerEvent.bind(this),
         // ReplaySubject extends Subject — dispose only needs .complete() which both have.
         event$: this.#event$,
+        pluginTeardowns: this._pluginTeardowns,
       },
       instance,
       ref,

--- a/packages/modules/module/src/lib/configurator/index.ts
+++ b/packages/modules/module/src/lib/configurator/index.ts
@@ -13,6 +13,15 @@ export type {
   ModuleConfiguratorConfigCallback,
   ModulesConfiguratorConfigCallback,
 } from './types.js';
+export type {
+  FrameworkPluginArgs,
+  FrameworkPluginTeardown,
+  FrameworkPluginCallback,
+  FrameworkPlugin,
+  FrameworkPluginInitializer,
+  FrameworkPluginRegistration,
+} from '../plugin/index.js';
+export { createPlugin } from '../plugin/index.js';
 
 export { RequiredModuleTimeoutError } from './types.js';
 
@@ -27,4 +36,5 @@ export {
 } from './phases/configure.js';
 export { runInitializePhase, createRequireInstance } from './phases/initialize.js';
 export { runPostInitializePhase } from './phases/post-initialize.js';
+export { runPluginPhase } from './phases/plugin.js';
 export { runDisposePhase } from './phases/dispose.js';

--- a/packages/modules/module/src/lib/configurator/phases/dispose.ts
+++ b/packages/modules/module/src/lib/configurator/phases/dispose.ts
@@ -2,6 +2,19 @@
 import type { Subject } from 'rxjs';
 
 import { ModuleEventLevel, type AnyModule, type ModuleEvent } from '../../../types.js';
+import type { FrameworkPluginTeardown } from '../../plugin/index.js';
+
+function getPluginTeardownName(teardown: FrameworkPluginTeardown): string {
+  return typeof teardown === 'function' ? teardown.name || 'anonymous' : 'dispose';
+}
+
+async function runPluginTeardown(teardown: FrameworkPluginTeardown): Promise<void> {
+  if (typeof teardown === 'function') {
+    await teardown();
+    return;
+  }
+  await teardown.dispose();
+}
 
 /**
  * Context passed to the dispose lifecycle phase.
@@ -18,6 +31,8 @@ export interface DisposePhaseContext {
    * are disposed to signal that the lifecycle is fully torn down.
    */
   event$: Subject<ModuleEvent>;
+  /** Plugin teardown callbacks registered during the plugin phase. */
+  pluginTeardowns?: FrameworkPluginTeardown[];
 }
 
 /**
@@ -38,7 +53,7 @@ export async function runDisposePhase(
   instance: Record<string, unknown>,
   ref?: unknown,
 ): Promise<void> {
-  const { modules, registerEvent, event$ } = ctx;
+  const { modules, registerEvent, event$, pluginTeardowns = [] } = ctx;
 
   registerEvent({
     level: ModuleEventLevel.Debug,
@@ -46,6 +61,43 @@ export async function runDisposePhase(
     message: 'Disposing modules instance',
     properties: { modules: Object.keys(instance).join(', ') },
   });
+
+  if (pluginTeardowns.length) {
+    registerEvent({
+      level: ModuleEventLevel.Debug,
+      name: 'dispose.pluginsDisposing',
+      message: `Disposing plugins [${pluginTeardowns.length}]`,
+      properties: { count: pluginTeardowns.length },
+    });
+
+    // Tear down plugins before module providers so side effects can still access
+    // live providers while unsubscribing. LIFO mirrors common subscription stacks.
+    await Promise.allSettled(
+      pluginTeardowns
+        .splice(0)
+        .reverse()
+        .map(async (teardown) => {
+          const name = getPluginTeardownName(teardown);
+          try {
+            await runPluginTeardown(teardown);
+            registerEvent({
+              level: ModuleEventLevel.Debug,
+              name: 'dispose.pluginDisposed',
+              message: `Plugin ${name} disposed successfully`,
+              properties: { name },
+            });
+          } catch (err) {
+            registerEvent({
+              level: ModuleEventLevel.Warning,
+              name: 'dispose.pluginDisposeError',
+              message: `Plugin ${name} dispose failed`,
+              properties: { name },
+              error: err,
+            });
+          }
+        }),
+    );
+  }
 
   // Dispose all modules concurrently; failures are isolated per module so
   // one bad teardown cannot leave other modules in an inconsistent state.

--- a/packages/modules/module/src/lib/configurator/phases/dispose.ts
+++ b/packages/modules/module/src/lib/configurator/phases/dispose.ts
@@ -72,31 +72,26 @@ export async function runDisposePhase(
 
     // Tear down plugins before module providers so side effects can still access
     // live providers while unsubscribing. LIFO mirrors common subscription stacks.
-    await Promise.allSettled(
-      pluginTeardowns
-        .splice(0)
-        .reverse()
-        .map(async (teardown) => {
-          const name = getPluginTeardownName(teardown);
-          try {
-            await runPluginTeardown(teardown);
-            registerEvent({
-              level: ModuleEventLevel.Debug,
-              name: 'dispose.pluginDisposed',
-              message: `Plugin ${name} disposed successfully`,
-              properties: { name },
-            });
-          } catch (err) {
-            registerEvent({
-              level: ModuleEventLevel.Warning,
-              name: 'dispose.pluginDisposeError',
-              message: `Plugin ${name} dispose failed`,
-              properties: { name },
-              error: err,
-            });
-          }
-        }),
-    );
+    for (const teardown of pluginTeardowns.splice(0).reverse()) {
+      const name = getPluginTeardownName(teardown);
+      try {
+        await runPluginTeardown(teardown);
+        registerEvent({
+          level: ModuleEventLevel.Debug,
+          name: 'dispose.pluginDisposed',
+          message: `Plugin ${name} disposed successfully`,
+          properties: { name },
+        });
+      } catch (err) {
+        registerEvent({
+          level: ModuleEventLevel.Warning,
+          name: 'dispose.pluginDisposeError',
+          message: `Plugin ${name} dispose failed`,
+          properties: { name },
+          error: err,
+        });
+      }
+    }
   }
 
   // Dispose all modules concurrently; failures are isolated per module so

--- a/packages/modules/module/src/lib/configurator/phases/plugin.ts
+++ b/packages/modules/module/src/lib/configurator/phases/plugin.ts
@@ -1,0 +1,94 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: internal type-erased dispatch — plugins are registered with concrete module maps but stored erased by the orchestrator
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ModuleEventLevel, type ModuleEvent } from '../../../types.js';
+import type { FrameworkPluginCallback, FrameworkPluginTeardown } from '../../plugin/index.js';
+
+function isPluginTeardown(value: unknown): value is FrameworkPluginTeardown {
+  return (
+    typeof value === 'function' ||
+    (typeof value === 'object' &&
+      value !== null &&
+      'dispose' in value &&
+      typeof value.dispose === 'function')
+  );
+}
+
+/**
+ * Context passed to the plugin lifecycle phase.
+ *
+ * @internal
+ */
+export interface PluginPhaseContext<TRef = unknown> {
+  /** Registered plugin callbacks to run after module initialization. */
+  plugins: Array<FrameworkPluginCallback<any, TRef>>;
+  /** Mutable teardown registry consumed by the dispose phase. */
+  teardowns: FrameworkPluginTeardown[];
+  /** Emits a structured lifecycle event into the configurator's event stream. */
+  registerEvent: (event: ModuleEvent) => void;
+}
+
+/**
+ * Runs configurator plugins after modules are ready.
+ *
+ * Executes all registered plugins with the initialized module map. Plugin
+ * failures are isolated and emitted as warning events so one failing side
+ * effect cannot block application rendering. Returned teardown callbacks are
+ * stored for the dispose phase.
+ *
+ * @param ctx - The plugin phase context.
+ * @param modules - The initialized module instance map.
+ * @param ref - Optional reference forwarded from module initialization.
+ * @returns A promise resolving when all plugin callbacks have settled.
+ */
+export async function runPluginPhase<TRef = unknown>(
+  ctx: PluginPhaseContext<TRef>,
+  modules: Record<string, unknown>,
+  ref?: TRef,
+): Promise<void> {
+  const { plugins, teardowns, registerEvent } = ctx;
+
+  if (!plugins.length) return;
+
+  registerEvent({
+    level: ModuleEventLevel.Debug,
+    name: '_plugin.pluginsRegistering',
+    message: `Registering plugins [${plugins.length}]`,
+    properties: { count: plugins.length },
+  });
+
+  await Promise.allSettled(
+    plugins.map(async (plugin) => {
+      const pluginStart = performance.now();
+      const name = plugin.name || 'anonymous';
+      try {
+        const teardown = await plugin({ modules, ref });
+        if (isPluginTeardown(teardown)) {
+          teardowns.push(teardown);
+        }
+        const pluginTime = Math.round(performance.now() - pluginStart);
+        registerEvent({
+          level: ModuleEventLevel.Debug,
+          name: '_plugin.pluginRegistered',
+          message: `Plugin ${name} registered in ${pluginTime}ms`,
+          properties: { name, pluginTime },
+          metric: pluginTime,
+        });
+      } catch (err) {
+        registerEvent({
+          level: ModuleEventLevel.Warning,
+          name: '_plugin.pluginRegisterError',
+          message: `Plugin ${name} registration failed`,
+          properties: { name },
+          error: err,
+        });
+      }
+    }),
+  );
+
+  registerEvent({
+    level: ModuleEventLevel.Debug,
+    name: '_plugin.pluginsRegistered',
+    message: 'Plugin registration complete',
+    properties: { count: plugins.length, teardowns: teardowns.length },
+  });
+}

--- a/packages/modules/module/src/lib/configurator/phases/plugin.ts
+++ b/packages/modules/module/src/lib/configurator/phases/plugin.ts
@@ -56,15 +56,12 @@ export async function runPluginPhase<TRef = unknown>(
     properties: { count: plugins.length },
   });
 
-  await Promise.allSettled(
+  const pluginRegistrations = await Promise.all(
     plugins.map(async (plugin) => {
       const pluginStart = performance.now();
       const name = plugin.name || 'anonymous';
       try {
         const teardown = await plugin({ modules, ref });
-        if (isPluginTeardown(teardown)) {
-          teardowns.push(teardown);
-        }
         const pluginTime = Math.round(performance.now() - pluginStart);
         registerEvent({
           level: ModuleEventLevel.Debug,
@@ -73,6 +70,7 @@ export async function runPluginPhase<TRef = unknown>(
           properties: { name, pluginTime },
           metric: pluginTime,
         });
+        return isPluginTeardown(teardown) ? teardown : undefined;
       } catch (err) {
         registerEvent({
           level: ModuleEventLevel.Warning,
@@ -81,9 +79,16 @@ export async function runPluginPhase<TRef = unknown>(
           properties: { name },
           error: err,
         });
+        return undefined;
       }
     }),
   );
+
+  for (const teardown of pluginRegistrations) {
+    if (teardown) {
+      teardowns.push(teardown);
+    }
+  }
 
   registerEvent({
     level: ModuleEventLevel.Debug,

--- a/packages/modules/module/src/lib/plugin/create-plugin.ts
+++ b/packages/modules/module/src/lib/plugin/create-plugin.ts
@@ -1,0 +1,47 @@
+import type { AnyModule } from '../../types.js';
+import type { FrameworkPlugin, FrameworkPluginInitializer } from './types.js';
+
+/**
+ * Creates a named framework plugin callback for module configurators.
+ *
+ * Use `createPlugin` when a plugin should have a stable lifecycle event name
+ * without relying on JavaScript function name inference. The returned callback
+ * can be passed directly to {@link IModulesConfigurator.registerPlugin}.
+ *
+ * @template TModules - Module descriptors available to the plugin.
+ * @template TRef - Optional reference object forwarded from initialization.
+ * @param name - Stable plugin name used in lifecycle events and diagnostics.
+ * @param callback - Plugin callback that runs after modules initialize.
+ * @returns A named framework plugin callback.
+ * @throws {Error} When the plugin name is empty or whitespace.
+ * @example
+ * ```typescript
+ * const contextTelemetryPlugin = createPlugin<[EventModule, TelemetryModule]>(
+ *   'contextTelemetry',
+ *   (modules) => modules.event.addEventListener('context:changed', (event) => {
+ *     modules.telemetry.track('context.changed', event.detail);
+ *   }),
+ * );
+ *
+ * configurator.registerPlugin(contextTelemetryPlugin);
+ * ```
+ */
+export function createPlugin<TModules extends Array<AnyModule>, TRef = unknown>(
+  name: string,
+  callback: FrameworkPluginInitializer<TModules, TRef>,
+): FrameworkPlugin<TModules, TRef> {
+  const normalizedName = name.trim();
+
+  if (!normalizedName) {
+    throw new Error('Framework plugin name must be a non-empty string');
+  }
+
+  const plugin = ((args) => callback(args.modules, args.ref)) as FrameworkPlugin<TModules, TRef>;
+
+  Object.defineProperty(plugin, 'name', {
+    value: normalizedName,
+    configurable: true,
+  });
+
+  return plugin;
+}

--- a/packages/modules/module/src/lib/plugin/index.ts
+++ b/packages/modules/module/src/lib/plugin/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Framework plugin API for module configurators.
+ *
+ * Use these types with {@link IModulesConfigurator.registerPlugin} when adding
+ * application-level side effects that run after modules initialize.
+ *
+ * @packageDocumentation
+ */
+export type {
+  FrameworkPluginArgs,
+  FrameworkPluginCallback,
+  FrameworkPlugin,
+  FrameworkPluginInitializer,
+  FrameworkPluginRegistration,
+  FrameworkPluginTeardown,
+} from './types.js';
+export { createPlugin } from './create-plugin.js';

--- a/packages/modules/module/src/lib/plugin/types.ts
+++ b/packages/modules/module/src/lib/plugin/types.ts
@@ -1,0 +1,148 @@
+import type { AnyModule, ModulesInstanceType } from '../../types.js';
+
+/**
+ * Cleanup callback returned by a configurator plugin.
+ *
+ * The callback runs during {@link IModulesConfigurator.dispose} and should undo
+ * subscriptions, global event listeners, telemetry bindings, or other side
+ * effects created by {@link IModulesConfigurator.registerPlugin}.
+ *
+ * @example
+ * ```typescript
+ * function removeContextTelemetry(): void {
+ *   window.removeEventListener('context:changed', handleContextChange);
+ * }
+ * ```
+ */
+export type FrameworkPluginTeardown =
+  | (() => void | Promise<void>)
+  | { dispose: () => void | Promise<void> };
+
+/**
+ * Registration returned by a configurator plugin.
+ *
+ * Return `undefined` when the plugin has no cleanup work, or return a teardown
+ * callback that should run during dispose.
+ *
+ * @example
+ * ```typescript
+ * function connectTelemetry(): FrameworkPluginRegistration {
+ *   const subscription = telemetry.events.subscribe(handleTelemetryEvent);
+ *
+ *   return {
+ *     dispose: () => subscription.unsubscribe(),
+ *   };
+ * }
+ * ```
+ */
+export type FrameworkPluginRegistration = FrameworkPluginTeardown | undefined;
+
+/**
+ * Arguments passed to a framework plugin callback.
+ *
+ * Plugins receive the initialized module map and the optional reference that
+ * was forwarded through module initialization.
+ *
+ * @template TModules - Module descriptors available to the plugin.
+ * @template TRef - Optional reference object forwarded from initialization.
+ * @example
+ * ```typescript
+ * function connectContextTelemetry({
+ *   modules,
+ *   ref,
+ * }: FrameworkPluginArgs<[EventModule, TelemetryModule], FrameworkRef>) {
+ *   modules.telemetry.track('framework.ready', { source: ref?.source });
+ * }
+ * ```
+ */
+export interface FrameworkPluginArgs<TModules extends Array<AnyModule>, TRef = unknown> {
+  /** Initialized module instance map available after all modules are ready. */
+  modules: ModulesInstanceType<TModules>;
+  /** Optional reference object forwarded from module initialization. */
+  ref?: TRef;
+}
+
+/**
+ * Named framework plugin callback created by {@link createPlugin}.
+ *
+ * The function name is used in lifecycle events and diagnostics while preserving
+ * the callback signature accepted by {@link IModulesConfigurator.registerPlugin}.
+ *
+ * @template TModules - Module descriptors available to the plugin.
+ * @template TRef - Optional reference object forwarded from initialization.
+ * @example
+ * ```typescript
+ * const contextTelemetryPlugin = createPlugin<[EventModule, TelemetryModule]>(
+ *   'contextTelemetry',
+ *   (modules) => modules.event.addEventListener('context:changed', (event) => {
+ *     modules.telemetry.track('context.changed', event.detail);
+ *   }),
+ * );
+ *
+ * configurator.registerPlugin(contextTelemetryPlugin);
+ * ```
+ */
+export interface FrameworkPlugin<TModules extends Array<AnyModule>, TRef = unknown> {
+  /** Runs the plugin after modules are initialized. */
+  (
+    args: FrameworkPluginArgs<TModules, TRef>,
+  ): FrameworkPluginRegistration | Promise<FrameworkPluginRegistration>;
+}
+
+/**
+ * Developer-facing callback used by {@link createPlugin}.
+ *
+ * The callback receives the initialized module map directly instead of the
+ * lower-level args object used by {@link IModulesConfigurator.registerPlugin}.
+ *
+ * @template TModules - Module descriptors available to the plugin.
+ * @template TRef - Optional reference object forwarded from initialization.
+ * @param modules - Initialized module map available after all modules are ready.
+ * @param ref - Optional reference object forwarded from module initialization.
+ * @returns Optional teardown callback invoked when the module instance is disposed.
+ * @example
+ * ```typescript
+ * const contextTelemetryPlugin = createPlugin<[EventModule, TelemetryModule]>(
+ *   'contextTelemetry',
+ *   (modules) => modules.event.addEventListener('context:changed', (event) => {
+ *     modules.telemetry.track('context.changed', event.detail);
+ *   }),
+ * );
+ * ```
+ */
+export type FrameworkPluginInitializer<TModules extends Array<AnyModule>, TRef = unknown> = (
+  modules: ModulesInstanceType<TModules>,
+  ref?: TRef,
+) => FrameworkPluginRegistration | Promise<FrameworkPluginRegistration>;
+
+/**
+ * Callback registered through {@link IModulesConfigurator.registerPlugin}.
+ *
+ * Plugins run after all modules have initialized and after post-initialize hooks
+ * have settled. Return a teardown callback when the plugin creates side effects
+ * that must be cleaned up during dispose.
+ *
+ * @template TModules - Module descriptors available to the plugin.
+ * @template TRef - Optional reference object forwarded from initialization.
+ * @param args - Initialized module map and optional initialization reference.
+ * @returns Optional teardown callback invoked when the module instance is disposed.
+ * @example
+ * ```typescript
+ * function connectContextTelemetry({
+ *   modules,
+ * }: FrameworkPluginArgs<[EventModule, TelemetryModule]>): FrameworkPluginRegistration {
+ *   const teardown = modules.event.addEventListener('context:changed', (event) => {
+ *     modules.telemetry.track('context.changed', event.detail);
+ *   });
+ *
+ *   return teardown;
+ * }
+ *
+ * configurator.registerPlugin(connectContextTelemetry);
+ * ```
+ */
+export type FrameworkPluginCallback<TModules extends Array<AnyModule>, TRef = unknown> =
+  | FrameworkPlugin<TModules, TRef>
+  | ((
+      args: FrameworkPluginArgs<TModules, TRef>,
+    ) => FrameworkPluginRegistration | Promise<FrameworkPluginRegistration>);

--- a/packages/react/modules/module/src/ModuleProvider.tsx
+++ b/packages/react/modules/module/src/ModuleProvider.tsx
@@ -34,22 +34,23 @@ type ModuleProviderCreator = <
  * ```ts
  * import http, { HttpModule } from '@equinor/fusion-framework-module-http';
  * import msal, { MsalModule } from '@equinor/fusion-framework-module-msal';
+ * import { ModulesConfigurator } from '@equinor/fusion-framework-module';
  * import { createModuleProvider } from '@equinor/fusion-framework-react-module';
  *
- * export default createModuleProvider(
- *   (config) => {
- *     config.auth.configureDefault({
- *       tenantId: 'MY_TENANT_ID',
- *       clientId: 'MY_CLIENT_ID',
- *       redirectUri: '/authentication/login-callback',
- *     });
- *     config.http.configureClient('foo', {
- *       baseUri: 'https://foo.bar',
- *       defaultScopes: ['FOO_CLIENT_ID/.default'],
- *     });
- *   },
- *  [http, msal]
- *);
+ * const configurator = new ModulesConfigurator([http, msal]);
+ * configurator.onConfigured((config) => {
+ *   config.auth.configureDefault({
+ *     tenantId: 'MY_TENANT_ID',
+ *     clientId: 'MY_CLIENT_ID',
+ *     redirectUri: '/authentication/login-callback',
+ *   });
+ *   config.http.configureClient('foo', {
+ *     baseUri: 'https://foo.bar',
+ *     defaultScopes: ['FOO_CLIENT_ID/.default'],
+ *   });
+ * });
+ *
+ * export default createModuleProvider(configurator);
  * ```
  * @param configurator configurator for the modules that should be initialized
  * @param ref optional parent module instance

--- a/packages/react/modules/module/src/ModuleProvider.tsx
+++ b/packages/react/modules/module/src/ModuleProvider.tsx
@@ -21,8 +21,7 @@ type ModuleProviderCreator = <
   // biome-ignore lint/suspicious/noExplicitAny: Default type parameter for module instance reference
   TRef extends ModulesInstanceType<[AnyModule]> = any,
 >(
-  configurator: ModulesConfigurator<TModules>,
-  modules: TModules,
+  configurator: ModulesConfigurator<TModules, TRef>,
   ref?: TRef,
 ) => Promise<LazyExoticComponent<FunctionComponent>>;
 
@@ -52,8 +51,7 @@ type ModuleProviderCreator = <
  *  [http, msal]
  *);
  * ```
- * @param configurator callback for configuring provided modules
- * @param modules modules which should be initiated
+ * @param configurator configurator for the modules that should be initialized
  * @param ref optional parent module instance
  * @returns Suspensive `ModuleProvider`
  */
@@ -62,7 +60,7 @@ export const createModuleProvider: ModuleProviderCreator = async <
   // biome-ignore lint/suspicious/noExplicitAny: Default type parameter for module instance reference
   TRef extends ModulesInstanceType<[AnyModule]> = any,
 >(
-  configurator: ModulesConfigurator<TModules>,
+  configurator: ModulesConfigurator<TModules, TRef>,
   ref?: TRef,
 ): Promise<LazyExoticComponent<FunctionComponent>> => {
   const Component = lazy(async () => {


### PR DESCRIPTION
**Why is this change needed?**

Fusion applications need a first-class plugin phase for application-level side effects that depend on initialized modules. This supports work such as event listeners, telemetry bridges, and runtime integrations that should connect after module initialization but before application render.

**What is the current behavior?**

`ModulesConfigurator` exposes configure, initialize, post-initialize, and dispose phases. Consumers can use `onInitialized`, but there is no dedicated plugin registration API that captures teardown callbacks for dispose.

**What is the new behavior?**

`IModulesConfigurator` and `ModulesConfigurator` now expose `registerPlugin`. Registered plugins run after post-initialize hooks settle and before `initialize` resolves. Plugins receive the initialized modules instance and optional `ref`, and may return either a teardown function or a disposable object with `dispose()`.

Plugin registration failures are isolated so one failing plugin does not block the application from continuing. Plugin teardowns run during dispose before module providers are disposed, and teardown failures are isolated from other plugin and module cleanup.

**What is the intended behavior or invariant?**

The lifecycle order is configure -> initialize -> post-initialize -> plugin registration -> dispose. Plugin callbacks must see the same modules instance shape returned to the application, including `dispose`. Plugin teardown must run at most once per initialized instance and before module dispose so side effects can unsubscribe while providers are still available.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No.
- Version bump: Minor for `@equinor/fusion-framework-module` through the included changeset.
- Consumer impact: Consumers can use `registerPlugin` for application-level side effects after modules are ready.
- Downstream impact: Packages typed against `IModulesConfigurator` get the new method through the shared interface.

**Review guidance:**

Focus on the lifecycle ordering, failure isolation, and teardown semantics. In particular, verify that plugins run after `onInitialized`, that both teardown function and `{ dispose() }` return values are supported, and that dispose runs plugin teardown before module disposal.

**Additional context**

Package README and broader documentation updates are intentionally deferred because PR 4738 owns the documentation surface. This PR keeps the implementation, TSDoc, tests, and changeset only.

Targeted validation run locally:

- `pnpm --filter @equinor/fusion-framework-module test -- --run`
- `pnpm --filter @equinor/fusion-framework-module build`

Full workspace validation was not rerun after the focused change.

**Related issues**

Closes: https://github.com/equinor/fusion-core-tasks/issues/1259

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated with targeted package test/build
  - No new diagnostics were reported for touched files
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
