### PR TITLE
fix(module): address configurator review feedback

### DIFF
--- a/.changeset/fusion-framework-module_refactor-configurator-phases.md
+++ b/.changeset/fusion-framework-module_refactor-configurator-phases.md
@@ -11,6 +11,6 @@ Internal: split `ModulesConfigurator` monolith into explicit lifecycle phase mod
 - `post-initialize` — `postInitialize` hooks and `onInitialized` callbacks
 - `dispose` — ordered teardown with failure isolation
 
-All public exports (`IModulesConfigurator`, `IModuleConfigurator`, `ModulesConfigurator`, `addConfig`, `configure`, `initialize`, `dispose`, `onConfigured`, `onInitialized`, `event$`) are unchanged and re-exported from the same entry points. No consumer-facing behaviour is altered.
+All configurator symbols remain available from the package root and are also exposed through the `@equinor/fusion-framework-module/configurator` secondary entrypoint. No consumer-facing behaviour is altered.
 
-Prerequisite for the plugin registration phase (equinor/fusion-core-tasks#1257).
+Prerequisite for the plugin registration phase (equinor/fusion-core-tasks#1256).

--- a/packages/modules/module/package.json
+++ b/packages/modules/module/package.json
@@ -13,6 +13,10 @@
     "./provider": {
       "import": "./dist/esm/lib/provider/index.js",
       "types": "./dist/types/lib/provider/index.d.ts"
+    },
+    "./configurator": {
+      "import": "./dist/esm/lib/configurator/index.js",
+      "types": "./dist/types/lib/configurator/index.d.ts"
     }
   },
   "typesVersions": {
@@ -22,6 +26,9 @@
       ],
       "provider": [
         "dist/types/lib/provider/index.d.ts"
+      ],
+      "configurator": [
+        "dist/types/lib/configurator/index.d.ts"
       ]
     }
   },

--- a/packages/modules/module/src/lib/configurator/IModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/IModulesConfigurator.ts
@@ -95,7 +95,7 @@ export interface IModulesConfigurator<
    * @template T - Additional modules to include in the instance type.
    */
   onInitialized<T extends Array<AnyModule> | unknown>(
-    cb: (instance: ModulesInstanceType<CombinedModules<T, TModules>>) => void,
+    cb: (instance: ModulesInstanceType<CombinedModules<T, TModules>>) => void | Promise<void>,
   ): void;
 
   /**

--- a/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
+++ b/packages/modules/module/src/lib/configurator/ModulesConfigurator.ts
@@ -122,7 +122,7 @@ export class ModulesConfigurator<
    * internal dispatch; concrete instance types are known at registration but not stored.
    * @protected
    */
-  protected _afterInit: Array<(instance: any) => void> = [];
+  protected _afterInit: Array<(instance: any) => void | Promise<void>> = [];
 
   /**
    * Set of all registered module descriptors.
@@ -231,7 +231,7 @@ export class ModulesConfigurator<
    * @template T - Additional modules to include in the instance type.
    */
   public onInitialized<T>(
-    cb: (instance: ModulesInstanceType<CombinedModules<T, TModules>>) => void,
+    cb: (instance: ModulesInstanceType<CombinedModules<T, TModules>>) => void | Promise<void>,
   ): void {
     this._afterInit.push(cb);
     this._registerEvent({

--- a/packages/modules/module/src/lib/configurator/index.ts
+++ b/packages/modules/module/src/lib/configurator/index.ts
@@ -1,8 +1,9 @@
 /**
  * Module configurator — public API re-exports.
  *
- * Consumers should import from `@equinor/fusion-framework-module` (or its
- * `configurator.js` path) rather than from this internal directory directly.
+ * Consumers should import from `@equinor/fusion-framework-module` or the
+ * `@equinor/fusion-framework-module/configurator` secondary entrypoint rather
+ * than from this internal directory directly.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
**Why is this change needed?**

This addresses the latest review feedback on the configurator refactor PR and makes the new configurator barrel available through a supported package secondary entrypoint.

**What is the current behavior?**

The configurator barrel exists in source and is re-exported from the package root, but the package manifest does not expose a dedicated `@equinor/fusion-framework-module/configurator` subpath. The post-initialize callback storage type also does not reflect that async callbacks are awaited by the post-initialize phase.

**What is the new behavior?**

`@equinor/fusion-framework-module/configurator` is exported with matching runtime and type entries. `onInitialized` and internal post-initialize callback storage now accept `void | Promise<void>`, matching the supported async callback behavior. The changeset now references the plugin registration prerequisite issue correctly.

**What is the intended behavior or invariant?**

Configurator symbols remain available from the package root while the new secondary entrypoint provides an explicit public import path for configurator-specific usage. Async post-initialize callbacks remain supported and are still isolated by the post-initialize phase.

**Does this PR introduce a breaking change?**

No. This adds a secondary export and widens callback return typing without removing existing root exports.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch, covered by the existing module changeset
- Consumer impact: Consumers may import configurator APIs from `@equinor/fusion-framework-module/configurator`
- Downstream impact: Limited to `@equinor/fusion-framework-module`

**Review guidance:**

Focus on whether the secondary export path matches the package output layout and whether the async callback type now matches the post-initialize implementation contract.

**Additional context**

Targeted validation was run under Node `v24.15.0` because the system Node `v25.8.1` does not satisfy dependency engine constraints.

**Related issues**

ref: equinor/fusion-core-tasks#1256
ref: equinor/fusion-framework#4737

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated with `pnpm --filter @equinor/fusion-framework-module test` and `pnpm --filter @equinor/fusion-framework-module build`
  - No new TypeScript diagnostics were reported for touched files
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
