### PR TITLE
feat(observable): refactor useObservableState with useSyncExternalStore

### DIFF
--- a/.changeset/fusion-observable_use-sync-external-store.md
+++ b/.changeset/fusion-observable_use-sync-external-store.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Internal: refactor `useObservableState` to use React `useSyncExternalStore` while preserving the existing API and behavior for value, error, completion, and teardown handling.
+
+Closes: https://github.com/equinor/fusion-framework/issues/3819

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -1,6 +1,5 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import type { Observable, StatefulObservable } from '../types';
-import { useObservableLayoutSubscription } from './useObservableSubscription';
 
 /**
  * Options for {@link useObservableState}.
@@ -28,6 +27,125 @@ export type ObservableStateReturnType<TType, TError = unknown> = {
   /** Whether the observable has completed. */
   complete: boolean;
 };
+
+/**
+ * Internal snapshot model used by `useSyncExternalStore`.
+ *
+ * @template TType - Observable value type.
+ * @template TError - Observable error type.
+ */
+type ObservableStateSnapshot<TType, TError> = ObservableStateReturnType<TType | undefined, TError>;
+
+/**
+ * Internal store contract consumed by `useSyncExternalStore`.
+ *
+ * @template TType - Observable value type.
+ * @template TError - Observable error type.
+ */
+type ObservableStateStore<TType, TError> = {
+  /** Returns the current client snapshot. */
+  getSnapshot: () => ObservableStateSnapshot<TType, TError>;
+  /** Returns the current server snapshot. */
+  getServerSnapshot: () => ObservableStateSnapshot<TType, TError>;
+  /** Subscribes to store updates and returns an unsubscribe function. */
+  subscribe: (onStoreChange: () => void) => () => void;
+};
+
+/**
+ * Type guard for observables exposing a synchronous `value` property.
+ *
+ * @template TType - Observable value type.
+ * @param subject - Observable candidate.
+ * @returns `true` when the observable exposes a `value` field.
+ */
+function hasStatefulValue<TType>(
+  subject: Observable<TType> | StatefulObservable<TType>,
+): subject is StatefulObservable<TType> {
+  return 'value' in (subject as object);
+}
+
+/**
+ * Resolves the initial value for an observable snapshot.
+ *
+ * @template TType - Observable value type.
+ * @param subject - Observable source.
+ * @param initial - Optional initial value supplied by the caller.
+ * @returns A resolved initial value, or `undefined`.
+ */
+function resolveInitialValue<TType>(
+  subject: Observable<TType> | StatefulObservable<TType>,
+  initial: TType | undefined,
+): TType | undefined {
+  return (
+    /** provided initial value */
+    initial ??
+    /** use subject current value if supported */
+    (hasStatefulValue(subject) ? subject.value : undefined) ??
+    /** nothing to resolve */
+    undefined
+  );
+}
+
+/**
+ * Creates a `useSyncExternalStore` adapter for observable state.
+ *
+ * @template TType - Observable value type.
+ * @template TError - Observable error type.
+ * @param subject - Observable source.
+ * @param options - Hook options.
+ * @returns Store methods used by `useSyncExternalStore`.
+ */
+function createObservableStateStore<TType, TError = unknown>(
+  subject: Observable<TType> | StatefulObservable<TType>,
+  initial?: TType,
+  teardown?: VoidFunction,
+): ObservableStateStore<TType, TError> {
+  let snapshot: ObservableStateSnapshot<TType, TError> = {
+    value: resolveInitialValue(subject, initial),
+    error: null,
+    complete: false,
+  };
+
+  const listeners = new Set<() => void>();
+
+  const notify = (): void => {
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const getSnapshot = (): ObservableStateSnapshot<TType, TError> => snapshot;
+
+  return {
+    getSnapshot,
+    getServerSnapshot: getSnapshot,
+    subscribe: (onStoreChange: () => void): (() => void) => {
+      listeners.add(onStoreChange);
+
+      const subscription = subject.subscribe({
+        next: (value) => {
+          snapshot = { ...snapshot, value };
+          notify();
+        },
+        error: (error) => {
+          snapshot = { ...snapshot, error: error as TError };
+          notify();
+        },
+        complete: () => {
+          snapshot = { ...snapshot, complete: true };
+          notify();
+        },
+      });
+
+      subscription.add(teardown);
+
+      return (): void => {
+        listeners.delete(onStoreChange);
+        subscription.unsubscribe();
+      };
+    },
+  };
+}
 
 /**
  * use state of observable
@@ -81,49 +199,18 @@ export function useObservableState<S, E = unknown>(
   subject: Observable<S> | StatefulObservable<S>,
   opt?: ObservableStateOptions<S>,
 ): ObservableStateReturnType<S | undefined, E> {
-  const resolveInitial = useCallback(
-    () =>
-      /** provided initial value */
-      opt?.initial ??
-      /** use subject current value if supported */
-      (subject as StatefulObservable<S>).value ??
-      /** nothing to resolve */
-      undefined,
-    [subject, opt?.initial],
+  const store = useMemo(
+    () => createObservableStateStore<S, E>(subject, opt?.initial, opt?.teardown),
+    [subject, opt?.initial, opt?.teardown],
   );
 
-  const initialValue = useRef(resolveInitial());
-
-  const [next, setNext] = useState<S | undefined>(initialValue.current);
-  const [error, setError] = useState<E | null>(null);
-  const [complete, setComplete] = useState<boolean>(false);
-
-  useLayoutEffect(() => {
-    initialValue.current = resolveInitial();
-  }, [resolveInitial]);
-
-  /**
-   * when subject change, reset state
-   */
-  useLayoutEffect(() => {
-    subject;
-    setError(null);
-    setComplete(false);
-    setNext(initialValue.current);
-  }, [subject]);
-
-  const subscriber = useMemo(
-    () => ({
-      next: setNext,
-      error: setError,
-      complete: () => setComplete(true),
-    }),
-    [],
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
   );
 
-  useObservableLayoutSubscription(subject, subscriber, opt?.teardown);
-
-  return { value: next, error, complete };
+  return snapshot;
 }
 
 export default useObservableState;

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -92,7 +92,8 @@ function resolveInitialValue<TType>(
  * @template TType - Observable value type.
  * @template TError - Observable error type.
  * @param subject - Observable source.
- * @param options - Hook options.
+ * @param initial - Optional initial value supplied by the caller.
+ * @param teardown - Optional teardown function added to the subscription.
  * @returns Store methods used by `useSyncExternalStore`.
  */
 function createObservableStateStore<TType, TError = unknown>(
@@ -199,9 +200,10 @@ export function useObservableState<S, E = unknown>(
   subject: Observable<S> | StatefulObservable<S>,
   opt?: ObservableStateOptions<S>,
 ): ObservableStateReturnType<S | undefined, E> {
+  const { initial, teardown } = opt ?? {};
   const store = useMemo(
-    () => createObservableStateStore<S, E>(subject, opt?.initial, opt?.teardown),
-    [subject, opt?.initial, opt?.teardown],
+    () => createObservableStateStore<S, E>(subject, initial, teardown),
+    [subject, initial, teardown],
   );
 
   const snapshot = useSyncExternalStore(

--- a/packages/utils/observable/tests/react/useObservableState.test.ts
+++ b/packages/utils/observable/tests/react/useObservableState.test.ts
@@ -1,36 +1,91 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { BehaviorSubject, Subject } from 'rxjs';
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { useObservableState } from '../../src/react';
 
 describe('useObservableState', () => {
-  it('should sync state with an Observable', async () => {
-    const subject = new Subject();
+  it('should sync state with an Observable', () => {
+    const subject = new Subject<number>();
     const { result } = renderHook(() => useObservableState(subject));
 
-    expect(result.current.value).toBeUndefined;
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
 
-    await waitFor(() => {
+    act(() => {
       subject.next(1);
     });
 
     expect(result.current.value).toBe(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
   });
 
-  it('should sync state with an Stateful Observable', async () => {
+  it('should sync state with a Stateful Observable', () => {
     const subject = new BehaviorSubject(0);
     const { result } = renderHook(() => useObservableState(subject));
 
-    expect(result.current.value).toBeUndefined;
     expect(result.current.value).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
 
-    await waitFor(() => {
+    act(() => {
       subject.next(1);
     });
 
     expect(result.current.value).toBe(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
+  });
+
+  it('should use provided initial value for a non-stateful observable', () => {
+    const subject = new Subject<number>();
+    const { result } = renderHook(() =>
+      useObservableState(subject, {
+        initial: 42,
+      }),
+    );
+
+    expect(result.current.value).toBe(42);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
+  });
+
+  it('should expose error state when observable errors', () => {
+    const subject = new Subject<number>();
+    const { result } = renderHook(() => useObservableState(subject));
+    const error = new Error('observable failed');
+
+    act(() => {
+      subject.error(error);
+    });
+
+    expect(result.current.error).toBe(error);
+    expect(result.current.complete).toBe(false);
+  });
+
+  it('should expose completion state when observable completes', () => {
+    const subject = new Subject<number>();
+    const { result } = renderHook(() => useObservableState(subject));
+
+    act(() => {
+      subject.complete();
+    });
+
+    expect(result.current.complete).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should invoke teardown when unsubscribing', () => {
+    const subject = new Subject<number>();
+    const teardown = vi.fn();
+    const { unmount } = renderHook(() => useObservableState(subject, { teardown }));
+
+    unmount();
+
+    expect(teardown).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/utils/observable/tests/react/useObservableState.test.ts
+++ b/packages/utils/observable/tests/react/useObservableState.test.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { act, renderHook } from '@testing-library/react';
 
 import { useObservableState } from '../../src/react';
+import type { StatefulObservable } from '../../src/types';
 
 describe('useObservableState', () => {
   it('should sync state with an Observable', () => {
@@ -39,6 +40,29 @@ describe('useObservableState', () => {
     expect(result.current.value).toBe(1);
     expect(result.current.error).toBeNull();
     expect(result.current.complete).toBe(false);
+  });
+
+  it('should prioritize explicit initial value over stateful observable value', () => {
+    const subject: Subject<number> & StatefulObservable<number> = Object.assign(
+      new Subject<number>(),
+      { value: 0 },
+    );
+
+    const { result } = renderHook(() =>
+      useObservableState(subject, {
+        initial: 42,
+      }),
+    );
+
+    expect(result.current.value).toBe(42);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
+
+    act(() => {
+      subject.next(1);
+    });
+
+    expect(result.current.value).toBe(1);
   });
 
   it('should use provided initial value for a non-stateful observable', () => {


### PR DESCRIPTION
**Why is this change needed?**
`useObservableState` used manual React state/effect subscription logic. React 19 provides `useSyncExternalStore` for external subscription sources and concurrent-safe updates, so this hook should align with that model.

**What is the current behavior?**
The hook tracked `value`, `error`, and `complete` via `useState` and `useLayoutEffect` plus a custom subscription lifecycle.

**What is the new behavior?**
The hook now uses a `useSyncExternalStore` adapter around observable subscriptions while preserving the existing hook API and output shape. Tests were updated to verify compatibility for:
- Observable and StatefulObservable value sync
- explicit initial values
- error and completion state propagation
- teardown callback invocation on unsubscribe

**What is the intended behavior or invariant?**
`useObservableState` must keep the same consumer contract: stable API surface, correct initial value resolution (`initial` option first, then stateful `value`), and synchronized `value`/`error`/`complete` updates from the observable stream.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`@equinor/fusion-observable`)
- Consumer impact: No API changes; internal implementation aligned with React 19 external store pattern
- Downstream impact: Consumers of `@equinor/fusion-observable/react` keep current usage, but gain the updated subscription model

**Review guidance:**
Focus review on [packages/utils/observable/src/react/useObservableState.ts](packages/utils/observable/src/react/useObservableState.ts) to validate the `useSyncExternalStore` store adapter semantics and on [packages/utils/observable/tests/react/useObservableState.test.ts](packages/utils/observable/tests/react/useObservableState.test.ts) for backward-compatibility coverage.

**Additional context**
Added a changeset for `@equinor/fusion-observable`:
- [\.changeset/fusion-observable_use-sync-external-store.md](.changeset/fusion-observable_use-sync-external-store.md)

Validation run before PR:
- `pnpm test`
- `pnpm build`
- `pnpm -w check`

**Related issues**
closes: #3819

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated: `packages/utils/observable/src/react/useObservableState.ts`, `packages/utils/observable/tests/react/useObservableState.test.ts`, `.changeset/fusion-observable_use-sync-external-store.md`
  - No new linting warnings in changed files
  - Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
