### PR TITLE
Fix/navigation/navigation router issues

### DIFF
--- a/.changeset/fusion-framework-module-navigation_fix-basename-trailing-slash.md
+++ b/.changeset/fusion-framework-module-navigation_fix-basename-trailing-slash.md
@@ -2,9 +2,11 @@
 "@equinor/fusion-framework-module-navigation": patch
 ---
 
-Fix blank page caused by trailing slash in app basename.
+Fix blank page caused by basename slash mismatch in app navigation.
 
 `NavigationProvider` now normalizes the basename on construction by stripping trailing slashes. React Router performs a strict `startsWith` check against the basename, so a basename of `/apps/my-app/` would never match the URL `/apps/my-app` and the router would render nothing.
+
+Slash-only basenames (for example `/`) are preserved when normalization would otherwise collapse to an empty string, so root-mounted configurations keep their previous behavior.
 
 The `AppLoader` in the dev portal extracts the basename with a regex that captures an optional trailing slash from the current URL, which could produce basenames like `/apps/app-admin/`. This fix ensures such values are normalized regardless of how the basename is supplied.
 

--- a/.changeset/fusion-framework-module-navigation_fix-basename-trailing-slash.md
+++ b/.changeset/fusion-framework-module-navigation_fix-basename-trailing-slash.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-module-navigation": patch
+---
+
+Fix blank page caused by trailing slash in app basename.
+
+`NavigationProvider` now normalizes the basename on construction by stripping trailing slashes. React Router performs a strict `startsWith` check against the basename, so a basename of `/apps/my-app/` would never match the URL `/apps/my-app` and the router would render nothing.
+
+The `AppLoader` in the dev portal extracts the basename with a regex that captures an optional trailing slash from the current URL, which could produce basenames like `/apps/app-admin/`. This fix ensures such values are normalized regardless of how the basename is supplied.
+
+Fixes: https://github.com/equinor/fusion/issues/848

--- a/.changeset/fusion-framework-react-router_fix-strictmode-router-init.md
+++ b/.changeset/fusion-framework-react-router_fix-strictmode-router-init.md
@@ -8,4 +8,6 @@ Fix blank page and broken back/forward navigation under React StrictMode.
 
 The router is now initialized and disposed inside a `useEffect`, matching React's expected side-effect lifecycle. A `loader` prop (already accepted by `RouterProps`) is rendered as a fallback during the brief initialization window.
 
+Readiness is tied to the active router instance identity so a newly recreated router is never rendered before its own initialization effect has completed.
+
 Fixes: https://github.com/equinor/fusion/issues/848

--- a/.changeset/fusion-framework-react-router_fix-strictmode-router-init.md
+++ b/.changeset/fusion-framework-react-router_fix-strictmode-router-init.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Fix blank page and broken back/forward navigation under React StrictMode.
+
+`router.initialize()` was previously called during render (inside `useMemo`), which creates history listener side effects before React's commit phase. In StrictMode, React intentionally mounts, unmounts, and remounts components in development, which left stale initialized router instances with dangling history subscriptions. This caused `navigation.navigate()` to update the URL without the app router reacting, and browser back/forward to produce a blank page.
+
+The router is now initialized and disposed inside a `useEffect`, matching React's expected side-effect lifecycle. A `loader` prop (already accepted by `RouterProps`) is rendered as a fallback during the brief initialization window.
+
+Fixes: https://github.com/equinor/fusion/issues/848

--- a/packages/modules/navigation/src/NavigationProvider.ts
+++ b/packages/modules/navigation/src/NavigationProvider.ts
@@ -133,7 +133,9 @@ export class NavigationProvider
     // the current URL to start with the exact basename string, so a basename
     // of "/apps/my-app/" would fail to match the URL "/apps/my-app" and
     // render nothing (blank page).
-    this.#basename = basename ? normalizePathname(basename) : basename;
+    // Preserve slash-only basenames (e.g. "/") by falling back to the
+    // original input when normalization collapses to an empty string.
+    this.#basename = basename ? normalizePathname(basename) || basename : basename;
     this.#event = eventProvider;
     this.#telemetry = telemetry;
 

--- a/packages/modules/navigation/src/NavigationProvider.ts
+++ b/packages/modules/navigation/src/NavigationProvider.ts
@@ -129,7 +129,11 @@ export class NavigationProvider
     // Extract configuration values
     const { basename, history, telemetry, eventProvider } = args.config;
 
-    this.#basename = basename;
+    // Normalize the basename to strip trailing slashes. React Router requires
+    // the current URL to start with the exact basename string, so a basename
+    // of "/apps/my-app/" would fail to match the URL "/apps/my-app" and
+    // render nothing (blank page).
+    this.#basename = basename ? normalizePathname(basename) : basename;
     this.#event = eventProvider;
     this.#telemetry = telemetry;
 

--- a/packages/modules/navigation/src/__tests__/NavigationProvider.test.ts
+++ b/packages/modules/navigation/src/__tests__/NavigationProvider.test.ts
@@ -57,4 +57,15 @@ describe('NavigationProvider', () => {
     provider.dispose();
     expect(disposeSpy).toHaveBeenCalled();
   });
+
+  it('should preserve root basename when set to slash', () => {
+    const providerWithRootBasename = new NavigationProvider({
+      version: '1.0.0',
+      config: { history, basename: '/' },
+    });
+
+    expect(providerWithRootBasename.basename).toBe('/');
+
+    providerWithRootBasename.dispose();
+  });
 });

--- a/packages/react/router/src/Router.tsx
+++ b/packages/react/router/src/Router.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { RouterProvider } from 'react-router/dom';
 import {
   type Modules,
@@ -84,7 +84,7 @@ function normalizeRoutes(
  * }
  * ```
  */
-export function Router({ routes, context }: RouterProps) {
+export function Router({ routes, context, loader }: RouterProps) {
   const modules = useModules();
 
   const fusionRouterContext: FusionRouterContext = useMemo(() => {
@@ -104,7 +104,7 @@ export function Router({ routes, context }: RouterProps) {
       navigation: NavigationModule;
     }>;
 
-    const routerInstance = UNSAFE_createRouter({
+    return UNSAFE_createRouter({
       routes: normalizeRoutes(routes),
       history: navigation.history,
       basename: navigation.basename,
@@ -165,14 +165,27 @@ export function Router({ routes, context }: RouterProps) {
         return mapped;
       },
     });
-    return routerInstance.initialize();
     // Intentionally excluding fusionRouterContext — it is read via ref so
     // context updates do not destroy and recreate the entire router.
   }, [routes, modules]);
 
-  // Dispose previous router instance when the router is recreated or unmounted
-  // to clean up history listeners and pending navigations.
-  useEffect(() => router.dispose.bind(router), [router]);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    // Initialize and dispose the router inside an effect to avoid side effects
+    // during render. This prevents leaked subscriptions in React StrictMode.
+    setIsInitialized(false);
+    router.initialize();
+    setIsInitialized(true);
+
+    // Dispose previous router instance when the router is recreated or unmounted
+    // to clean up history listeners and pending navigations.
+    return router.dispose.bind(router);
+  }, [router]);
+
+  if (!isInitialized) {
+    return loader ?? null;
+  }
 
   return (
     <FusionRouterContextProvider value={fusionRouterContext}>

--- a/packages/react/router/src/Router.tsx
+++ b/packages/react/router/src/Router.tsx
@@ -169,21 +169,22 @@ export function Router({ routes, context, loader }: RouterProps) {
     // context updates do not destroy and recreate the entire router.
   }, [routes, modules]);
 
-  const [isInitialized, setIsInitialized] = useState(false);
+  const [initializedRouter, setInitializedRouter] = useState<ReturnType<
+    typeof UNSAFE_createRouter
+  > | null>(null);
 
   useEffect(() => {
     // Initialize and dispose the router inside an effect to avoid side effects
     // during render. This prevents leaked subscriptions in React StrictMode.
-    setIsInitialized(false);
     router.initialize();
-    setIsInitialized(true);
+    setInitializedRouter(router);
 
     // Dispose previous router instance when the router is recreated or unmounted
     // to clean up history listeners and pending navigations.
     return router.dispose.bind(router);
   }, [router]);
 
-  if (!isInitialized) {
+  if (initializedRouter !== router) {
     return loader ?? null;
   }
 


### PR DESCRIPTION
**Why is this change needed?**
We observed intermittent blank pages during portal navigation when an app is open, especially on browser back/forward and cross-app navigation. This was tracked in https://github.com/equinor/fusion/issues/848 and reproduced with two contributing problems:
- Basename mismatch caused by trailing slash variance.
- Router lifecycle side effects running during render under React StrictMode.

**What is the current behavior?**
1. Basename mismatch:
- If basename is stored as /apps/app-admin/ but URL is /apps/app-admin, React Router cannot match and renders nothing.
- Console warning: Router basename cannot match URL because it does not start with basename.

2. StrictMode router lifecycle issue:
- Router initialization happened during render.
- In StrictMode dev lifecycle (mount/unmount/remount), this can leave stale router/history subscriptions.
- Result: URL changes but app router may not react reliably, leading to blank page behavior on navigation/back-forward.

**What is the new behavior?**
1. Navigation basename normalization:
- NavigationProvider now normalizes basename on construction (trailing slash removed), so /apps/app-admin/ and /apps/app-admin are treated consistently.
- Slash-only basenames (for example /) are preserved when normalization would otherwise collapse to an empty string.

2. StrictMode-safe router lifecycle:
- Router instance creation remains memoized, but initialize/dispose are now managed in useEffect instead of render.
- This aligns side effects with React lifecycle and prevents leaked subscriptions in StrictMode.
- Readiness is tied to the current router instance identity, so a recreated router is never rendered before its own initialize effect completes.
- Router renders provided loader fallback (or null) until initialization is complete.

**What is the intended behavior or invariant?**
- Basename comparison must be path-normalized and trailing-slash-insensitive for equivalent paths.
- Slash-only/root basenames must retain root semantics.
- Router initialization and disposal are side effects and must only happen in effect lifecycle, never during render.
- A router instance must not be rendered before that same instance has completed initialization.
- Back/forward and cross-app navigation must keep URL, portal navigation state, and app router state synchronized.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact:
  - More robust routing when URLs vary by trailing slash.
  - Improved stability in StrictMode navigation lifecycle.
- Downstream impact:
  - Affects package consumers of:
    - @equinor/fusion-framework-module-navigation
    - @equinor/fusion-framework-react-router

**Review guidance:**
Please focus review on:
- NavigationProvider basename normalization logic.
- Root basename preservation in normalization path.
- Router.tsx lifecycle change from render-time initialize to effect-time initialize/dispose.
- Router instance readiness gating (`initializedRouter === router`).
- Loader fallback behavior before router initialization.

Suggested manual verification:
1. Open app route with and without trailing slash.
2. Navigate across portal and app routes.
3. Use browser back/forward repeatedly with app open.
4. Repeat under React StrictMode.

**Additional context**
This PR includes two patch changesets:
- @equinor/fusion-framework-module-navigation
- @equinor/fusion-framework-react-router

Validation performed:
- Built and tested navigation module successfully.
- Built react-router package successfully.
- Added regression test for root basename preservation (`basename: '/'`) in NavigationProvider tests.
- Test result: 5 test files passed, 42 tests passed (navigation module).

**Related issues**
ref: https://github.com/equinor/fusion/issues/848

### Checklist

- [ ] Confirm completion of the self-review checklist
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [ ] Confirm adherence to code of conduct
