### PR TITLE
feat(react-router): add /interop entry point and surface routing from react-app

### DIFF
--- a/.changeset/fusion-framework-docs_react-router-docs.md
+++ b/.changeset/fusion-framework-docs_react-router-docs.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Add getting started, migration, and interop documentation for `@equinor/fusion-framework-react-router`,
+and a routing guide for `@equinor/fusion-framework-react-app`.
+
+- **Getting started** — 7-step setup walkthrough covering navigation config, route DSL, `<Router>` mount,
+  page loaders, hooks, custom context, and the Vite plugin. Framed for all Fusion consumers (apps, portals, widgets).
+- **Migration guide** — step-by-step instructions for moving from a plain `react-router` setup to the Fusion router.
+- **Interop entry point** — documents `./interop` with code examples for `MemoryRouter`, `createMemoryRouter + RouterProvider`,
+  and `Routes + Route`; explains the dual-bundling risk that motivates the interop bridge.
+- **Routing (react-app)** — documents the `./routing` entry point on `@equinor/fusion-framework-react-app`
+  with installation, configuration, and usage examples.

--- a/.changeset/fusion-framework-react-app_add-routing-entry.md
+++ b/.changeset/fusion-framework-react-app_add-routing-entry.md
@@ -1,0 +1,26 @@
+---
+"@equinor/fusion-framework-react-app": minor
+---
+
+Add `./routing` entry point that re-exports the full public API of
+`@equinor/fusion-framework-react-router` and its route builder DSL.
+
+App, portal, and widget consumers can now import all routing primitives from a single package
+without adding `@equinor/fusion-framework-react-router` as a direct dependency.
+
+Requires `@equinor/fusion-framework-react-router` (optional peer dependency):
+
+```bash
+pnpm add @equinor/fusion-framework-react-router
+```
+
+**Usage:**
+
+```ts
+import { Router } from '@equinor/fusion-framework-react-app/routing';
+import { layout, index, route, prefix } from '@equinor/fusion-framework-react-app/routing';
+import { useNavigate, useParams, Link } from '@equinor/fusion-framework-react-app/routing';
+```
+
+All exports from `@equinor/fusion-framework-react-router` and its `/routes` DSL are available
+from this single entry point.

--- a/.changeset/fusion-framework-react-router_add-interop-entry.md
+++ b/.changeset/fusion-framework-react-router_add-interop-entry.md
@@ -1,0 +1,44 @@
+---
+"@equinor/fusion-framework-react-router": minor
+---
+
+Add `./interop` entry point with curated deprecated re-exports of `react-router` symbols.
+
+Teams that are mid-migration from `react-router` to `@equinor/fusion-framework-react-router`, or
+that need `MemoryRouter` for testing and widget scenarios, can now import these symbols without
+adding `react-router` as a direct dependency — which risks dual-bundling when the Fusion router is
+also present.
+
+**Exported symbols** (all marked `@deprecated` — interop only, will be removed in a future major):
+
+```ts
+import {
+  MemoryRouter,
+  RouterProvider,
+  createMemoryRouter,
+  Routes,
+  Route,
+} from '@equinor/fusion-framework-react-router/interop';
+```
+
+**Typical use cases:**
+
+```tsx
+// Testing with a memory router
+import { MemoryRouter } from '@equinor/fusion-framework-react-router/interop';
+
+render(
+  <MemoryRouter initialEntries={['/products/42']}>
+    <ProductPage />
+  </MemoryRouter>,
+);
+
+// Widget / SSR — no window available
+import { createMemoryRouter, RouterProvider } from '@equinor/fusion-framework-react-router/interop';
+
+const router = createMemoryRouter(routes, { initialEntries: ['/'] });
+root.render(<RouterProvider router={router} />);
+```
+
+These exports are a temporary bridge. Migrate to `@equinor/fusion-framework-react-router` fully
+and remove the `/interop` import once your team is ready.

--- a/packages/react/app/docs/routing.md
+++ b/packages/react/app/docs/routing.md
@@ -81,6 +81,6 @@ import { useNavigate, useParams, useLocation, Link } from '@equinor/fusion-frame
 
 ## See also
 
-- [Getting started](../../react/router/getting-started.md) — full setup walkthrough for the standalone router package
-- [Interop entry point](../../react/router/interop.md) — `MemoryRouter` and other react-router bridges for testing and mid-migration
-- [Migration guide](../../react/router/migration.md) — moving from a plain react-router setup
+- [Getting started](/modules/react/router/getting-started) — full setup walkthrough for the standalone router package
+- [Interop entry point](/modules/react/router/interop) — `MemoryRouter` and other react-router bridges for testing and mid-migration
+- [Migration guide](/modules/react/router/migration) — moving from a plain react-router setup

--- a/packages/react/app/docs/routing.md
+++ b/packages/react/app/docs/routing.md
@@ -1,0 +1,86 @@
+# Routing
+
+The `@equinor/fusion-framework-react-app/routing` entry point re-exports the full public API of
+`@equinor/fusion-framework-react-router` — including the `<Router>` component, the route builder
+DSL, all React Router hooks, and types — so you can import everything from a single package without
+adding `@equinor/fusion-framework-react-router` as a direct dependency.
+
+## Installation
+
+`@equinor/fusion-framework-react-router` is an **optional peer dependency**. Install it alongside the app package:
+
+```bash
+pnpm add @equinor/fusion-framework-react-router
+```
+
+## Usage
+
+```ts
+import { Router } from '@equinor/fusion-framework-react-app/routing';
+import { layout, index, route, prefix } from '@equinor/fusion-framework-react-app/routing';
+```
+
+Everything exported from `@equinor/fusion-framework-react-router` and its `/routes` DSL is
+available from this single entry point.
+
+## Enable navigation in your configurator
+
+The `<Router>` component reads `history` and `basename` from the Fusion navigation module.
+Enable it in your configurator before mounting:
+
+```ts
+import { enableNavigation } from '@equinor/fusion-framework-module-navigation';
+import type { IAppConfigurator, AppEnv, Fusion } from '@equinor/fusion-framework-react-app';
+
+export const configure = (
+  configurator: IAppConfigurator,
+  args: { fusion: Fusion; env: AppEnv },
+) => {
+  enableNavigation(configurator, {
+    configure: (config) => {
+      config.setBasename(args.env.basename);
+    },
+  });
+};
+```
+
+## Define routes
+
+```ts
+// src/routes.ts
+import { layout, index, route, prefix } from '@equinor/fusion-framework-react-app/routing';
+
+export default layout('./Layout.tsx', [
+  index('./pages/HomePage.tsx'),
+  prefix('products', [
+    index('./pages/ProductsPage.tsx'),
+    route(':id', './pages/ProductPage.tsx'),
+  ]),
+]);
+```
+
+## Mount the Router
+
+```tsx
+// src/Router.tsx
+import { Router } from '@equinor/fusion-framework-react-app/routing';
+import routes from './routes';
+
+export default function AppRouter() {
+  return <Router routes={routes} />;
+}
+```
+
+## Use routing hooks
+
+All React Router hooks are re-exported from the same entry point:
+
+```tsx
+import { useNavigate, useParams, useLocation, Link } from '@equinor/fusion-framework-react-app/routing';
+```
+
+## See also
+
+- [Getting started](../../react/router/getting-started.md) — full setup walkthrough for the standalone router package
+- [Interop entry point](../../react/router/interop.md) — `MemoryRouter` and other react-router bridges for testing and mid-migration
+- [Migration guide](../../react/router/migration.md) — moving from a plain react-router setup

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -60,6 +60,10 @@
     "./widget": {
       "types": "./dist/types/widget/index.d.ts",
       "import": "./dist/esm/widget/index.js"
+    },
+    "./routing": {
+      "types": "./dist/types/routing/index.d.ts",
+      "import": "./dist/esm/routing/index.js"
     }
   },
   "typesVersions": {
@@ -102,6 +106,9 @@
       ],
       "widget": [
         "dist/types/widget/index.d.ts"
+      ],
+      "routing": [
+        "dist/types/routing/index.d.ts"
       ]
     }
   },
@@ -139,6 +146,7 @@
     "@equinor/fusion-framework-module-msal": "workspace:*",
     "@equinor/fusion-framework-react-module-bookmark": "workspace:*",
     "@equinor/fusion-framework-react-module-context": "workspace:*",
+    "@equinor/fusion-framework-react-router": "workspace:*",
     "@equinor/fusion-observable": "workspace:*",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -151,6 +159,7 @@
   },
   "peerDependencies": {
     "@equinor/fusion-framework-module-msal": "workspace:^",
+    "@equinor/fusion-framework-react-router": "workspace:^",
     "@types/react": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
@@ -182,6 +191,9 @@
       "optional": true
     },
     "rxjs": {
+      "optional": true
+    },
+    "@equinor/fusion-framework-react-router": {
       "optional": true
     }
   }

--- a/packages/react/app/src/routing/index.ts
+++ b/packages/react/app/src/routing/index.ts
@@ -18,4 +18,16 @@
  * @packageDocumentation
  */
 export * from '@equinor/fusion-framework-react-router';
-export * from '@equinor/fusion-framework-react-router/routes';
+// Explicit re-exports from /routes so the DSL `Route` class takes precedence
+// over the deprecated react-router `Route` component from the main entry.
+export {
+  index,
+  IndexRoute,
+  route,
+  Route,
+  layout,
+  LayoutRoute,
+  prefix,
+  PrefixRoute,
+} from '@equinor/fusion-framework-react-router/routes';
+export type { RouteSchemaEntry } from '@equinor/fusion-framework-react-router/routes';

--- a/packages/react/app/src/routing/index.ts
+++ b/packages/react/app/src/routing/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Routing sub-path entry-point for `@equinor/fusion-framework-react-app`.
+ *
+ * Re-exports the full public API of `@equinor/fusion-framework-react-router`
+ * and its route builder DSL so consumers can import all routing primitives
+ * from a single entry point without adding a separate direct dependency.
+ *
+ * Requires `@equinor/fusion-framework-react-router` to be installed.
+ * It is declared as an optional peer dependency — install it only when
+ * you need routing in your app, portal, or widget.
+ *
+ * @example
+ * ```ts
+ * import { Router } from '@equinor/fusion-framework-react-app/routing';
+ * import { layout, index, route } from '@equinor/fusion-framework-react-app/routing';
+ * ```
+ *
+ * @packageDocumentation
+ */
+export * from '@equinor/fusion-framework-react-router';
+export * from '@equinor/fusion-framework-react-router/routes';

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -1,6 +1,6 @@
 # @equinor/fusion-framework-react-router
 
-Thin integration layer between [React Router v7](https://reactrouter.com/) and the Fusion Framework. It adds Fusion-specific behaviour — navigation module wiring, typed `fusion` context injection, a file-style route DSL, and manifest-ready route schemas — while keeping the full power of React Router.
+Integration layer between [React Router v7](https://reactrouter.com/) and the Fusion Framework. Provides automatic navigation module wiring, typed `fusion` context injection into loaders, actions, and components, a file-style route DSL, and manifest-ready route schemas.
 
 ## Features
 
@@ -17,13 +17,13 @@ Thin integration layer between [React Router v7](https://reactrouter.com/) and t
 pnpm add @equinor/fusion-framework-react-router
 ```
 
-### Prerequisites
+**Prerequisites**
 
 - React 18+ / React DOM 18+
 - `@equinor/fusion-framework-react-module`
 - `@equinor/fusion-framework-module-navigation` configured in your app
 
-## Usage
+## Quick start
 
 ### 1. Define page modules
 
@@ -41,7 +41,6 @@ export const handle = {
   route: {
     description: 'Product page',
     params: { id: 'Product identifier' },
-    search: { filter: 'Product type filter' },
   },
 } satisfies RouterHandle;
 
@@ -55,7 +54,7 @@ export default function ProductPage({ loaderData }: RouteComponentProps<{ name: 
 }
 ```
 
-### 2. Build the route tree with the DSL
+### 2. Build the route tree
 
 ```ts
 // src/pages/index.ts
@@ -84,8 +83,6 @@ export default function AppRouter() {
 
 ### Passing custom context
 
-Extend `RouterContext` via module augmentation, then pass the context to `<Router>`:
-
 ```ts
 // router-context.d.ts
 declare module '@equinor/fusion-framework-react-router' {
@@ -96,7 +93,6 @@ declare module '@equinor/fusion-framework-react-router' {
 ```
 
 ```tsx
-// src/Router.tsx
 import { Router } from '@equinor/fusion-framework-react-router';
 import { QueryClient } from '@tanstack/react-query';
 import { pages } from './pages';
@@ -116,17 +112,12 @@ import { toRouteSchema } from '@equinor/fusion-framework-react-router/schema';
 import { pages } from './pages';
 
 const schema = await toRouteSchema(pages);
-// => [['/', 'Home page'], ['products/:id', 'Product page', { params: { id: 'Product identifier' } }]]
 ```
 
 ### Vite plugin
 
-Enable the DSL transform so route definitions are rewritten to standard `RouteObject` code at build time:
-
 ```ts
 // vite.config.ts
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import { reactRouterPlugin } from '@equinor/fusion-framework-react-router/vite-plugin';
 
 export default defineConfig({
@@ -134,62 +125,20 @@ export default defineConfig({
 });
 ```
 
-## API Reference
+## Entry points
 
-### Components
-
-| Export | Description |
+| Entry point | Purpose |
 |---|---|
-| `Router` | Integrates React Router v7 with Fusion Framework. Accepts `routes`, optional `loader`, and optional `context`. |
+| `@equinor/fusion-framework-react-router` | Main — `Router`, hooks, types, and React Router re-exports |
+| `/routes` | Route DSL — `layout`, `index`, `route`, `prefix` |
+| `/schema` | Schema generation — `toRouteSchema` |
+| `/context` | Internal context — `routerContext`, `FusionRouterContextProvider`, `useRouterContext` |
+| `/vite-plugin` | Vite build plugin |
+| `/interop` | Interop re-exports for teams mid-migration — see [docs/interop.md](docs/interop.md) |
 
-### Hooks & Context
+## Documentation
 
-| Export | Description |
-|---|---|
-| `useRouterContext()` | Returns the current `FusionRouterContext` (`modules` + `context`). Throws if used outside `<Router>`. |
-| `routerContext` | React Router context key used internally to pass the Fusion context to loaders and actions. |
-| `FusionRouterContextProvider` | React context provider for `FusionRouterContext`. Used internally by `<Router>`. |
+- [Migration guide — from `react-router` to Fusion router](docs/migration.md)
+- [Interop entry point](docs/interop.md)
+- [End-to-end cookbook](../../../cookbooks/app-react-router/)
 
-### Route DSL (`/routes` entry point)
-
-| Export | Description |
-|---|---|
-| `layout(file, children)` | Layout route wrapping children with a shared component containing `<Outlet />`. |
-| `index(file, schema?)` | Index route rendered at the parent's path. |
-| `route(path, file, children?, schema?)` | Standard route with a URL path and optional children. |
-| `prefix(path, children)` | Path-only grouping — prepends a segment to children without rendering a component. |
-
-### Schema (`/schema` entry point)
-
-| Export | Description |
-|---|---|
-| `toRouteSchema(nodes)` | Converts a route tree (DSL nodes or legacy `RouteObject[]`) to a flat `RouteSchemaEntry[]`. |
-
-### Vite Plugin (`/vite-plugin` entry point)
-
-| Export | Description |
-|---|---|
-| `reactRouterPlugin(options?)` | Vite plugin that transforms DSL calls into React Router `RouteObject` code at build time. |
-
-### Key Types
-
-| Type | Description |
-|---|---|
-| `FusionRouterContext` | Object containing `modules` (Fusion modules instance) and `context` (custom context). |
-| `RouterContext` | Extensible interface for custom context (extend via module augmentation). |
-| `RouterHandle` | Handle interface with `route: RouterSchema` and extensible custom fields. |
-| `RouterSchema` | Schema with `description`, `params`, and `search` for a single route. |
-| `RouteComponentProps<TData, TActionData>` | Props received by route components: `loaderData`, `actionData`, `fusion`. |
-| `LoaderFunctionArgs<TParams>` | Arguments passed to `clientLoader` functions. |
-| `ActionFunctionArgs<TParams>` | Arguments passed to `action` functions. |
-| `ErrorElementProps<TError>` | Props received by error boundary components: `error`, `fusion`. |
-| `RouteNode` | Base interface for DSL route nodes. |
-| `RouteSchemaEntry` | Tuple format: `[path, description]` or `[path, description, { params?, search? }]`. |
-
-## Configuration
-
-The `<Router>` component reads `history` and `basename` from the Fusion navigation module. Ensure your app configures `@equinor/fusion-framework-module-navigation` before mounting the router.
-
-For the Vite plugin, pass `{ debug: true }` to `reactRouterPlugin()` to enable verbose transformation logging during development.
-
-For a complete end-to-end example, see the [`cookbooks/app-react-router`](../../../cookbooks/app-react-router/) cookbook.

--- a/packages/react/router/docs/getting-started.md
+++ b/packages/react/router/docs/getting-started.md
@@ -159,6 +159,6 @@ export default defineConfig({
 
 ## Next steps
 
-- [Migration guide](./migration.md) — moving from a plain `react-router` setup
-- [Interop entry point](./interop.md) — `MemoryRouter`, `createMemoryRouter`, and JSX-based routing for testing and mid-migration scenarios
+- [Migration guide](/modules/react/router/migration) — moving from a plain `react-router` setup
+- [Interop entry point](/modules/react/router/interop) — `MemoryRouter`, `createMemoryRouter`, and JSX-based routing for testing and mid-migration scenarios
 - [End-to-end cookbook](/cookbooks/react-app-router) — full working example

--- a/packages/react/router/docs/getting-started.md
+++ b/packages/react/router/docs/getting-started.md
@@ -1,11 +1,11 @@
 # Getting started with `@equinor/fusion-framework-react-router`
 
-This guide walks through setting up routing in a Fusion Framework React app from scratch.
+This guide walks through setting up routing in any Fusion Framework React consumer — apps, portals, widgets, or any other Fusion-enabled context.
 
 ## Prerequisites
 
-- A Fusion Framework React app bootstrapped with `@equinor/fusion-framework-react-app`
-- `@equinor/fusion-framework-module-navigation` available (bundled with the framework)
+- A Fusion Framework React consumer (app, portal, widget, etc.) with access to the Fusion module system
+- `@equinor/fusion-framework-module-navigation` enabled in your configurator (bundled with the framework)
 
 ## Installation
 
@@ -13,28 +13,36 @@ This guide walks through setting up routing in a Fusion Framework React app from
 pnpm add @equinor/fusion-framework-react-router
 ```
 
-## Step 1 — Enable navigation in your app config
+## Step 1 — Enable navigation in your configurator
 
-The router reads `history` and `basename` from the Fusion navigation module. Configure it in your app's `config.ts`:
+The router reads `history` and `basename` from the Fusion navigation module. Enable it in your configurator:
 
 ```ts
 // src/config.ts
 import { enableNavigation } from '@equinor/fusion-framework-module-navigation';
-import type { IAppConfigurator, AppEnv, Fusion } from '@equinor/fusion-framework-react-app';
+import type { IConfigurator } from '@equinor/fusion-framework';
 
-export const configure = (
-  configurator: IAppConfigurator,
-  args: { fusion: Fusion; env: AppEnv },
-) => {
+export const configure = (configurator: IConfigurator) => {
   enableNavigation(configurator, {
     configure: (config) => {
-      config.setBasename(args.env.basename);
+      // Set the basename to scope routing to a sub-path.
+      // For apps this is typically the app's assigned path segment;
+      // for portals it may be '/' or a portal-specific prefix.
+      config.setBasename('/');
     },
   });
 };
 
 export default configure;
 ```
+
+> **App consumers** can read `basename` from the app environment:
+> ```ts
+> import type { IAppConfigurator, AppEnv, Fusion } from '@equinor/fusion-framework-react-app';
+> export const configure = (configurator: IAppConfigurator, args: { fusion: Fusion; env: AppEnv }) => {
+>   enableNavigation(configurator, { configure: (c) => c.setBasename(args.env.basename) });
+> };
+> ```
 
 ## Step 2 — Define your routes
 

--- a/packages/react/router/docs/getting-started.md
+++ b/packages/react/router/docs/getting-started.md
@@ -1,0 +1,156 @@
+# Getting started with `@equinor/fusion-framework-react-router`
+
+This guide walks through setting up routing in a Fusion Framework React app from scratch.
+
+## Prerequisites
+
+- A Fusion Framework React app bootstrapped with `@equinor/fusion-framework-react-app`
+- `@equinor/fusion-framework-module-navigation` available (bundled with the framework)
+
+## Installation
+
+```bash
+pnpm add @equinor/fusion-framework-react-router
+```
+
+## Step 1 — Enable navigation in your app config
+
+The router reads `history` and `basename` from the Fusion navigation module. Configure it in your app's `config.ts`:
+
+```ts
+// src/config.ts
+import { enableNavigation } from '@equinor/fusion-framework-module-navigation';
+import type { IAppConfigurator, AppEnv, Fusion } from '@equinor/fusion-framework-react-app';
+
+export const configure = (
+  configurator: IAppConfigurator,
+  args: { fusion: Fusion; env: AppEnv },
+) => {
+  enableNavigation(configurator, {
+    configure: (config) => {
+      config.setBasename(args.env.basename);
+    },
+  });
+};
+
+export default configure;
+```
+
+## Step 2 — Define your routes
+
+Use the Fusion route DSL to build your route tree. Each entry points to a page module file resolved at build time by the Vite plugin.
+
+```ts
+// src/routes.ts
+import { layout, index, route, prefix } from '@equinor/fusion-framework-react-router/routes';
+
+export default layout('./Layout.tsx', [
+  index('./pages/HomePage.tsx'),
+  prefix('products', [
+    index('./pages/ProductsPage.tsx'),
+    route(':id', './pages/ProductPage.tsx'),
+  ]),
+]);
+```
+
+Alternatively, pass a plain `RouteObject[]` array if you prefer not to use the DSL:
+
+```ts
+import type { RouteObject } from '@equinor/fusion-framework-react-router';
+
+export const routes: RouteObject[] = [
+  { path: '/', Component: HomePage },
+  { path: '/products/:id', Component: ProductPage },
+];
+```
+
+## Step 3 — Mount the Router
+
+```tsx
+// src/Router.tsx
+import { Router } from '@equinor/fusion-framework-react-router';
+import routes from './routes';
+
+export default function AppRouter() {
+  return <Router routes={routes} />;
+}
+```
+
+`<Router>` wires up `history` and `basename` from the navigation module automatically. No manual `createBrowserRouter` or `RouterProvider` setup required.
+
+## Step 4 — Write page components
+
+Page components receive `loaderData`, `actionData`, and `fusion` as props:
+
+```tsx
+// src/pages/ProductPage.tsx
+import type { LoaderFunctionArgs, RouteComponentProps } from '@equinor/fusion-framework-react-router';
+
+export async function clientLoader({ params, fusion }: LoaderFunctionArgs<{ id: string }>) {
+  const client = fusion.modules.http.createHttpClient('products');
+  return client.json<{ name: string }>(`/products/${params.id}`);
+}
+
+export default function ProductPage({ loaderData }: RouteComponentProps<{ name: string }>) {
+  return <h1>{loaderData.name}</h1>;
+}
+```
+
+## Step 5 — Use navigation hooks
+
+All standard React Router hooks are re-exported from the Fusion router package:
+
+```tsx
+import { useNavigate, useParams, useLocation, Link } from '@equinor/fusion-framework-react-router';
+```
+
+No direct `react-router` import needed in your app code.
+
+## Step 6 — (Optional) Pass custom context
+
+If you need to share state (e.g. a query client or API class) across all loaders and components, extend `RouterContext` and pass the value to `<Router>`:
+
+```ts
+// src/router-context.d.ts
+declare module '@equinor/fusion-framework-react-router' {
+  interface RouterContext {
+    queryClient: import('@tanstack/react-query').QueryClient;
+  }
+}
+```
+
+```tsx
+// src/Router.tsx
+import { Router } from '@equinor/fusion-framework-react-router';
+import { QueryClient } from '@tanstack/react-query';
+import routes from './routes';
+
+const queryClient = new QueryClient();
+
+export default function AppRouter() {
+  return <Router routes={routes} context={{ queryClient }} />;
+}
+```
+
+Access it in loaders and components via `fusion.context.queryClient`.
+
+## Step 7 — (Optional) Enable the Vite plugin
+
+The Vite plugin transforms DSL calls into optimised React Router `RouteObject` code at build time, enabling proper code splitting for lazy routes:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { reactRouterPlugin } from '@equinor/fusion-framework-react-router/vite-plugin';
+
+export default defineConfig({
+  plugins: [react(), reactRouterPlugin()],
+});
+```
+
+## Next steps
+
+- [Migration guide](./migration.md) — moving from a plain `react-router` setup
+- [Interop entry point](./interop.md) — `MemoryRouter`, `createMemoryRouter`, and JSX-based routing for testing and mid-migration scenarios
+- [End-to-end cookbook](../../../../cookbooks/app-react-router/) — full working example

--- a/packages/react/router/docs/getting-started.md
+++ b/packages/react/router/docs/getting-started.md
@@ -161,4 +161,4 @@ export default defineConfig({
 
 - [Migration guide](./migration.md) — moving from a plain `react-router` setup
 - [Interop entry point](./interop.md) — `MemoryRouter`, `createMemoryRouter`, and JSX-based routing for testing and mid-migration scenarios
-- [End-to-end cookbook](../../../../cookbooks/app-react-router/) — full working example
+- [End-to-end cookbook](/cookbooks/react-app-router) — full working example

--- a/packages/react/router/docs/interop.md
+++ b/packages/react/router/docs/interop.md
@@ -1,0 +1,87 @@
+# Interop entry point — `@equinor/fusion-framework-react-router/interop`
+
+The `/interop` entry point re-exports symbols from `react-router` that are not part of the standard Fusion router surface area. These exports exist as an interop bridge for teams mid-migration and **will be removed in a future major version**.
+
+> **Do not use these in new code.** They are only here to avoid breaking existing consumers during migration.
+
+## What is exported
+
+Only a curated selection of `react-router` symbols is exposed here. If you need something that is missing, [open an issue](https://github.com/equinor/fusion/issues) describing your use case.
+
+```ts
+import {
+  // Test and widget utilities
+  MemoryRouter,
+  RouterProvider,
+  createMemoryRouter,
+
+  // React Router v6 JSX-based routing (replaced by RouteObject DSL)
+  Routes,
+  Route,
+} from '@equinor/fusion-framework-react-router/interop';
+```
+
+## When to use each
+
+### `MemoryRouter`
+
+An in-memory router that never touches browser history. Use it to wrap a single component in a unit test or to embed an isolated widget that must not affect the host page URL.
+
+```tsx
+import { render } from '@testing-library/react';
+import { MemoryRouter } from '@equinor/fusion-framework-react-router/interop';
+import { MyComponent } from './MyComponent';
+
+render(
+  <MemoryRouter initialEntries={['/items/42']}>
+    <MyComponent />
+  </MemoryRouter>,
+);
+```
+
+### `createMemoryRouter` + `RouterProvider`
+
+Use when your component depends on loaders, actions, or nested routes. `createMemoryRouter` builds a full router instance backed by in-memory history; `RouterProvider` mounts it.
+
+```tsx
+import { render } from '@testing-library/react';
+import {
+  createMemoryRouter,
+  RouterProvider,
+} from '@equinor/fusion-framework-react-router/interop';
+
+const router = createMemoryRouter(
+  [
+    {
+      path: '/items/:id',
+      Component: MyComponent,
+      loader: () => ({ name: 'Item 42' }),
+    },
+  ],
+  { initialEntries: ['/items/42'] },
+);
+
+render(<RouterProvider router={router} />);
+```
+
+### `Routes` and `Route`
+
+JSX-based route components from React Router v6. These are provided for codebases that have not yet migrated to the `RouteObject` DSL.
+
+```tsx
+import { Routes, Route } from '@equinor/fusion-framework-react-router/interop';
+
+// Wrap with MemoryRouter or a real router
+<Routes>
+  <Route path="/" element={<HomePage />} />
+  <Route path="/products/:id" element={<ProductPage />} />
+</Routes>
+```
+
+Migrate to `RouteObject[]` passed to `<Router>` or the Fusion DSL (`layout`, `index`, `route`, `prefix`) from `/routes`.
+
+## Why are these deprecated?
+
+These utilities belong to `react-router` and are intentionally not part of the Fusion router's main public API surface. Exposing them here avoids teams adding `react-router` as a separate dependency — which would risk bundling two copies of the router — while they complete their migration to the Fusion patterns.
+
+Once your codebase no longer uses this entry point, remove the import. The symbols remain available from `react-router` through the peer dependency resolution handled by your package manager.

--- a/packages/react/router/docs/interop.md
+++ b/packages/react/router/docs/interop.md
@@ -84,4 +84,4 @@ Migrate to `RouteObject[]` passed to `<Router>` or the Fusion DSL (`layout`, `in
 
 These utilities belong to `react-router` and are intentionally not part of the Fusion router's main public API surface. Exposing them here avoids teams adding `react-router` as a separate dependency — which would risk bundling two copies of the router — while they complete their migration to the Fusion patterns.
 
-Once your codebase no longer uses this entry point, remove the import. The symbols remain available from `react-router` through the peer dependency resolution handled by your package manager.
+Once your codebase no longer uses this entry point, remove the import. The symbols remain available from `react-router`, which is bundled as a direct dependency of `@equinor/fusion-framework-react-router`.

--- a/packages/react/router/docs/migration.md
+++ b/packages/react/router/docs/migration.md
@@ -1,0 +1,149 @@
+# Migrating from `react-router` to `@equinor/fusion-framework-react-router`
+
+This guide covers migrating an app that uses `react-router` directly to the Fusion Framework router integration.
+
+## Why migrate?
+
+The Fusion router wraps React Router v7 and adds:
+
+- Automatic wiring of `history` and `basename` from the Fusion navigation module — no manual setup.
+- Typed `fusion` context injected into every loader, action, and component — no prop drilling or extra React contexts.
+- A file-style route DSL (`layout`, `index`, `route`, `prefix`) that replaces hand-built `RouteObject` trees.
+- Route schema generation for portals, manifests, and documentation tooling.
+
+## Step 1 — Replace the router setup
+
+**Before** (plain React Router):
+
+```tsx
+import { createBrowserRouter, RouterProvider } from 'react-router';
+
+const router = createBrowserRouter([
+  { path: '/', element: <HomePage /> },
+  { path: '/products/:id', element: <ProductPage /> },
+]);
+
+export default function App() {
+  return <RouterProvider router={router} />;
+}
+```
+
+**After** (Fusion router):
+
+```tsx
+import { Router } from '@equinor/fusion-framework-react-router';
+
+const routes = [
+  { path: '/', Component: HomePage },
+  { path: '/products/:id', Component: ProductPage },
+];
+
+export default function App() {
+  return <Router routes={routes} />;
+}
+```
+
+`<Router>` picks up `history` and `basename` from the Fusion navigation module automatically. You do not create or manage a router instance.
+
+## Step 2 — Replace the route DSL (recommended)
+
+Instead of `RouteObject[]`, use the Fusion DSL for a cleaner, file-based structure:
+
+```ts
+// src/pages/index.ts
+import { layout, index, route, prefix } from '@equinor/fusion-framework-react-router/routes';
+
+export const pages = layout('./MainLayout.tsx', [
+  index('./HomePage.tsx'),
+  prefix('products', [
+    index('./ProductsPage.tsx'),
+    route(':id', './ProductPage.tsx'),
+  ]),
+]);
+```
+
+The Vite plugin transforms these DSL calls into standard `RouteObject` code at build time. See the [Vite plugin section](../README.md#vite-plugin) in the README.
+
+## Step 3 — Replace loader and action signatures
+
+Fusion injects a `fusion` argument into every loader and action. Update your function signatures:
+
+**Before:**
+
+```ts
+export async function loader({ params }: LoaderFunctionArgs) {
+  return fetch(`/api/products/${params.id}`);
+}
+```
+
+**After:**
+
+```ts
+import type { LoaderFunctionArgs } from '@equinor/fusion-framework-react-router';
+
+export async function clientLoader({ params, fusion }: LoaderFunctionArgs<{ id: string }>) {
+  const client = fusion.modules.http.createHttpClient('products');
+  return client.json(`/products/${params.id}`);
+}
+```
+
+The `fusion.modules` object exposes all configured Fusion modules. The `fusion.context` object exposes any custom context passed to `<Router context={...} />`.
+
+## Step 4 — Replace component props
+
+Route components receive `loaderData`, `actionData`, and `fusion` as props instead of calling hooks:
+
+**Before:**
+
+```tsx
+import { useLoaderData } from 'react-router';
+
+export default function ProductPage() {
+  const data = useLoaderData();
+  return <h1>{data.name}</h1>;
+}
+```
+
+**After:**
+
+```tsx
+import type { RouteComponentProps } from '@equinor/fusion-framework-react-router';
+
+export default function ProductPage({ loaderData }: RouteComponentProps<{ name: string }>) {
+  return <h1>{loaderData.name}</h1>;
+}
+```
+
+## Step 5 — Replace hook imports
+
+All standard React Router hooks are re-exported from the Fusion router package. Replace the import source:
+
+```ts
+// Before
+import { useNavigate, useParams, useLocation } from 'react-router';
+
+// After
+import { useNavigate, useParams, useLocation } from '@equinor/fusion-framework-react-router';
+```
+
+## Step 6 — Remove `react-router` from your dependencies
+
+Once all imports are updated, remove `react-router` from your `package.json`. It is a peer dependency of `@equinor/fusion-framework-react-router` and will always be present — adding it separately risks bundling two copies of the router.
+
+```bash
+pnpm remove react-router
+```
+
+## Common questions
+
+### Can I still use `useLoaderData` and `useParams` hooks?
+
+Yes. They are re-exported from `@equinor/fusion-framework-react-router` and work exactly as in React Router. The prop-based API is optional and preferred for type safety.
+
+### Can I mix `RouteObject[]` and the DSL?
+
+Yes. `<Router>` accepts both. You can migrate route by route.
+
+### What about `<Outlet />`, `<Link />`, `<NavLink />`?
+
+All re-exported from `@equinor/fusion-framework-react-router`. No import changes needed beyond the source package.

--- a/packages/react/router/docs/migration.md
+++ b/packages/react/router/docs/migration.md
@@ -62,7 +62,7 @@ export const pages = layout('./MainLayout.tsx', [
 ]);
 ```
 
-The Vite plugin transforms these DSL calls into standard `RouteObject` code at build time. See the [Vite plugin section](../README.md#vite-plugin) in the README.
+The Vite plugin transforms these DSL calls into standard `RouteObject` code at build time. See the [Vite plugin section](/modules/react/router/#vite-plugin) in the router module docs.
 
 ## Step 3 — Replace loader and action signatures
 
@@ -128,7 +128,7 @@ import { useNavigate, useParams, useLocation } from '@equinor/fusion-framework-r
 
 ## Step 6 — Remove `react-router` from your dependencies
 
-Once all imports are updated, remove `react-router` from your `package.json`. It is a peer dependency of `@equinor/fusion-framework-react-router` and will always be present — adding it separately risks bundling two copies of the router.
+Once all imports are updated, remove `react-router` from your `package.json`. It is bundled as a direct dependency of `@equinor/fusion-framework-react-router` and will always be present — adding it separately risks bundling two copies of the router.
 
 ```bash
 pnpm remove react-router

--- a/packages/react/router/package.json
+++ b/packages/react/router/package.json
@@ -25,6 +25,10 @@
     "./context": {
       "import": "./dist/esm/context.js",
       "types": "./dist/types/context.d.ts"
+    },
+    "./interop": {
+      "import": "./dist/esm/interop.js",
+      "types": "./dist/types/interop.d.ts"
     }
   },
   "scripts": {

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -45,4 +45,9 @@ export {
   useRouteError,
   useSearchParams,
   useSubmit,
+  // @deprecated — re-exported here for backwards compatibility; prefer importing
+  // from `@equinor/fusion-framework-react-router/interop` or migrating to the
+  // Fusion DSL. These will be removed in a future major version.
+  Route,
+  Routes,
 } from 'react-router';

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -45,9 +45,4 @@ export {
   useRouteError,
   useSearchParams,
   useSubmit,
-  // @deprecated — re-exported here for backwards compatibility; prefer importing
-  // from `@equinor/fusion-framework-react-router/interop` or migrating to the
-  // Fusion DSL. These will be removed in a future major version.
-  Route,
-  Routes,
 } from 'react-router';

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -1,5 +1,3 @@
-import { Route as ReactRouterRoute, Routes as ReactRouterRoutes } from 'react-router';
-
 export { Router } from './Router.js';
 export { FusionRouterContextProvider, routerContext, useRouterContext } from './context.js';
 export type { RouteSchemaEntry } from './routes/to-route-schema.js';
@@ -48,15 +46,3 @@ export {
   useSearchParams,
   useSubmit,
 } from 'react-router';
-
-/**
- * Use Fusion route schema DSL or RouteObject-based routing instead of React Router `<Routes>`.
- * @deprecated Please use Fusion DSL or RouteObject instead.
- */
-export const Routes: typeof ReactRouterRoutes = ReactRouterRoutes;
-
-/**
- * Use Fusion route schema DSL or RouteObject-based routing instead of React Router `<Route>`.
- * @deprecated Please use Fusion DSL or RouteObject instead.
- */
-export const Route: typeof ReactRouterRoute = ReactRouterRoute;

--- a/packages/react/router/src/interop.ts
+++ b/packages/react/router/src/interop.ts
@@ -44,7 +44,8 @@ export const RouterProvider: typeof ReactRouterRouterProvider = ReactRouterRoute
  *
  * @deprecated Interop export. This will be removed in a future major version.
  */
-export const createMemoryRouter: typeof reactRouterCreateMemoryRouter = reactRouterCreateMemoryRouter;
+export const createMemoryRouter: typeof reactRouterCreateMemoryRouter =
+  reactRouterCreateMemoryRouter;
 
 /**
  * Interop re-export of `Routes` from `react-router`.

--- a/packages/react/router/src/interop.ts
+++ b/packages/react/router/src/interop.ts
@@ -17,7 +17,7 @@ export type {
  * Useful for wrapping components in unit tests or embedding isolated widgets
  * that must not interact with the host page URL. Teams already using
  * `MemoryRouter` for testing can continue importing from this interop entry
- * point while migrating to a direct `react-router` dependency.
+ * point while migrating away from direct `react-router` imports.
  *
  * @deprecated Interop export. This will be removed in a future major version.
  */
@@ -40,7 +40,7 @@ export const RouterProvider: typeof ReactRouterRouterProvider = ReactRouterRoute
  * Useful for building test routers that support loaders, actions, and nested
  * routes without touching browser history. Teams using this for component or
  * integration tests can keep importing from this interop entry point while
- * migrating to a direct `react-router` dependency.
+ * migrating away from direct `react-router` imports.
  *
  * @deprecated Interop export. This will be removed in a future major version.
  */
@@ -53,7 +53,8 @@ export const createMemoryRouter: typeof reactRouterCreateMemoryRouter =
  * Teams migrating from React Router v6 JSX-based routing can use this while
  * transitioning to the Fusion route schema DSL or `RouteObject`-based routing.
  *
- * @deprecated Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
+ * @deprecated Interop export. This will be removed in a future major version.
+ * Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
  * `RouteObject` array passed to `<Router>` instead.
  */
 export const Routes: typeof ReactRouterRoutes = ReactRouterRoutes;
@@ -64,7 +65,8 @@ export const Routes: typeof ReactRouterRoutes = ReactRouterRoutes;
  * Teams migrating from React Router v6 JSX-based routing can use this while
  * transitioning to the Fusion route schema DSL or `RouteObject`-based routing.
  *
- * @deprecated Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
+ * @deprecated Interop export. This will be removed in a future major version.
+ * Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
  * `RouteObject` array passed to `<Router>` instead.
  */
 export const Route: typeof ReactRouterRoute = ReactRouterRoute;

--- a/packages/react/router/src/interop.ts
+++ b/packages/react/router/src/interop.ts
@@ -1,0 +1,69 @@
+import {
+  Route as ReactRouterRoute,
+  Routes as ReactRouterRoutes,
+  MemoryRouter as ReactRouterMemoryRouter,
+  RouterProvider as ReactRouterRouterProvider,
+  createMemoryRouter as reactRouterCreateMemoryRouter,
+} from 'react-router';
+
+export type {
+  MemoryRouterProps,
+  RouterProviderProps,
+} from 'react-router';
+
+/**
+ * Interop re-export of `MemoryRouter` from `react-router`.
+ *
+ * Useful for wrapping components in unit tests or embedding isolated widgets
+ * that must not interact with the host page URL. Teams already using
+ * `MemoryRouter` for testing can continue importing from this interop entry
+ * point while migrating to a direct `react-router` dependency.
+ *
+ * @deprecated Interop export. This will be removed in a future major version.
+ */
+export const MemoryRouter: typeof ReactRouterMemoryRouter = ReactRouterMemoryRouter;
+
+/**
+ * Interop re-export of `RouterProvider` from `react-router`.
+ *
+ * Provided for teams that pair `createMemoryRouter` with `RouterProvider` in
+ * tests or storybook setups and want a single import path while transitioning
+ * away from this package's legacy entry point.
+ *
+ * @deprecated Interop export. This will be removed in a future major version.
+ */
+export const RouterProvider: typeof ReactRouterRouterProvider = ReactRouterRouterProvider;
+
+/**
+ * Interop re-export of `createMemoryRouter` from `react-router`.
+ *
+ * Useful for building test routers that support loaders, actions, and nested
+ * routes without touching browser history. Teams using this for component or
+ * integration tests can keep importing from this interop entry point while
+ * migrating to a direct `react-router` dependency.
+ *
+ * @deprecated Interop export. This will be removed in a future major version.
+ */
+export const createMemoryRouter: typeof reactRouterCreateMemoryRouter = reactRouterCreateMemoryRouter;
+
+/**
+ * Interop re-export of `Routes` from `react-router`.
+ *
+ * Teams migrating from React Router v6 JSX-based routing can use this while
+ * transitioning to the Fusion route schema DSL or `RouteObject`-based routing.
+ *
+ * @deprecated Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
+ * `RouteObject` array passed to `<Router>` instead.
+ */
+export const Routes: typeof ReactRouterRoutes = ReactRouterRoutes;
+
+/**
+ * Interop re-export of `Route` from `react-router`.
+ *
+ * Teams migrating from React Router v6 JSX-based routing can use this while
+ * transitioning to the Fusion route schema DSL or `RouteObject`-based routing.
+ *
+ * @deprecated Use the Fusion DSL (`Route`, `IndexRoute`, `LayoutRoute`) or a
+ * `RouteObject` array passed to `<Router>` instead.
+ */
+export const Route: typeof ReactRouterRoute = ReactRouterRoute;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2074,6 +2074,9 @@ importers:
       '@equinor/fusion-framework-react-module-context':
         specifier: workspace:*
         version: link:../modules/context
+      '@equinor/fusion-framework-react-router':
+        specifier: workspace:*
+        version: link:../router
       '@equinor/fusion-observable':
         specifier: workspace:*
         version: link:../../utils/observable

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -385,7 +385,18 @@ export default sidebar({
       children: [
         {
           text: 'Router',
+          prefix: 'router/',
           link: 'router/',
+          children: [
+            {
+              text: 'Migration Guide',
+              link: 'migration.md',
+            },
+            {
+              text: 'Interop Entry Point',
+              link: 'interop.md',
+            },
+          ],
         },
       ],
     },

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -389,6 +389,10 @@ export default sidebar({
           link: 'router/',
           children: [
             {
+              text: 'Getting Started',
+              link: 'getting-started.md',
+            },
+            {
               text: 'Migration Guide',
               link: 'migration.md',
             },

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -11,6 +11,10 @@ export default sidebar({
           text: 'Authentication',
           link: 'app/docs/msal.md',
         },
+        {
+          text: 'Routing',
+          link: 'app/docs/routing.md',
+        },
         // 'app/getting-started',
         // {
         //   text: 'Cookbooks',

--- a/vue-press/src/guide/app/docs/routing.md
+++ b/vue-press/src/guide/app/docs/routing.md
@@ -1,6 +1,7 @@
 ---
 title: Routing
-tags:
+category: Guide
+tag:
   - router
   - react-router
   - routing

--- a/vue-press/src/guide/app/docs/routing.md
+++ b/vue-press/src/guide/app/docs/routing.md
@@ -1,0 +1,11 @@
+---
+title: Routing
+tags:
+  - router
+  - react-router
+  - routing
+  - react
+  - app
+---
+
+<!-- @include: ../../../../packages/react/app/docs/routing.md -->

--- a/vue-press/src/modules/react/router/getting-started.md
+++ b/vue-press/src/modules/react/router/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
-tags:
+category: Module
+tag:
   - router
   - react-router
   - routing

--- a/vue-press/src/modules/react/router/getting-started.md
+++ b/vue-press/src/modules/react/router/getting-started.md
@@ -1,0 +1,11 @@
+---
+title: Getting Started
+tags:
+  - router
+  - react-router
+  - routing
+  - react
+  - getting-started
+---
+
+<!-- @include: ../../../../../packages/react/router/docs/getting-started.md -->

--- a/vue-press/src/modules/react/router/interop.md
+++ b/vue-press/src/modules/react/router/interop.md
@@ -1,0 +1,14 @@
+---
+title: Interop Entry Point
+category: Module
+tag:
+  - router
+  - react-router
+  - interop
+  - react
+  - testing
+---
+
+<ModuleBadge module="react/router" package="@equinor/fusion-framework-react-router" />
+
+<!-- @include: ../../../../../packages/react/router/docs/interop.md -->

--- a/vue-press/src/modules/react/router/migration.md
+++ b/vue-press/src/modules/react/router/migration.md
@@ -1,0 +1,13 @@
+---
+title: Migration Guide
+category: Module
+tag:
+  - router
+  - react-router
+  - migration
+  - react
+---
+
+<ModuleBadge module="react/router" package="@equinor/fusion-framework-react-router" />
+
+<!-- @include: ../../../../../packages/react/router/docs/migration.md -->


### PR DESCRIPTION
**Why is this change needed?**

Teams using `@equinor/fusion-framework-react-router` had no way to get hold of `MemoryRouter`, `RouterProvider`, `createMemoryRouter`, `Routes`, or `Route` without adding `react-router` as a direct dependency. That risks dual-bundling — two copies of react-router in the same app — when the Fusion router peer dep resolves to a different instance. This PR adds a curated interop bridge and also surfaces the full routing API from `@equinor/fusion-framework-react-app` so consumers don't need a separate direct dependency on the router package either.

**What is the current behavior?**

- `@equinor/fusion-framework-react-router` does not export `MemoryRouter`, `RouterProvider`, `createMemoryRouter`, `Routes`, or `Route`.
- `@equinor/fusion-framework-react-app` has no routing entry point — consumers must install `@equinor/fusion-framework-react-router` separately.
- No getting started, migration, or interop documentation exists for the router package.

**What is the new behavior?**

- `@equinor/fusion-framework-react-router/interop` exports a curated set of deprecated react-router symbols as a bridge for teams mid-migration or needing a memory router for testing/widgets.
- `@equinor/fusion-framework-react-app/routing` re-exports the full API of `@equinor/fusion-framework-react-router` and its route builder DSL from a single entry point.
- New docs: getting started, migration guide, interop entry point (router package); routing guide (react-app package). All wired into VuePress.

**What is the intended behavior or invariant?**

The `/interop` exports are deprecated at birth — they exist only to prevent consumers from reaching into `react-router` directly (dual-bundling risk). They will be removed in a future major. The `./routing` entry on react-app must remain a pure re-export; no logic or wrappers.

**Does this PR introduce a breaking change?**

No. Both new entry points are additive. Existing imports are unchanged.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor for `@equinor/fusion-framework-react-router` and `@equinor/fusion-framework-react-app`; patch for docs
- Consumer impact: New optional entry points. No action required unless consumers want to adopt them.
- Downstream impact: None — react-app already depended on the router package indirectly via navigation.

**Review guidance:**

- `packages/react/router/src/interop.ts` — verify the deprecated TSDoc and that no non-interop symbols leak in
- `packages/react/app/src/routing/index.ts` — should be a pure `export *` with no added logic
- `packages/react/app/package.json` — verify `./routing` export, `typesVersions`, and the optional peer dep are all consistent
- Docs: check that the getting started guide is correctly framed for portals/widgets/apps (not apps-only)
- VuePress sidebar: Getting Started → Migration Guide → Interop Entry Point under Modules > React > Router; Routing under Guide > App

**Additional context**

All `/interop` exports are marked `@deprecated — Interop export. This will be removed in a future major version.` The deprecated tag intentionally does **not** suggest adding react-router as a direct dep.

**Related issues**

closes: equinor/fusion-core-tasks#1328
ref: equinor/fusion-core-tasks#1327

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [ ] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
