### PR TITLE
fix(cli-plugin-copilot): remove autoStart option removed in copilot-sdk 1.0.0

### DIFF
--- a/packages/cli-plugins/copilot/src/commands/app/eval.ts
+++ b/packages/cli-plugins/copilot/src/commands/app/eval.ts
@@ -35,7 +35,7 @@ export const createSession = async (options: SessionOptions): Promise<CopilotSes
   const { ctx, config, defaultToolTimeoutMs } = options;
 
   const { CopilotClient, defineTool, approveAll } = await loadCopilotSdk();
-  const client = new CopilotClient({ autoStart: true });
+  const client = new CopilotClient();
   await client.start();
 
   const fileTools = [


### PR DESCRIPTION
## Summary

Removes the `autoStart` option from `CopilotClient` constructor call in the eval command — this option was removed in `@github/copilot-sdk` 1.0.0 (merged in #4790).

The client is started explicitly via `client.start()` on the next line, so removing `autoStart: true` has no behavioral change.

## Root cause

`autoStart` no longer exists in `CopilotClientOptions` in v1.0.0, causing a `TS2353` compile error:
```
packages/cli-plugins/copilot/src/commands/app/eval.ts(38,38): error TS2353: Object literal may only specify known properties, and 'autoStart' does not exist in type 'CopilotClientOptions'.
```

## Change

```diff
- const client = new CopilotClient({ autoStart: true });
+ const client = new CopilotClient();
```