### PR TITLE
fix(observable): prevent infinite re-render loop in useObservableState with stateful observables

### DIFF
--- a/.changeset/fusion-observable_fix-use-sync-external-store-rerender.md
+++ b/.changeset/fusion-observable_fix-use-sync-external-store-rerender.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Fix infinite re-render loop in `useObservableState` when used with stateful observables (`BehaviorSubject`, `FlowSubject`).
+
+The `useSyncExternalStore` integration introduced in the previous release had two interacting bugs:
+
+1. **Listener registered before subscription**: `onStoreChange` was added to the listeners set before `subject.subscribe()` was called. Synchronous-emitting observables (e.g. `BehaviorSubject`) fire `next` immediately inside `subscribe`, which triggered `onStoreChange` synchronously from within the `subscribe` callback. React's `useSyncExternalStore` contract forbids calling the change notifier during the subscribe call itself, causing an infinite re-render loop.
+
+2. **Spurious snapshot object on unchanged value**: The `next` handler always created a new snapshot object (`{ ...snapshot, value }`), even when the value was identical. Because `useSyncExternalStore` uses `Object.is` to detect tearing, a new object reference was always treated as a change, which forced a re-render, re-subscribed, replayed the BehaviorSubject value again, and looped indefinitely.
+
+**Fix**: Subscribe first (so any synchronous emission updates the snapshot without notifying listeners), then add the listener. Also skip snapshot creation when the incoming value is `Object.is`-equal to the current snapshot value.
+
+Any application using `useObservableState` with a `BehaviorSubject` or `FlowSubject` will have been caught in this loop since upgrading to `9.0.1`. Upgrade to this patch to resolve it — no consumer code changes required.

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -122,21 +122,19 @@ function createObservableStateStore<TType, TError = unknown>(
     getSnapshot,
     getServerSnapshot: getSnapshot,
     subscribe: (onStoreChange: () => void): (() => void) => {
-      /**
-       * Filter out emissions that match the current snapshot value.
-       *
-       * `distinctUntilChanged` is not sufficient here because it always emits
-       * the first value (no previous to compare against). A BehaviorSubject
-       * fires synchronously on subscribe, so without this filter the snapshot
-       * gets a new object reference before the listener is registered — React's
-       * useSyncExternalStore tearing check then detects a mismatch and forces
-       * a re-render, which re-subscribes, which repeats indefinitely.
-       *
-       * Using `snapshot.value` as the comparand is correct: it is already
-       * seeded via resolveInitialValue and advances with each emission, so
-       * subsequent duplicate values are also suppressed.
-       */
-      const subscription = subject.pipe(filter((value) => !Object.is(snapshot.value, value))).subscribe({
+      const subscription = subject
+        .pipe(
+          // `distinctUntilChanged` is not sufficient — it always emits the first value
+          // (no previous to compare against). BehaviorSubject fires synchronously on
+          // subscribe, so that first emission would update the snapshot before the listener
+          // is registered. React's tearing check then sees a new object reference and forces
+          // a re-render, which re-subscribes, which repeats indefinitely.
+          // Comparing against `snapshot.value` is correct: it is already seeded via
+          // resolveInitialValue, so the sync replay is caught, and subsequent duplicates
+          // are suppressed for free.
+          filter((value) => !Object.is(snapshot.value, value)),
+        )
+        .subscribe({
         next: (value) => {
           snapshot = { ...snapshot, value };
           notify();

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -1,5 +1,5 @@
 import { useMemo, useSyncExternalStore } from 'react';
-import { distinctUntilChanged } from 'rxjs';
+import { filter } from 'rxjs';
 import type { Observable, StatefulObservable } from '../types';
 
 /**
@@ -123,13 +123,20 @@ function createObservableStateStore<TType, TError = unknown>(
     getServerSnapshot: getSnapshot,
     subscribe: (onStoreChange: () => void): (() => void) => {
       /**
-       * Pipe distinctUntilChanged so synchronous emissions from stateful
-       * observables (BehaviorSubject, FlowSubject) that replay their current
-       * value on subscribe are filtered out before reaching the next handler.
-       * This prevents spurious snapshot object creation and the resulting
-       * useSyncExternalStore tearing loop.
+       * Filter out emissions that match the current snapshot value.
+       *
+       * `distinctUntilChanged` is not sufficient here because it always emits
+       * the first value (no previous to compare against). A BehaviorSubject
+       * fires synchronously on subscribe, so without this filter the snapshot
+       * gets a new object reference before the listener is registered — React's
+       * useSyncExternalStore tearing check then detects a mismatch and forces
+       * a re-render, which re-subscribes, which repeats indefinitely.
+       *
+       * Using `snapshot.value` as the comparand is correct: it is already
+       * seeded via resolveInitialValue and advances with each emission, so
+       * subsequent duplicate values are also suppressed.
        */
-      const subscription = subject.pipe(distinctUntilChanged()).subscribe({
+      const subscription = subject.pipe(filter((value) => !Object.is(snapshot.value, value))).subscribe({
         next: (value) => {
           snapshot = { ...snapshot, value };
           notify();

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -78,11 +78,10 @@ function resolveInitialValue<TType>(
   initial: TType | undefined,
 ): TType | undefined {
   return (
-    /** provided initial value */
+    // caller wins over subject's current value
     initial ??
-    /** use subject current value if supported */
+    // read synchronous value from stateful subjects (BehaviorSubject, FlowSubject)
     (hasStatefulValue(subject) ? subject.value : undefined) ??
-    /** nothing to resolve */
     undefined
   );
 }
@@ -124,14 +123,15 @@ function createObservableStateStore<TType, TError = unknown>(
     subscribe: (onStoreChange: () => void): (() => void) => {
       const subscription = subject
         .pipe(
-          // `distinctUntilChanged` is not sufficient — it always emits the first value
-          // (no previous to compare against). BehaviorSubject fires synchronously on
-          // subscribe, so that first emission would update the snapshot before the listener
-          // is registered. React's tearing check then sees a new object reference and forces
-          // a re-render, which re-subscribes, which repeats indefinitely.
-          // Comparing against `snapshot.value` is correct: it is already seeded via
-          // resolveInitialValue, so the sync replay is caught, and subsequent duplicates
-          // are suppressed for free.
+          // Stateful observables (BehaviorSubject, FlowSubject) emit their current value
+          // synchronously on subscribe. useSyncExternalStore compares getSnapshot() before
+          // and after the subscribe call; a new snapshot object causes a tearing mismatch,
+          // which forces a re-render → re-subscribe → infinite loop.
+          //
+          // We compare against snapshot.value (already seeded by resolveInitialValue) so
+          // the replayed current value is dropped. Subsequent duplicate emissions are
+          // suppressed for free — distinctUntilChanged cannot do this because it always
+          // passes the first emission through.
           filter((value) => !Object.is(snapshot.value, value)),
         )
         .subscribe({
@@ -151,12 +151,9 @@ function createObservableStateStore<TType, TError = unknown>(
 
       subscription.add(teardown);
 
-      /**
-       * Add the listener AFTER subscribing so that synchronous emissions from
-       * stateful observables (BehaviorSubject, FlowSubject) don't call
-       * onStoreChange during the subscribe call itself — React forbids this and
-       * it causes a re-render / tearing loop.
-       */
+      // Register the listener only after subscribing. The filter above drops the
+      // synchronous replay, but adding the listener first would still cause
+      // onStoreChange to be called inside subscribe — React forbids this.
       listeners.add(onStoreChange);
 
       return (): void => {
@@ -168,16 +165,19 @@ function createObservableStateStore<TType, TError = unknown>(
 }
 
 /**
- * use state of observable
- * @param subject [dep] Observable subject
+ * Subscribes to an {@link Observable} and returns its current state.
+ *
+ * @param subject - Observable to subscribe to.
  */
 export function useObservableState<S, TError = unknown>(
   subject: Observable<S>,
 ): ObservableStateReturnType<S | undefined, TError>;
 
 /**
- * use state of observable
- * @param subject [dep] Observable subject
+ * Subscribes to an {@link Observable} and returns its current state.
+ *
+ * @param subject - Observable to subscribe to.
+ * @param opt - Options including an optional initial value and teardown callback.
  */
 export function useObservableState<
   TType,
@@ -188,19 +188,24 @@ export function useObservableState<
   opt: ObservableStateOptions<TInitial>,
 ): ObservableStateReturnType<TType | TInitial, TError>;
 
-/** === StatefulObservable === */
+// --- StatefulObservable overloads (BehaviorSubject, FlowSubject) ---
+// The initial value is read synchronously from subject.value on mount.
 
 /**
- * use state of observable with value property (`FlowSubject`, `BehaviorSubject`)
- * @param subject [dep] Observable subject
+ * Subscribes to a {@link StatefulObservable} and returns its current state.
+ * The initial value is read synchronously from `subject.value`.
+ *
+ * @param subject - Stateful observable (e.g. `BehaviorSubject`, `FlowSubject`).
  */
 export function useObservableState<TType, TError = unknown>(
   subject: StatefulObservable<TType>,
 ): ObservableStateReturnType<TType, TError>;
 
 /**
- * use state of observable with value property (`FlowSubject`, `BehaviorSubject`)
- * @param subject [dep] Observable subject
+ * Subscribes to a {@link StatefulObservable} and returns its current state.
+ *
+ * @param subject - Stateful observable (e.g. `BehaviorSubject`, `FlowSubject`).
+ * @param options - Options including an optional override initial value and teardown callback.
  */
 export function useObservableState<TType, TError = unknown>(
   subject: StatefulObservable<TType>,
@@ -208,12 +213,12 @@ export function useObservableState<TType, TError = unknown>(
 ): ObservableStateReturnType<TType, TError>;
 
 /**
- * Hook for extracting state of observable.
- * **note** when state changes the consumer of the hook will rerender
+ * Hook that subscribes to an observable and exposes its state to a React component.
+ * Re-renders the consumer whenever a new value, error, or completion is emitted.
  *
- * @param subject [dep] Observable subject
- * @param initial initial value
- * @returns current state of observable
+ * @param subject - Observable or stateful observable to subscribe to.
+ * @param opt - Optional initial value and teardown callback.
+ * @returns Current `{ value, error, complete }` snapshot.
  */
 export function useObservableState<S, E = unknown>(
   subject: Observable<S> | StatefulObservable<S>,

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -121,10 +121,15 @@ function createObservableStateStore<TType, TError = unknown>(
     getSnapshot,
     getServerSnapshot: getSnapshot,
     subscribe: (onStoreChange: () => void): (() => void) => {
-      listeners.add(onStoreChange);
-
       const subscription = subject.subscribe({
         next: (value) => {
+          /**
+           * Skip when value is unchanged — avoids creating a new snapshot object
+           * for synchronous emissions (e.g. BehaviorSubject) that fire during
+           * subscribe and would otherwise trigger infinite re-renders via
+           * useSyncExternalStore's tearing detection.
+           */
+          if (Object.is(snapshot.value, value)) return;
           snapshot = { ...snapshot, value };
           notify();
         },
@@ -139,6 +144,14 @@ function createObservableStateStore<TType, TError = unknown>(
       });
 
       subscription.add(teardown);
+
+      /**
+       * Add the listener AFTER subscribing so that synchronous emissions from
+       * stateful observables (BehaviorSubject, FlowSubject) don't call
+       * onStoreChange during the subscribe call itself — React forbids this and
+       * it causes a re-render / tearing loop.
+       */
+      listeners.add(onStoreChange);
 
       return (): void => {
         listeners.delete(onStoreChange);

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -1,4 +1,5 @@
 import { useMemo, useSyncExternalStore } from 'react';
+import { distinctUntilChanged } from 'rxjs';
 import type { Observable, StatefulObservable } from '../types';
 
 /**
@@ -121,15 +122,15 @@ function createObservableStateStore<TType, TError = unknown>(
     getSnapshot,
     getServerSnapshot: getSnapshot,
     subscribe: (onStoreChange: () => void): (() => void) => {
-      const subscription = subject.subscribe({
+      /**
+       * Pipe distinctUntilChanged so synchronous emissions from stateful
+       * observables (BehaviorSubject, FlowSubject) that replay their current
+       * value on subscribe are filtered out before reaching the next handler.
+       * This prevents spurious snapshot object creation and the resulting
+       * useSyncExternalStore tearing loop.
+       */
+      const subscription = subject.pipe(distinctUntilChanged()).subscribe({
         next: (value) => {
-          /**
-           * Skip when value is unchanged — avoids creating a new snapshot object
-           * for synchronous emissions (e.g. BehaviorSubject) that fire during
-           * subscribe and would otherwise trigger infinite re-renders via
-           * useSyncExternalStore's tearing detection.
-           */
-          if (Object.is(snapshot.value, value)) return;
           snapshot = { ...snapshot, value };
           notify();
         },

--- a/packages/utils/observable/tests/react/useObservableState.test.ts
+++ b/packages/utils/observable/tests/react/useObservableState.test.ts
@@ -112,4 +112,32 @@ describe('useObservableState', () => {
 
     expect(teardown).toHaveBeenCalledTimes(1);
   });
+
+  it('should not re-render when a stateful observable emits the same value', () => {
+    const subject = new BehaviorSubject(1);
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useObservableState(subject);
+    });
+
+    const renderCountAfterMount = renderCount;
+
+    // Emitting the same value should be swallowed by distinctUntilChanged
+    act(() => {
+      subject.next(1);
+    });
+
+    expect(result.current.value).toBe(1);
+    expect(renderCount).toBe(renderCountAfterMount);
+
+    // A different value should still trigger a re-render
+    act(() => {
+      subject.next(2);
+    });
+
+    expect(result.current.value).toBe(2);
+    expect(renderCount).toBeGreaterThan(renderCountAfterMount);
+  });
 });


### PR DESCRIPTION
**Why is this change needed?**

The `useSyncExternalStore` integration introduced in `9.0.1` broke all usage of `useObservableState` with stateful observables (`BehaviorSubject`, `FlowSubject`). Any component subscribed to a stateful observable entered an infinite re-render loop immediately on mount.

**What is the current behavior?**

`useObservableState` with a `BehaviorSubject` or `FlowSubject` causes an infinite re-render loop on React 18/19. Two interacting bugs are responsible:

1. The listener (`onStoreChange`) was added to the internal set **before** `subject.subscribe()` was called. Stateful observables emit synchronously inside `subscribe`, so `onStoreChange` was called from within the `subscribe` callback — a violation of `useSyncExternalStore`'s contract, which forbids calling the notifier during the subscribe phase.

2. The `next` handler always created a new snapshot object (`{ ...snapshot, value }`) even when the value was unchanged. React's tearing detection uses `Object.is` on the snapshot reference, so a new object on every sync emission forced a re-render, which re-subscribed, which replayed the current value again — loop.

**What is the new behavior?**

- `subscribe` now calls `subject.subscribe()` first, letting any synchronous emissions update the internal snapshot silently, then adds the listener. React picks up any diff in its post-subscribe consistency check, resulting in at most one extra render.
- The `next` handler skips snapshot creation when `Object.is(snapshot.value, value)` is true, preventing spurious reference changes for unchanged values.

**What is the intended behavior or invariant?**

`useSyncExternalStore`'s `subscribe` callback must never call the change notifier synchronously. The snapshot reference must only change when the content changes.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Any app using `useObservableState` with a `BehaviorSubject` or `FlowSubject` was broken since `9.0.1`. This patch restores correct behavior — no consumer code changes required.
- Downstream impact: All packages consuming `@equinor/fusion-observable` React hooks are affected.

**Review guidance:**

Focus on [packages/utils/observable/src/react/useObservableState.ts](packages/utils/observable/src/react/useObservableState.ts) — specifically `createObservableStateStore`. The key invariant to verify: `subscribe` must not call `onStoreChange` during its own execution. Check that the listener is added only after `subject.subscribe()` returns, and that the `Object.is` guard in `next` is correct.

**Additional context**

The old `useState`/`useLayoutEffect` implementation did not have this problem because React's batching and effect scheduling naturally deferred notifications. `useSyncExternalStore` has stricter synchronous constraints.

**Related issues**

ref: feat/useObservableState/useSyncExternalStore branch (commits `50db75276`, `d9672f63f`)

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)