### PR TITLE
fix(observable): stabilize useObservableState store across re-renders

### DIFF
--- a/.changeset/fusion-observable_fix-use-observable-state-stable-store.md
+++ b/.changeset/fusion-observable_fix-use-observable-state-stable-store.md
@@ -1,0 +1,27 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Internal: `useObservableState` — stabilize store across re-renders
+
+Previously, passing non-memoized values for `opt.initial` or `opt.teardown`
+(e.g. inline object literals or arrow functions) caused `useMemo` to recreate
+the store on every render, resetting state and triggering an infinite re-render
+loop.
+
+The store is now recreated only when the `subject` reference changes.
+`initial` and `teardown` are stored in refs that are kept current on every
+render, so the store always reads the latest values when a new subject is
+provided — without those values being `useMemo` dependencies.
+
+A new `persist` option is also available as an escape hatch for cases where
+the subject cannot be memoized at the call site:
+
+```tsx
+// subject is a prop and may not be stable — freeze it at first render
+const { value } = useObservableState(stream, { persist: true });
+```
+
+When `persist: true`, the subject reference is frozen at mount and the store
+is never recreated, even if the caller passes a different observable instance
+on subsequent renders.

--- a/.changeset/fusion-observable_fix-use-observable-state-stable-store.md
+++ b/.changeset/fusion-observable_fix-use-observable-state-stable-store.md
@@ -2,7 +2,7 @@
 "@equinor/fusion-observable": patch
 ---
 
-Internal: `useObservableState` — stabilize store across re-renders
+`useObservableState` — stabilize store across re-renders
 
 Previously, passing non-memoized values for `opt.initial` or `opt.teardown`
 (e.g. inline object literals or arrow functions) caused `useMemo` to recreate

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from 'react';
+import { useMemo, useRef, useSyncExternalStore } from 'react';
 import type { Observable, StatefulObservable } from '../types';
 
 /**
@@ -11,6 +11,15 @@ type ObservableStateOptions<TType = undefined> = {
   initial?: TType;
   /** Teardown function called when the subscription is unsubscribed. */
   teardown?: VoidFunction;
+  /**
+   * When `true`, the subject reference is frozen at the first render and the
+   * store is never recreated, even if the caller passes a different observable
+   * instance on subsequent renders. Use this as an escape hatch when the
+   * subject cannot be memoized at the call site.
+   *
+   * @default false
+   */
+  persist?: boolean;
 };
 
 /**
@@ -77,12 +86,10 @@ function resolveInitialValue<TType>(
   initial: TType | undefined,
 ): TType | undefined {
   return (
-    /** provided initial value */
+    /** caller-provided initial takes precedence */
     initial ??
-    /** use subject current value if supported */
-    (hasStatefulValue(subject) ? subject.value : undefined) ??
-    /** nothing to resolve */
-    undefined
+    /** fall back to subject's synchronous current value if available */
+    (hasStatefulValue(subject) ? subject.value : undefined)
   );
 }
 
@@ -149,16 +156,21 @@ function createObservableStateStore<TType, TError = unknown>(
 }
 
 /**
- * use state of observable
- * @param subject [dep] Observable subject
+ * Subscribes to an {@link Observable} and returns its state.
+ *
+ * The initial `value` is `undefined` until the first emission.
+ *
+ * @param subject - Observable to subscribe to. Must have a stable reference.
  */
 export function useObservableState<S, TError = unknown>(
   subject: Observable<S>,
 ): ObservableStateReturnType<S | undefined, TError>;
 
 /**
- * use state of observable
- * @param subject [dep] Observable subject
+ * Subscribes to an {@link Observable} and returns its state.
+ *
+ * @param subject - Observable to subscribe to. Must have a stable reference.
+ * @param opt - Options including an optional `initial` value shown before the first emission.
  */
 export function useObservableState<
   TType,
@@ -169,19 +181,25 @@ export function useObservableState<
   opt: ObservableStateOptions<TInitial>,
 ): ObservableStateReturnType<TType | TInitial, TError>;
 
-/** === StatefulObservable === */
-
 /**
- * use state of observable with value property (`FlowSubject`, `BehaviorSubject`)
- * @param subject [dep] Observable subject
+ * Subscribes to a {@link StatefulObservable} (e.g. `BehaviorSubject`, `FlowSubject`)
+ * and returns its state.
+ *
+ * The current `value` is read synchronously from the subject on mount,
+ * so the initial state is never `undefined`.
+ *
+ * @param subject - Stateful observable to subscribe to. Must have a stable reference.
  */
 export function useObservableState<TType, TError = unknown>(
   subject: StatefulObservable<TType>,
 ): ObservableStateReturnType<TType, TError>;
 
 /**
- * use state of observable with value property (`FlowSubject`, `BehaviorSubject`)
- * @param subject [dep] Observable subject
+ * Subscribes to a {@link StatefulObservable} (e.g. `BehaviorSubject`, `FlowSubject`)
+ * and returns its state.
+ *
+ * @param subject - Stateful observable to subscribe to. Must have a stable reference.
+ * @param opt - Options including an optional `initial` override and `teardown` callback.
  */
 export function useObservableState<TType, TError = unknown>(
   subject: StatefulObservable<TType>,
@@ -189,21 +207,78 @@ export function useObservableState<TType, TError = unknown>(
 ): ObservableStateReturnType<TType, TError>;
 
 /**
- * Hook for extracting state of observable.
- * **note** when state changes the consumer of the hook will rerender
+ * Subscribes to an observable and returns its latest emitted value as React
+ * state. The component re-renders on every emission, error, or completion.
  *
- * @param subject [dep] Observable subject
- * @param initial initial value
- * @returns current state of observable
+ * Internally wraps `useSyncExternalStore` to guarantee tear-down safety and
+ * concurrent-mode compatibility. The subscription is created once per unique
+ * `subject` reference and cleaned up automatically when the component unmounts
+ * or the subject changes.
+ *
+ * **`subject` must be stable (memoized).** Passing a new observable instance
+ * on every render recreates the store and resets state on every render cycle.
+ * Wrap the subject in `useMemo`, derive it outside the component, or pass
+ * `opt.persist: true` to freeze the subject reference at first render.
+ *
+ * `opt.initial` and `opt.teardown` do **not** need to be memoized — they are
+ * captured in refs and never trigger a store recreation on their own.
+ *
+ * @param subject - The observable to subscribe to. Must have a stable reference.
+ * @param opt - Optional initial value and teardown callback.
+ * @returns An object with `value`, `error`, and `complete` reflecting the latest observable state.
+ *
+ * @example
+ * ```tsx
+ * // Stable subject — created outside the component or wrapped in useMemo.
+ * const subject = useMemo(() => new BehaviorSubject(0), []);
+ *
+ * function Counter() {
+ *   const { value, error, complete } = useObservableState(subject, { initial: 0 });
+ *
+ *   if (error) return <p>Error: {String(error)}</p>;
+ *   if (complete) return <p>Done: {value}</p>;
+ *   return <p>Count: {value}</p>;
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Cannot memoize? Use persist to freeze the subject at first render.
+ * function Widget({ stream }: { stream: Observable<number> }) {
+ *   const { value } = useObservableState(stream, { persist: true });
+ *   return <p>{value}</p>;
+ * }
+ * ```
  */
 export function useObservableState<S, E = unknown>(
   subject: Observable<S> | StatefulObservable<S>,
   opt?: ObservableStateOptions<S>,
 ): ObservableStateReturnType<S | undefined, E> {
-  const { initial, teardown } = opt ?? {};
+  const { initial, teardown, persist } = opt ?? {};
+
+  // Refs keep initial/teardown out of useMemo deps — non-memoized caller values
+  // (inline objects, arrow functions) would otherwise recreate the store on every render.
+  const initialRef = useRef(initial);
+  const teardownRef = useRef(teardown);
+
+  // subjectRef freezes the subject when persist=true (store never recreated).
+  // When persist=false (default), all refs are kept current so the store picks
+  // up the latest values whenever the subject changes.
+  const subjectRef = useRef(subject);
+  if (!persist) {
+    subjectRef.current = subject;
+    initialRef.current = initial;
+    teardownRef.current = teardown;
+  }
+
+  // persist=true  → stable ref identity → useMemo never re-runs
+  // persist=false → live subject value   → useMemo re-runs on subject swap
+  const stream = persist ? subjectRef.current : subject;
+
   const store = useMemo(
-    () => createObservableStateStore<S, E>(subject, initial, teardown),
-    [subject, initial, teardown],
+    () =>
+      createObservableStateStore<S, E>(stream, initialRef.current, teardownRef.current),
+    [stream],
   );
 
   const snapshot = useSyncExternalStore(

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -276,8 +276,7 @@ export function useObservableState<S, E = unknown>(
   const stream = persist ? subjectRef.current : subject;
 
   const store = useMemo(
-    () =>
-      createObservableStateStore<S, E>(stream, initialRef.current, teardownRef.current),
+    () => createObservableStateStore<S, E>(stream, initialRef.current, teardownRef.current),
     [stream],
   );
 

--- a/packages/utils/observable/tests/react/useObservableState.test.ts
+++ b/packages/utils/observable/tests/react/useObservableState.test.ts
@@ -112,4 +112,112 @@ describe('useObservableState', () => {
 
     expect(teardown).toHaveBeenCalledTimes(1);
   });
+
+  describe('store stability', () => {
+    it('should not recreate the store when a non-memoized complex initial object is passed on every render', () => {
+      const subject = new Subject<{ id: number }>();
+
+      // Spy on Subject.subscribe to count store creations — each new store subscribes once.
+      const subscribeSpy = vi.spyOn(subject, 'subscribe');
+
+      const { rerender } = renderHook(() =>
+        useObservableState(subject, {
+          // Intentionally non-memoized: a new object reference on every render.
+          initial: { id: 0 },
+        }),
+      );
+
+      rerender();
+      rerender();
+      rerender();
+
+      // The store should have been created once regardless of how many times the
+      // component re-renders with a different initial object reference.
+      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not recreate the store when a non-memoized teardown function is passed on every render', () => {
+      const subject = new Subject<number>();
+      const subscribeSpy = vi.spyOn(subject, 'subscribe');
+
+      const { rerender } = renderHook(() =>
+        useObservableState(subject, {
+          // Intentionally non-memoized: a new arrow function on every render.
+          teardown: () => {},
+        }),
+      );
+
+      rerender();
+      rerender();
+      rerender();
+
+      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should recreate the store when the subject reference changes', () => {
+      const subjectA = new BehaviorSubject(1);
+      const subjectB = new BehaviorSubject(2);
+
+      const spyA = vi.spyOn(subjectA, 'subscribe');
+      const spyB = vi.spyOn(subjectB, 'subscribe');
+
+      let activeSubject = subjectA as BehaviorSubject<number>;
+      const { result, rerender } = renderHook(() => useObservableState(activeSubject));
+
+      expect(result.current.value).toBe(1);
+
+      activeSubject = subjectB;
+      rerender();
+
+      expect(result.current.value).toBe(2);
+      expect(spyA).toHaveBeenCalledTimes(1);
+      expect(spyB).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use the latest initial value when the subject changes', () => {
+      const subjectA = new Subject<{ label: string }>();
+      const subjectB = new Subject<{ label: string }>();
+
+      let activeSubject = subjectA as Subject<{ label: string }>;
+      let initialValue = { label: 'first' };
+
+      const { result, rerender } = renderHook(() =>
+        useObservableState(activeSubject, { initial: initialValue }),
+      );
+
+      expect(result.current.value).toEqual({ label: 'first' });
+
+      // Switch to a new subject with an updated initial value.
+      activeSubject = subjectB;
+      initialValue = { label: 'second' };
+      rerender();
+
+      expect(result.current.value).toEqual({ label: 'second' });
+    });
+  });
+
+  describe('persist option', () => {
+    it('should not recreate the store when subject reference changes and persist=true', () => {
+      const subjectA = new BehaviorSubject(1);
+      const subjectB = new BehaviorSubject(99);
+
+      const spyA = vi.spyOn(subjectA, 'subscribe');
+      const spyB = vi.spyOn(subjectB, 'subscribe');
+
+      let activeSubject = subjectA as BehaviorSubject<number>;
+      const { result, rerender } = renderHook(() =>
+        useObservableState(activeSubject, { persist: true }),
+      );
+
+      expect(result.current.value).toBe(1);
+
+      // Swap subject — the store should ignore it because persist=true.
+      activeSubject = subjectB;
+      rerender();
+
+      expect(result.current.value).toBe(1);
+      expect(spyA).toHaveBeenCalledTimes(1);
+      expect(spyB).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
**Why is this change needed?**

`useObservableState` included `opt.initial` and `opt.teardown` as `useMemo` dependencies. Callers that pass non-memoized values — inline object literals for `initial`, arrow functions for `teardown` — produce a new reference on every render. This caused the store to be recreated on every render, resetting emitted state and in the worst case triggering an infinite re-render loop.

**What is the current behavior?**

Any non-memoized value passed to `opt.initial` or `opt.teardown` silently recreates the internal store on every render. State resets to the initial value each cycle, and components that pass inline options never stabilize.

**What is the new behavior?**

The store is recreated **only when the `subject` reference changes**. `initial` and `teardown` are held in refs that are updated on every render, so the store always reads the latest caller-provided values when a new subject is provided — without those values being `useMemo` dependencies.

A new `persist` option is added as an escape hatch for subjects that cannot be memoized at the call site:

```tsx
// stream is a prop with no stability guarantee — freeze it at first render
const { value } = useObservableState(stream, { persist: true });
```

When `persist: true`, the subject reference is frozen at mount and the store is never recreated, even if the caller provides a different observable instance on subsequent renders.

**What is the intended behavior or invariant?**

- The store is created exactly once per stable `subject` reference (or once per component lifetime when `persist: true`).
- `opt.initial` is applied once at store creation; `opt.teardown` is read at subscription time (always the latest ref value).
- Non-memoized `opt.initial` / `opt.teardown` values must never trigger a store recreation.
- `persist: true` silently ignores subject swaps after mount — callers must be aware they lose subject-swap reactivity.

**Does this PR introduce a breaking change?**

No. The change is additive (`persist` option) and corrective (store stability). Existing call sites that already memoize their subject are unaffected. Call sites that did not memoize and were silently broken will now behave correctly.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Fixes silent infinite re-render for callers passing non-memoized `initial`/`teardown`
- Downstream impact: None — no public API surface changed

**Review guidance:**

Focus on the implementation implementation in `useObservableState.ts`:

1. `initialRef` / `teardownRef` — updated unconditionally each render (except when `persist=true`). Verify the guard is correct.
2. `subjectRef` — frozen at mount when `persist=true`. Verify `useMemo` dep (`stream`) resolves to `subjectRef.current` in that branch.
3. Tests under `store stability` — spy on `subject.subscribe` to count store creations. Confirm the spy count assertions match expectations.
4. Tests under `persist option` — confirm the persisted subject is used and the swapped subject is ignored.

**Additional context**

The ref-as-stable-dep pattern (`useRef` objects have a stable identity guaranteed by React) is the standard solution for this class of problem. Including the ref objects themselves in the dep array satisfies `exhaustive-deps` without a disable comment, because their identity never changes.

**Related issues**

None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
