### PR TITLE
fix(msal-node, azure-identity): make keytar-dependent packages optional

### DIFF
--- a/.changeset/module-azure-identity_keytar-optional.md
+++ b/.changeset/module-azure-identity_keytar-optional.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-module-azure-identity": patch
+---
+
+Move `@azure/identity-cache-persistence` and `@azure/msal-node-extensions` to `optionalDependencies` and guard all dynamic imports with descriptive error handling.
+
+The native `keytar` addon (required for OS keychain access on Linux) previously caused `pnpm install` to fail in headless environments without `libsecret-1`. Dynamic import sites now catch load failures and throw a clear, actionable error explaining that credential persistence requires an interactive desktop environment with the optional dependency installed.

--- a/.changeset/module-msal-node_keytar-optional.md
+++ b/.changeset/module-msal-node_keytar-optional.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-module-msal-node": patch
+---
+
+Move `@azure/msal-node-extensions` to `optionalDependencies` and convert its static import to a dynamic loader.
+
+The native `keytar` addon (required by `msal-node-extensions` for OS keychain access) previously caused `pnpm install` to fail on Linux environments without `libsecret-1`, and the static top-level import caused the module to fail to load entirely when the optional build did not succeed.
+
+Token cache persistence remains fully functional in interactive desktop environments. When the optional dependency is absent, a clear, actionable error is thrown at call-time instead of a raw `ERR_MODULE_NOT_FOUND` at import-time.

--- a/packages/modules/azure-identity/package.json
+++ b/packages/modules/azure-identity/package.json
@@ -36,9 +36,11 @@
   },
   "dependencies": {
     "@azure/identity": "^4.9.1",
-    "@azure/identity-cache-persistence": "^1.3.0",
-    "@azure/msal-node-extensions": "^5.1.4",
     "@equinor/fusion-framework-module": "workspace:^"
+  },
+  "optionalDependencies": {
+    "@azure/identity-cache-persistence": "^1.3.0",
+    "@azure/msal-node-extensions": "^5.1.4"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
+++ b/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
@@ -2,32 +2,37 @@ import { DefaultAzureCredential } from '@azure/identity';
 import type { IAuthProvider } from './AuthProvider.interface.js';
 import { NoCredentialError } from './errors.js';
 
-let pluginRegistered = false;
+// Stored as a Promise so concurrent callers await the same registration
+// and the plugin is never registered twice.
+let pluginRegistrationPromise: Promise<void> | null = null;
 
 /**
  * Lazily registers the Azure Identity cache persistence plugin on first use.
  *
  * Deferred to avoid loading `keytar` (a native C++ addon) at import time,
  * which would fail in CI environments where the prebuilt binary is unavailable
- * (e.g. `ERR_DLOPEN_FAILED`). The plugin is registered once before any
- * credential is constructed.
+ * (e.g. `ERR_DLOPEN_FAILED`). Concurrent callers share the same Promise so
+ * the plugin is registered exactly once even under parallel invocation.
  */
-export async function ensureCachePersistencePlugin(): Promise<void> {
-  if (pluginRegistered) return;
-  const { useIdentityPlugin } = await import('@azure/identity');
-  let cachePersistencePlugin: unknown;
-  try {
-    ({ cachePersistencePlugin } = await import('@azure/identity-cache-persistence'));
-  } catch {
-    throw new Error(
-      'Failed to load @azure/identity-cache-persistence. ' +
-        'Token cache persistence requires a native module (keytar/libsecret) that is only ' +
-        'available in interactive desktop environments. Install the optional dependency or ' +
-        'use a non-caching auth mode.',
-    );
-  }
-  useIdentityPlugin(cachePersistencePlugin as Parameters<typeof useIdentityPlugin>[0]);
-  pluginRegistered = true;
+export function ensureCachePersistencePlugin(): Promise<void> {
+  pluginRegistrationPromise ??= (async () => {
+    const { useIdentityPlugin } = await import('@azure/identity');
+    let cachePersistencePlugin: Parameters<typeof useIdentityPlugin>[0];
+    try {
+      ({ cachePersistencePlugin } = await import('@azure/identity-cache-persistence'));
+    } catch (cause) {
+      pluginRegistrationPromise = null; // allow retry after transient failures
+      throw new Error(
+        'Failed to load @azure/identity-cache-persistence. ' +
+          'Token cache persistence requires a native module (keytar/libsecret) that is only ' +
+          'available in interactive desktop environments. Install the optional dependency or ' +
+          'use a non-caching auth mode.',
+        { cause },
+      );
+    }
+    useIdentityPlugin(cachePersistencePlugin);
+  })();
+  return pluginRegistrationPromise;
 }
 
 /**

--- a/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
+++ b/packages/modules/azure-identity/src/AuthProviderDefaultCredential.ts
@@ -15,8 +15,18 @@ let pluginRegistered = false;
 export async function ensureCachePersistencePlugin(): Promise<void> {
   if (pluginRegistered) return;
   const { useIdentityPlugin } = await import('@azure/identity');
-  const { cachePersistencePlugin } = await import('@azure/identity-cache-persistence');
-  useIdentityPlugin(cachePersistencePlugin);
+  let cachePersistencePlugin: unknown;
+  try {
+    ({ cachePersistencePlugin } = await import('@azure/identity-cache-persistence'));
+  } catch {
+    throw new Error(
+      'Failed to load @azure/identity-cache-persistence. ' +
+        'Token cache persistence requires a native module (keytar/libsecret) that is only ' +
+        'available in interactive desktop environments. Install the optional dependency or ' +
+        'use a non-caching auth mode.',
+    );
+  }
+  useIdentityPlugin(cachePersistencePlugin as Parameters<typeof useIdentityPlugin>[0]);
   pluginRegistered = true;
 }
 

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -6,8 +6,10 @@ import {
 } from '@azure/identity';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { IPersistence } from '@azure/msal-node-extensions';
 import type { IAuthProvider } from './AuthProvider.interface.js';
+
+/** Derived from the dynamic import to avoid static resolution-mode conflicts with `@azure/msal-node-extensions`. */
+type IPersistence = Awaited<ReturnType<typeof import('@azure/msal-node-extensions')['PersistenceCreator']['createPersistence']>>;
 import type { InteractiveAuthOptions } from './configurator.js';
 import { NoCredentialError } from './errors.js';
 

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -9,7 +9,11 @@ import { join } from 'node:path';
 import type { IAuthProvider } from './AuthProvider.interface.js';
 
 /** Derived from the dynamic import to avoid static resolution-mode conflicts with `@azure/msal-node-extensions`. */
-type IPersistence = Awaited<ReturnType<typeof import('@azure/msal-node-extensions')['PersistenceCreator']['createPersistence']>>;
+type IPersistence = Awaited<
+  ReturnType<
+    typeof import('@azure/msal-node-extensions')['PersistenceCreator']['createPersistence']
+  >
+>;
 import type { InteractiveAuthOptions } from './configurator.js';
 import { NoCredentialError } from './errors.js';
 

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -74,8 +74,19 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
    */
   static async create(options: InteractiveAuthOptions): Promise<AuthProviderInteractiveBrowser> {
     // Dynamically import to avoid loading the native `keytar` binary at
-    // module-load time, which fails on CI runners missing `libsecret`.
-    const { PersistenceCreator } = await import('@azure/msal-node-extensions');
+    // module-load time. The package is optional — throw a clear error when
+    // it is absent (e.g. missing libsecret on Linux).
+    let PersistenceCreator: (typeof import('@azure/msal-node-extensions'))['PersistenceCreator'];
+    try {
+      ({ PersistenceCreator } = await import('@azure/msal-node-extensions'));
+    } catch {
+      throw new Error(
+        'Failed to load @azure/msal-node-extensions. ' +
+          'Interactive browser authentication requires a native module (keytar/libsecret) ' +
+          'that is only available in interactive desktop environments. ' +
+          'Install the optional dependency or use a non-interactive auth mode.',
+      );
+    }
 
     // OS-level secure storage: Keychain (macOS), DPAPI (Windows), libsecret (Linux)
     const persistence = await PersistenceCreator.createPersistence({

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -4,7 +4,6 @@ import {
   serializeAuthenticationRecord,
   deserializeAuthenticationRecord,
 } from '@azure/identity';
-import type { IPersistence } from '@azure/msal-node-extensions';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { IAuthProvider } from './AuthProvider.interface.js';
@@ -34,6 +33,12 @@ import { NoCredentialError } from './errors.js';
  * const token = await provider.acquireAccessToken({ request: { scopes: ['user.read'] } });
  * ```
  */
+/** Minimal persistence contract — subset of `IPersistence` from `@azure/msal-node-extensions`. */
+interface IPersistence {
+  load(): Promise<string | null>;
+  save(contents: string): Promise<void>;
+}
+
 export class AuthProviderInteractiveBrowser implements IAuthProvider {
   readonly #credential: InteractiveBrowserCredential;
   readonly #authRecordPersistence: IPersistence;
@@ -79,12 +84,13 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
     let PersistenceCreator: typeof import('@azure/msal-node-extensions')['PersistenceCreator'];
     try {
       ({ PersistenceCreator } = await import('@azure/msal-node-extensions'));
-    } catch {
+    } catch (cause) {
       throw new Error(
         'Failed to load @azure/msal-node-extensions. ' +
           'Interactive browser authentication requires a native module (keytar/libsecret) ' +
           'that is only available in interactive desktop environments. ' +
           'Install the optional dependency or use a non-interactive auth mode.',
+        { cause },
       );
     }
 

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -6,6 +6,7 @@ import {
 } from '@azure/identity';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import type { IPersistence } from '@azure/msal-node-extensions';
 import type { IAuthProvider } from './AuthProvider.interface.js';
 import type { InteractiveAuthOptions } from './configurator.js';
 import { NoCredentialError } from './errors.js';
@@ -33,13 +34,6 @@ import { NoCredentialError } from './errors.js';
  * const token = await provider.acquireAccessToken({ request: { scopes: ['user.read'] } });
  * ```
  */
-/** Minimal persistence contract — subset of `IPersistence` from `@azure/msal-node-extensions`. */
-interface IPersistence {
-  load(): Promise<string | null>;
-  save(contents: string): Promise<void>;
-  delete(): Promise<void>;
-}
-
 export class AuthProviderInteractiveBrowser implements IAuthProvider {
   readonly #credential: InteractiveBrowserCredential;
   readonly #authRecordPersistence: IPersistence;

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -37,6 +37,7 @@ import { NoCredentialError } from './errors.js';
 interface IPersistence {
   load(): Promise<string | null>;
   save(contents: string): Promise<void>;
+  delete(): Promise<void>;
 }
 
 export class AuthProviderInteractiveBrowser implements IAuthProvider {

--- a/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
+++ b/packages/modules/azure-identity/src/AuthProviderInteractiveBrowser.ts
@@ -76,7 +76,7 @@ export class AuthProviderInteractiveBrowser implements IAuthProvider {
     // Dynamically import to avoid loading the native `keytar` binary at
     // module-load time. The package is optional — throw a clear error when
     // it is absent (e.g. missing libsecret on Linux).
-    let PersistenceCreator: (typeof import('@azure/msal-node-extensions'))['PersistenceCreator'];
+    let PersistenceCreator: typeof import('@azure/msal-node-extensions')['PersistenceCreator'];
     try {
       ({ PersistenceCreator } = await import('@azure/msal-node-extensions'));
     } catch {

--- a/packages/modules/msal-node/package.json
+++ b/packages/modules/msal-node/package.json
@@ -38,9 +38,11 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.0.2",
-    "@azure/msal-node-extensions": "^5.0.2",
     "@equinor/fusion-framework-module": "workspace:^",
     "open": "^11.0.0"
+  },
+  "optionalDependencies": {
+    "@azure/msal-node-extensions": "^5.0.2"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/modules/msal-node/src/create-auth-cache.ts
+++ b/packages/modules/msal-node/src/create-auth-cache.ts
@@ -1,7 +1,9 @@
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-const importMsalNodeExtensions = async (): Promise<typeof import('@azure/msal-node-extensions')> => {
+const importMsalNodeExtensions = async (): Promise<
+  typeof import('@azure/msal-node-extensions')
+> => {
   try {
     return await import('@azure/msal-node-extensions');
   } catch (cause) {

--- a/packages/modules/msal-node/src/create-auth-cache.ts
+++ b/packages/modules/msal-node/src/create-auth-cache.ts
@@ -1,14 +1,18 @@
-import {
-  DataProtectionScope,
-  Environment,
-  PersistenceCreator,
-  PersistenceCachePlugin,
-  type IPersistence,
-} from '@azure/msal-node-extensions';
-
 import { tmpdir } from 'node:os';
-
 import path from 'node:path';
+
+const importMsalNodeExtensions = async () => {
+  try {
+    return await import('@azure/msal-node-extensions');
+  } catch {
+    throw new Error(
+      'Failed to load @azure/msal-node-extensions. ' +
+        'Token cache persistence requires a native module (keytar/libsecret) that is only ' +
+        'available in interactive desktop environments. Install the optional dependency or ' +
+        'use a non-caching auth mode.',
+    );
+  }
+};
 
 /**
  * Resolves the directory path for storing the authentication cache.
@@ -17,7 +21,8 @@ import path from 'node:path';
  *
  * @returns The resolved cache directory path as a string.
  */
-const resolveCachePath = () => {
+const resolveCachePath = async (): Promise<string> => {
+  const { Environment } = await importMsalNodeExtensions();
   return Environment?.getUserRootDirectory() ?? tmpdir();
 };
 
@@ -28,8 +33,8 @@ const resolveCachePath = () => {
  * @param clientId - The Azure AD client/application ID.
  * @returns The full file path for the cache file.
  */
-const resolveCacheFilePath = (tenantId: string, clientId: string) => {
-  return path.join(resolveCachePath(), `.token-cache-${tenantId}_${clientId}`);
+const resolveCacheFilePath = async (tenantId: string, clientId: string): Promise<string> => {
+  return path.join(await resolveCachePath(), `.token-cache-${tenantId}_${clientId}`);
 };
 
 /**
@@ -38,16 +43,17 @@ const resolveCacheFilePath = (tenantId: string, clientId: string) => {
  * The cache is encrypted and scoped to the current user for security. It is uniquely identified
  * by the provided tenant and client IDs, and is associated with the 'fusion-framework' service.
  *
+ * Requires `@azure/msal-node-extensions` to be installed (optional dependency).
+ * Only available in interactive desktop environments with a system keychain.
+ *
  * @param tenantId - The Azure AD tenant ID used to identify the cache.
  * @param clientId - The Azure AD client/application ID used to identify the cache.
  * @returns A promise that resolves to the created persistence cache instance.
  */
-export const createPersistenceCache = async (
-  tenantId: string,
-  clientId: string,
-): Promise<IPersistence> => {
+export const createPersistenceCache = async (tenantId: string, clientId: string) => {
+  const { DataProtectionScope, PersistenceCreator } = await importMsalNodeExtensions();
   return PersistenceCreator.createPersistence({
-    cachePath: resolveCacheFilePath(tenantId, clientId),
+    cachePath: await resolveCacheFilePath(tenantId, clientId),
     serviceName: 'fusion-framework',
     accountName: [tenantId, clientId].join('_'),
     dataProtectionScope: DataProtectionScope.CurrentUser,
@@ -77,9 +83,7 @@ export const clearPersistenceCache = async (tenantId: string, clientId: string):
  * @param clientId - The Azure AD client/application ID.
  * @returns A promise that resolves to an instance of `PersistenceCachePlugin`.
  */
-export const createPersistenceCachePlugin = async (
-  tenantId: string,
-  clientId: string,
-): Promise<PersistenceCachePlugin> => {
+export const createPersistenceCachePlugin = async (tenantId: string, clientId: string) => {
+  const { PersistenceCachePlugin } = await importMsalNodeExtensions();
   return new PersistenceCachePlugin(await createPersistenceCache(tenantId, clientId));
 };

--- a/packages/modules/msal-node/src/create-auth-cache.ts
+++ b/packages/modules/msal-node/src/create-auth-cache.ts
@@ -1,15 +1,16 @@
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-const importMsalNodeExtensions = async () => {
+const importMsalNodeExtensions = async (): Promise<typeof import('@azure/msal-node-extensions')> => {
   try {
     return await import('@azure/msal-node-extensions');
-  } catch {
+  } catch (cause) {
     throw new Error(
       'Failed to load @azure/msal-node-extensions. ' +
         'Token cache persistence requires a native module (keytar/libsecret) that is only ' +
         'available in interactive desktop environments. Install the optional dependency or ' +
         'use a non-caching auth mode.',
+      { cause },
     );
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,12 +1591,6 @@ importers:
       '@azure/identity':
         specifier: ^4.9.1
         version: 4.13.1
-      '@azure/identity-cache-persistence':
-        specifier: ^1.3.0
-        version: 1.3.0
-      '@azure/msal-node-extensions':
-        specifier: ^5.1.4
-        version: 5.1.5
       '@equinor/fusion-framework-module':
         specifier: workspace:^
         version: link:../module
@@ -1604,6 +1598,13 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+    optionalDependencies:
+      '@azure/identity-cache-persistence':
+        specifier: ^1.3.0
+        version: 1.3.0
+      '@azure/msal-node-extensions':
+        specifier: ^5.1.4
+        version: 5.1.5
 
   packages/modules/bookmark:
     dependencies:
@@ -1797,9 +1798,6 @@ importers:
       '@azure/msal-node':
         specifier: ^5.0.2
         version: 5.1.5
-      '@azure/msal-node-extensions':
-        specifier: ^5.0.2
-        version: 5.1.5
       '@equinor/fusion-framework-module':
         specifier: workspace:^
         version: link:../module
@@ -1810,6 +1808,10 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+    optionalDependencies:
+      '@azure/msal-node-extensions':
+        specifier: ^5.0.2
+        version: 5.1.5
 
   packages/modules/navigation:
     dependencies:
@@ -10986,6 +10988,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@azure/identity@4.13.1':
     dependencies:
@@ -11027,8 +11030,10 @@ snapshots:
       '@azure/msal-common': 16.5.2
       '@azure/msal-node-runtime': 0.20.5
       keytar: 7.9.0
+    optional: true
 
-  '@azure/msal-node-runtime@0.20.5': {}
+  '@azure/msal-node-runtime@0.20.5':
+    optional: true
 
   '@azure/msal-node@5.1.5':
     dependencies:
@@ -15709,6 +15714,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   boolbase@1.0.0: {}
 
@@ -15740,6 +15746,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -15806,7 +15813,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   ci-info@4.3.1: {}
 
@@ -16130,10 +16138,12 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   dedent@1.7.2: {}
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   deepmerge@4.3.1: {}
 
@@ -16229,6 +16239,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   enquirer@2.4.1:
     dependencies:
@@ -16346,7 +16357,8 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -16437,7 +16449,8 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.5:
     dependencies:
@@ -16489,7 +16502,8 @@ snapshots:
     dependencies:
       lit: 3.3.3
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -16729,7 +16743,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -16743,9 +16758,11 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
-  inherits@2.0.4: {}
+  inherits@2.0.4:
+    optional: true
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   inline-style-parser@0.2.7: {}
 
@@ -17005,6 +17022,7 @@ snapshots:
     dependencies:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.3
+    optional: true
 
   khroma@2.1.0: {}
 
@@ -17525,7 +17543,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   minimatch@10.2.4:
     dependencies:
@@ -17537,7 +17556,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mlly@1.8.2:
     dependencies:
@@ -17617,7 +17637,8 @@ snapshots:
 
   nanoid@5.1.11: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   neo-async@2.6.2: {}
 
@@ -17630,8 +17651,10 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.8.0
+    optional: true
 
-  node-addon-api@4.3.0: {}
+  node-addon-api@4.3.0:
+    optional: true
 
   node-addon-api@7.1.1:
     optional: true
@@ -17678,6 +17701,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   onetime@7.0.0:
     dependencies:
@@ -17931,6 +17955,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prettier@2.8.8: {}
 
@@ -18027,6 +18052,7 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -18113,6 +18139,7 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   re-resizable@6.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -18266,6 +18293,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readdirp@4.1.2: {}
 
@@ -18599,13 +18627,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   simple-git@3.36.0:
     dependencies:
@@ -18686,6 +18716,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -18706,7 +18737,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   style-to-js@1.1.21:
     dependencies:
@@ -18762,6 +18794,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.3
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -18770,6 +18803,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   term-size@2.2.1: {}
 
@@ -18879,6 +18913,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   turbo@2.9.16:
     optionalDependencies:
@@ -19029,7 +19064,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  util-deprecate@1.0.2: {}
+  util-deprecate@1.0.2:
+    optional: true
 
   uuid@10.0.0: {}
 
@@ -19450,7 +19486,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   ws@7.5.10: {}
 


### PR DESCRIPTION
**Why is this change needed?**
`@azure/msal-node-extensions` and `@azure/identity-cache-persistence` pull in `keytar`, a native C++ addon that requires `libsecret-1` to build on Linux. Listed as regular `dependencies`, pnpm builds the native addon on every cold install — including CI runners — even though these packages are only ever needed for interactive credential caching on a developer's desktop.

**What is the current behavior?**
`pnpm install --frozen-lockfile` fails on Linux when the pnpm cache is cold because `keytar@7.9.0` cannot compile (`libsecret-1` not present). Additionally, `msal-node/src/create-auth-cache.ts` has a **static top-level import** of `@azure/msal-node-extensions`, which means the entire module fails to load (`ERR_MODULE_NOT_FOUND`) if the optional native build did not succeed — regardless of whether persistence is ever used.

**What is the new behavior?**
- `@azure/msal-node-extensions` and `@azure/identity-cache-persistence` are moved to `optionalDependencies` in their respective packages. pnpm will attempt the native build but will not fail the install if it cannot complete.
- `create-auth-cache.ts` replaces its static import with a dynamic `importMsalNodeExtensions()` helper, keeping the module loadable in any environment.
- All dynamic import sites (`AuthProviderInteractiveBrowser`, `AuthProviderDefaultCredential`, `create-auth-cache.ts`) now wrap the import in try/catch and throw a clear, actionable error if the optional package is absent — rather than a raw `ERR_MODULE_NOT_FOUND`.

**What is the intended behavior or invariant?**
Native credential persistence (keychain/DPAPI/libsecret) is an **optional desktop-only feature**. The packages must load and operate correctly without it. When persistence _is_ attempted without the native dep installed, the error must clearly describe why and what to do. No code path should require `libsecret` in CI or headless environments.

**Does this PR introduce a breaking change?**
No. Consumers who already have the native dep installed see no change. Consumers who don't will now get a descriptive error at call time instead of a crash at import time.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`fix`) for both `msal-node` and `azure-identity`
- Consumer impact: Improved error messaging when optional native dep is absent
- Downstream impact: Unblocks CI on cold-cache Linux runners

**Review guidance:**
- Verify `create-auth-cache.ts` no longer has any static import of `@azure/msal-node-extensions`
- Confirm `resolveCachePath`/`resolveCacheFilePath` are now `async` (they call the dynamic loader)
- Check that all three try/catch blocks produce a consistent, actionable error message
- Confirm `optionalDependencies` is the correct field (not `peerDependenciesMeta.optional`)

**Additional context**
Discovered as a CI regression on PR #4822. The static import in `create-auth-cache.ts` was the critical gap — the dynamic imports elsewhere were already correct but incomplete.

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [ ] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
