### PR TITLE
Fix/observable use observable state stable store

### DIFF
--- a/.changeset/fusion-observable_fix-use-observable-state-loop.md
+++ b/.changeset/fusion-observable_fix-use-observable-state-loop.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Fix useObservableState rerender loops caused by stateful observables that synchronously emit an unchanged current value on subscribe.
+
+The hook now skips redundant notifications when value, error, or complete state is unchanged, preventing infinite render/subscription cycles in apps with unstable observable references.

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -132,14 +132,29 @@ function createObservableStateStore<TType, TError = unknown>(
 
       const subscription = subject.subscribe({
         next: (value) => {
+          // Avoid notifying React when the emitted value does not change the snapshot.
+          // This prevents rerender loops for stateful observables that emit their current
+          // value synchronously on subscribe.
+          if (Object.is(snapshot.value, value)) {
+            return;
+          }
+
           snapshot = { ...snapshot, value };
           notify();
         },
         error: (error) => {
+          if (Object.is(snapshot.error, error)) {
+            return;
+          }
+
           snapshot = { ...snapshot, error: error as TError };
           notify();
         },
         complete: () => {
+          if (snapshot.complete) {
+            return;
+          }
+
           snapshot = { ...snapshot, complete: true };
           notify();
         },

--- a/packages/utils/observable/tests/react/useObservableState.test.ts
+++ b/packages/utils/observable/tests/react/useObservableState.test.ts
@@ -42,6 +42,14 @@ describe('useObservableState', () => {
     expect(result.current.complete).toBe(false);
   });
 
+  it('should not enter an update loop when a stateful observable is created in render', () => {
+    const { result } = renderHook(() => useObservableState(new BehaviorSubject(1)));
+
+    expect(result.current.value).toBe(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.complete).toBe(false);
+  });
+
   it('should prioritize explicit initial value over stateful observable value', () => {
     const subject: Subject<number> & StatefulObservable<number> = Object.assign(
       new Subject<number>(),


### PR DESCRIPTION

Fix useObservableState rerender loops caused by stateful observables that synchronously emit an unchanged current value on subscribe.

The hook now skips redundant notifications when value, error, or complete state is unchanged, preventing infinite render/subscription cycles in apps with unstable observable references.