### PR TITLE
docs(skills): compress custom skill catalog

### DIFF
--- a/.agents/skills/custom-dependency-pr-solver/SKILL.md
+++ b/.agents/skills/custom-dependency-pr-solver/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: custom-dependency-pr-solver
-description: 'Batch-process Dependabot PRs end-to-end: checkout, rebase, review, changeset, validate, and auto-merge high-confidence PRs. USE FOR: process all Dependabot PRs, clear dependency backlog, batch-merge safe Dependabot updates, batch-process dependency PRs. DO NOT USE FOR: single-PR deep review (use fusion-dependency-review), feature PRs, non-Dependabot dependency PRs, or PRs requiring manual code changes.'
+description: 'Batch-processes Dependabot PRs in Fusion Framework: list, confirm, checkout, rebase, review, changeset, validate, comment, and merge high-confidence updates. USE FOR: process all Dependabot PRs, clear dependency backlog, batch-merge safe dependency updates. DO NOT USE FOR: feature PRs, non-Dependabot PRs, single-PR deep review, or updates needing manual code changes.'
 license: MIT
-compatibility: Requires GitHub CLI (`gh`) authenticated with admin merge rights. Requires pnpm and the Fusion Framework monorepo build toolchain.
+compatibility: Requires authenticated `gh` with merge rights, `pnpm`, and the Fusion Framework monorepo toolchain.
 metadata:
   version: "0.1.0"
   status: experimental
@@ -20,128 +20,86 @@ metadata:
 
 # Dependency PR Solver
 
-Batch workflow that processes open Dependabot PRs sequentially. Delegates per-PR research, lens analysis, and verdicts to `fusion-dependency-review`. This skill owns batch orchestration, source-control operations, changeset creation, auto-merge, and reporting.
+## When To Use
 
-## When to use
+Use for an approved batch pass over open Dependabot PRs where the agent may mutate branches, post comments, create changesets, validate, and merge high-confidence updates.
 
-Typical triggers:
+Trigger phrases:
+- "process all Dependabot PRs"
+- "clear the dependency backlog"
+- "batch-process dependency PRs"
+- "batch-merge safe Dependabot updates"
 
-- "Process all open Dependabot PRs"
-- "Clear the dependency PR backlog"
-- "Batch-process dependency PRs"
-- "Batch-merge safe Dependabot updates"
-- "Solve all dependency PRs"
+## Hard Gates
 
-## When not to use
+- Read `.github/instructions/dependabot-pr.instructions.md` before processing any PR.
+- Ask for explicit user confirmation before starting the batch and before expanding scope.
+- Process only PRs authored by `app/dependabot` unless the user overrides with a specific PR.
+- Rebase onto the PR base branch; never merge the base branch into a Dependabot branch.
+- Do not merge major bumps, failing validation, low-confidence updates, or PRs needing manual code changes.
+- Always post research and verdict comments before merging.
 
-- Deep single-PR review → use `fusion-dependency-review`
-- Feature PRs or application code reviews
-- PRs requiring manual code changes beyond changesets
-- When you lack admin merge rights
+## Inputs
 
-## Required inputs
+- Repository owner/name, inferred from workspace when possible.
+- PR scope: all open Dependabot PRs or an include/exclude list.
+- Mode: normal, `--review-only`, or `--merge-medium` with explicit user approval.
 
-- **Repository**: owner and name (infer from workspace when possible)
-- **Confirmation**: explicit user approval before starting the batch
+## Workflow
 
-Optional: PR filter (include/exclude numbers), `--review-only` (skip merge), `--merge-medium` (merge medium-confidence too).
-
-## Delegation
-
-This skill delegates per-PR analysis to `fusion-dependency-review`:
-
-- **Research** — upstream changelog, breaking changes, security, existing discussion
-- **Lens analysis** — security, code quality, impact assessments
-- **Verdict** — recommendation and confidence scoring
-
-Changeset rules, confidence criteria, rebase strategy, and validation commands follow `.github/instructions/dependabot-pr.instructions.md`.
-
-## Instructions
-
-### Step 1 — List and triage
+1. List candidates:
 
 ```bash
 gh pr list --author "app/dependabot" --state open --json number,title,headRefName,baseRefName,mergeable,statusCheckRollup
 ```
 
-Present a summary table and ask the user to confirm which PRs to process or confirm "all".
+Show a compact table and get confirmation.
 
-### Step 2 — Process each PR sequentially
+2. For each confirmed PR:
+   - `git fetch origin <base-branch>`
+   - `gh pr checkout <number>`
+   - `git rebase origin/<base-branch>`
+   - On conflict, abort, mark `needs-manual-intervention`, and continue to the next PR.
+   - Push rebased branch with `git push --force-with-lease`.
 
-For each confirmed PR, execute Steps 3–7. If a PR fails at any step, log the failure, skip to the next, and include it in the final report.
+3. Validate dependency state:
+   - Run `pnpm install --frozen-lockfile`.
+   - If the lockfile must change, run `pnpm install`, commit the lockfile-only fix, and push.
 
-### Step 3 — Checkout and rebase
+4. Review:
+   - Delegate analysis to `fusion-dependency-review`.
+   - Capture upstream changes, security notes, existing discussion, impact, and confidence.
+   - Post research with `assets/research-comment-template.md`.
 
-Follow the rebase strategy in `.github/instructions/dependabot-pr.instructions.md`:
+5. Changesets:
+   - Follow `.github/instructions/dependabot-pr.instructions.md`.
+   - Create, commit, and push only required changesets.
 
-1. `git fetch origin <base-branch> && gh pr checkout <number>`
-2. `git rebase origin/<base-branch>`
-3. On conflict: abort, mark `needs-manual-intervention`, skip.
-4. `git push --force-with-lease`
-5. `pnpm install --frozen-lockfile` (if lockfile drifts: `pnpm install`, commit, push).
-
-### Step 4 — Review via fusion-dependency-review
-
-Run the `fusion-dependency-review` workflow for this PR:
-
-1. Research upstream changes and existing PR discussion.
-2. Assess security, code quality, and impact.
-3. Post a research comment using `assets/research-comment-template.md`.
-4. Produce a confidence score (high / medium / low) using the criteria in `.github/instructions/dependabot-pr.instructions.md`.
-
-Keep research focused — do not deep-dive unless a concern surfaces.
-
-### Step 5 — Create changesets
-
-Follow the changeset decision rules in `.github/instructions/dependabot-pr.instructions.md`. Create, commit, and push changesets for affected published packages.
-
-### Step 6 — Validate
+6. Validate:
 
 ```bash
 pnpm test && pnpm build && pnpm -w check
 ```
 
-On failure: attempt trivial fixes (e.g., `pnpm format`). If non-trivial, mark `needs-manual-intervention`.
+Attempt only trivial fixes. Mark anything else for manual intervention.
 
-### Step 7 — Merge or report
+7. Decide:
+   - High confidence: post verdict from `assets/verdict-comment-template.md`, then `gh pr merge <number> --squash --admin`.
+   - Medium confidence: merge only with `--merge-medium` approval; otherwise report.
+   - Low confidence or failed validation: post verdict and do not merge.
 
-**High confidence:**
+8. Finish:
+   - Return to `main`.
+   - Report every PR as merged, skipped, failed, or needs manual intervention.
 
-1. Post verdict comment using `assets/verdict-comment-template.md`.
-2. `gh pr merge <number> --squash --admin`
+## Expected Output
 
-**Medium or low confidence:**
+| PR | Status | Confidence | Action |
+|---|---|---|---|
+| `#N` | merged/skipped/failed | high/medium/low | short reason |
 
-1. Post verdict comment with findings.
-2. Do not merge. Include in final report.
+Also include posted-comment status, changeset files, validation results, and manual follow-ups.
 
-### Step 8 — Final batch report
+## Safety
 
-| PR | Title | Status | Confidence | Action |
-|----|-------|--------|------------|--------|
-| #N | ... | merged / skipped / failed | high/med/low | merged / needs review / needs intervention |
-
-## Expected output
-
-- Research and verdict comments posted to each processed PR
-- Changesets created where required
-- High-confidence PRs merged via admin squash
-- Final batch summary table
-- List of PRs needing manual intervention with reasons
-
-## Safety & constraints
-
-- This skill is mutation-capable. `.github/instructions/dependabot-pr.instructions.md` takes precedence on conflicts.
-
-Never:
-
-- Merge without posting research and verdict comments first
-- Merge a PR with failing validation
-- Merge major version bumps without explicit user override
-- Merge the base branch into a Dependabot PR branch (rebase only)
-- Force-push without `--force-with-lease`
-- Process PRs without initial user confirmation
-
-Always:
-
-- Return to `main` after batch processing is complete
+Never merge without validation, comments, and confidence. Never force-push without `--force-with-lease`. Never continue a conflicted Dependabot rebase by guessing.

--- a/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
+++ b/.agents/skills/custom-dependency-pr-solver/assets/research-comment-template.md
@@ -1,41 +1,27 @@
-# 🤖 Dependency Update Research
-
-## PR Snapshot
+# Dependency Update Research
 
 | Signal | Notes |
-| ------ | ----- |
+|---|---|
 | PR | `#<number>` |
-| Change scope | `<lockfile-only / manifest + lockfile>` |
-| CI status | `<passing/failing/pending/unknown>` |
-| Branch health | `<current / behind base / rebased>` |
+| Scope | `<lockfile-only | manifest + lockfile>` |
+| CI | `<passing | failing | pending | unknown>` |
+| Branch | `<current | rebased | blocked>` |
 
-## Dependencies Updated
+## Updated Dependencies
 
-| Dependency | From | To | Lane | Consumer role |
-|------------|------|----|------|---------------|
-| `<name>` | `<from>` | `<to>` | `<patch/minor/major>` | `<runtime / build / test / dev-tooling>` |
-| `<name>` | `<from>` | `<to>` | `<patch/minor/major>` | `<runtime / build / test / dev-tooling>` |
+| Dependency | From | To | Lane | Role |
+|---|---|---|---|---|
+| `<name>` | `<from>` | `<to>` | `<patch | minor | major>` | `<runtime | build | test | tooling>` |
 
-## Upstream Changes
+## Findings
 
-<!-- Key changelog entries, new features, deprecations, or behavioral changes. -->
-
-## Breaking Changes
-
-<!-- Concrete breakage or migration work. "None identified" if clean. -->
-
-## Security
-
-<!-- CVEs, advisories, or supply-chain concerns. "No advisories found" if clean. -->
-
-## Affected Packages
-
-| Package | Dependency role | Changeset needed |
-|---------|----------------|-----------------|
-| `@equinor/<name>` | `<prod/dev/peer>` | `<yes/no>` |
+- Upstream changes: `<summary or none identified>`
+- Breaking changes: `<summary or none identified>`
+- Security: `<advisory summary or none found>`
+- Affected packages: `<packages and changeset need>`
 
 ## Sources
 
 - Changelog: `<link>`
-- npm: `<link>`
-- Advisory: `<link or "none">`
+- Package registry: `<link>`
+- Advisory: `<link or none>`

--- a/.agents/skills/custom-dependency-pr-solver/assets/verdict-comment-template.md
+++ b/.agents/skills/custom-dependency-pr-solver/assets/verdict-comment-template.md
@@ -1,42 +1,31 @@
-# 🤖 Dependency Update Verdict
-
-## Decision
+# Dependency Update Verdict
 
 | Signal | Notes |
-| ------ | ----- |
-| Recommendation | `<merge / hold / decline>` |
-| Confidence | `<high / medium / low>` |
+|---|---|
+| Recommendation | `<merge | hold | decline>` |
+| Confidence | `<high | medium | low>` |
+| Action | `<merged | skipped | needs review>` |
 
-## Validation Results
+## Validation
 
 | Check | Status | Notes |
-|-------|--------|-------|
-| Build (`pnpm build`) | `<pass/fail>` | |
-| Test (`pnpm test`) | `<pass/fail>` | |
-| Lint & Format (`pnpm -w check`) | `<pass/fail>` | |
+|---|---|---|
+| `pnpm build` | `<pass | fail | skipped>` | `<notes>` |
+| `pnpm test` | `<pass | fail | skipped>` | `<notes>` |
+| `pnpm -w check` | `<pass | fail | skipped>` | `<notes>` |
 
 ## Changesets
 
 | Package | Bump | File |
-|---------|------|------|
-| `@equinor/<name>` | `patch` | `.changeset/<filename>.md` |
+|---|---|---|
+| `@equinor/<name>` | `<patch | minor | major | none>` | `.changeset/<file>.md` |
 
 ## Assessment
 
-### Security
-- Signal: `<clear / concern / blocking>`
-- Detail: <!-- brief note -->
+- Security: `<clear | concern | blocking>` - `<detail>`
+- Compatibility: `<clear | concern | blocking>` - `<detail>`
+- Impact: `<clear | concern | blocking>` - `<detail>`
 
-### Compatibility
-- Signal: `<clear / concern / blocking>`
-- Detail: <!-- brief note -->
+## Next Step
 
-### Impact
-- Signal: `<clear / concern / blocking>`
-- Detail: <!-- brief note -->
-
-## Action
-
-`<Merged via admin squash / Skipped — needs manual review / Skipped — validation failure>`
-
-<!-- If merged: commit SHA. If skipped: specific reason and recommended next steps. -->
+`<Merged via admin squash | skipped because ... | awaiting manual review because ...>`

--- a/.agents/skills/custom-index-eval/SKILL.md
+++ b/.agents/skills/custom-index-eval/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: custom-index-eval
-description: 'Iterative evaluation of Fusion Framework MCP search quality against documented domain patterns. Loads domain files from eval/index/, queries Fusion MCP for each pattern, validates recall against must/should requirements, and produces a human-readable pass/fail report. USE FOR: eval core, eval all, evaluate MCP index accuracy, validate search recall for a domain, check index freshness. DO NOT USE FOR: writing domain patterns, populating eval/index/ files, running CI pipelines, or batch automation.'
+description: 'Evaluates Fusion MCP search quality against eval/index domain files. USE FOR: eval core, eval all, validate MCP index recall, check search freshness, verify documented framework patterns. DO NOT USE FOR: authoring eval patterns, editing docs, CI automation, or application-development search answers.'
 license: MIT
-compatibility: Requires Fusion MCP access via `mcp_fusion_search` or `mcp_fusion_search_framework`. Works in any runtime that can read local files and call MCP tools.
+compatibility: Requires Fusion MCP search tools and local access to `eval/index/`.
 metadata:
   version: "0.2.0"
   status: experimental
@@ -12,8 +12,6 @@ metadata:
     - mcp
     - search
     - index
-    - quality
-    - validation
     - fusion-framework
   mcp:
     required:
@@ -22,139 +20,59 @@ metadata:
 
 # Evaluate Fusion MCP Search Index
 
-## When to use
+## When To Use
 
-Use this skill to evaluate whether Fusion MCP search returns accurate, relevant results for documented framework patterns.
+Use when the user wants a pass/fail read on whether Fusion MCP returns the expected framework knowledge for documented query patterns.
 
-Typical triggers:
-- `eval core` — evaluate all patterns in `eval/index/core.md`
-- `eval http-services` — evaluate patterns in `eval/index/http-services.md`
-- `eval all` — evaluate every domain file in `eval/index/`
-- "check MCP index accuracy for auth patterns"
-- "validate search recall for the state-data domain"
-- "how well does the index cover framework initialization?"
-- "run an eval pass against the index"
+Trigger phrases:
+- `eval core`
+- `eval <domain>`
+- `eval all`
+- "check MCP index accuracy"
+- "validate search recall"
+- "is the index stale?"
 
-## When not to use
+## Inputs
 
-Do not use this skill for:
-- Writing or populating domain pattern files (use normal editing workflow)
-- Creating new domain files in `eval/index/` (follow the README template)
-- CI/CD integration or scheduled evaluation runs (future phase)
-- Batch automation without human review (future phase)
-- Searching the index for application development answers (use Fusion MCP directly)
+- Domain target: `all` or a file stem under `eval/index/`, such as `core`.
+- Strictness: `full` by default, or `strict` for `must` expectations only.
 
-## Required inputs
+Ask one question if the user says only `eval`.
 
-Collect before execution:
-- **Domain target**: a specific domain file name (e.g., `core`, `http-services`) or `all`
-- **Evaluation strictness** (optional): `strict` (must patterns only) or `full` (must + should); default is `full`
+## Workflow
 
-If the user says only `eval` with no domain, ask which domain to evaluate or whether to run `all`.
+1. Resolve domain files:
+   - `<domain>` maps to `eval/index/<domain>.md`.
+   - `all` means every markdown file in `eval/index/` except `README.md`.
+   - Skip empty files or files without `##` query headings.
 
-## Instructions
+2. Parse each domain file:
+   - `#` heading is the domain name.
+   - Text under `#` is judgement guidance for every query.
+   - Each `##` heading is the MCP query.
+   - `- must ...` and `- should ...` bullets are expectations.
 
-### Step 1 — Resolve domain files
+3. Judge each query:
+   - Prefer the `agents/query-judge.md` sub-agent.
+   - If sub-agents are unavailable, run the same flow inline.
+   - Search with `mcp_fusion_search_framework` first, then `mcp_fusion_search` if needed.
+   - Verdicts are `pass`, `partial`, or `fail`; never inflate ambiguous results.
 
-1. If the target is a specific domain (e.g., `core`), read `eval/index/<domain>.md`
-2. If the target is `all`, list all `.md` files in `eval/index/` except `README.md` and process each one sequentially
-3. If the file does not exist or has no `##` query sections, report it as empty and skip
+4. Report using `assets/report-template.md`:
+   - Include date, domain file, strictness, verdict table, summary counts, and recommendations.
+   - For `all`, lead with per-domain summary before detailed results.
+   - Call out `must` failures as critical index gaps.
 
-### Step 2 — Parse the domain file
+## Safety
 
-Domain files have a simple structure:
+- Read-only repository behavior; do not edit eval files, docs, or index content.
+- MCP calls are read-only.
+- Stop clearly if MCP is unavailable or rate-limited.
+- Do not cache verdicts across sessions; results represent current index state.
 
-- `# Domain Name` — the domain heading
-- Paragraph below `#` — **judgement instructions** for how to evaluate results across all queries in this domain
-- `## <query>` — each `##` heading is a search query to run against MCP
-- `- must ...` / `- should ...` — expectations for each query's results
+## Expected Output
 
-Extract the judgement instructions once (use them as context when evaluating every query). Then build a list of queries, each with its `must` and `should` expectations.
-
-### Step 3 — Evaluate each query via judge sub-agent
-
-For each `##` heading, spin up a **query-judge** sub-agent (see `agents/query-judge.md`). Pass it:
-
-- The heading text (search query)
-- The `must` and `should` bullets for that query
-- The domain-level judgement instructions
-
-The judge sub-agent will:
-1. Search MCP using the heading text
-2. Check results against each expectation
-3. Return a verdict (`pass` / `partial` / `fail`) with counts and explanation
-
-If the runtime does not support sub-agents, follow the same workflow inline:
-1. Use the heading text as the search query
-2. Call `mcp_fusion_search_framework` (preferred) or `mcp_fusion_search`
-3. Check results against each `must` / `should` bullet
-4. Record verdict with explanation
-
-Collect all verdicts before producing the report.
-
-### Step 4 — Generate the evaluation report
-
-Produce a report following the template in `assets/report-template.md`. The report includes:
-
-1. **Header**: domain name, evaluation date, strictness level
-2. **Pattern results table**: one row per pattern with name, requirement, verdict, and explanation
-3. **Summary statistics**: total patterns, pass/partial/fail counts, pass rate
-4. **Recommendations**: actionable next steps for failed or partial patterns
-
-### Step 5 — Present results
-
-- Print the full report to the conversation
-- For `eval all`, present a per-domain summary first, then offer to show detailed results for any domain
-- Highlight `must` failures prominently — these indicate critical index gaps
-- Suggest concrete remediation for each failure (e.g., "re-index package X", "add documentation for Y")
-
-## Expected output
-
-A structured evaluation report containing:
-- Per-pattern pass/partial/fail verdicts with explanations
-- Summary statistics (total, pass rate, must vs should breakdown)
-- Prioritized recommendations for improving index coverage
-- Clear identification of stale or missing content
-
-## Example: `eval core`
-
-**User:** `eval core`
-
-**Workflow:**
-1. Read `eval/index/core.md`
-2. Note judgement instructions: "Results should reference `@equinor/fusion-framework` and `@equinor/fusion-framework-module`..."
-3. Extract 5 queries from `##` headings
-4. For each, search MCP and check `must`/`should` bullets
-5. Produce report:
-
-```
-## Evaluation Report: core
-
-Date: 2026-03-14
-Strictness: full
-Domain: eval/index/core.md
-
-| # | Query | Verdict | Explanation |
-|---|-------|---------|-------------|
-| 1 | How to initialize Fusion Framework | pass | Results mention FrameworkConfigurator, init, configureMsal |
-| 2 | How to create a custom module | pass | Module interface, BaseConfigBuilder, BaseModuleProvider all covered |
-| 3 | Module lifecycle phases | partial | Lifecycle order shown but postConfigure/postInitialize hooks not detailed |
-| 4 | How to configure an app with AppModuleInitiator | fail | No results reference AppModuleInitiator |
-| 5 | How to listen to framework events | pass | addEventListener, dispatchEvent, event module all returned |
-
-### Summary
-- Queries: 5 | Pass: 3 | Partial: 1 | Fail: 1
-- Must expectations met: 14/17 (82%)
-
-### Recommendations
-1. **[CRITICAL]** Query 4: Re-index `packages/app/src/types.ts` and `cookbooks/app-react/src/config.ts`
-2. **[IMPROVE]** Query 3: Enrich lifecycle section in `packages/modules/module/README.md`
-```
-
-## Safety & constraints
-
-- This skill is read-only with respect to the repository — it never modifies domain files or index content
-- MCP search calls are read-only queries; no mutations are performed
-- Do not fabricate pass verdicts — if results are ambiguous, mark as `partial` with explanation
-- If MCP is unavailable or rate-limited, report the failure clearly and stop; do not retry in a loop
-- Evaluation results reflect index state at query time; they are not cached across sessions
+- Per-query verdicts with one-sentence explanations
+- Must/should satisfaction counts
+- Pass rate and failure summary
+- Concrete recommendations for stale, missing, or weak search coverage

--- a/.agents/skills/custom-index-eval/agents/query-judge.md
+++ b/.agents/skills/custom-index-eval/agents/query-judge.md
@@ -1,40 +1,33 @@
 # Query Judge
 
-Evaluates a single MCP search query against documented expectations from a domain file.
-
-## Role
-
-You are a strict evaluator. Given a search query, its must/should expectations, domain-level judgement instructions, and MCP search results, determine whether the results satisfy the expectations. Return a verdict only — do not fix, edit, or suggest changes to the index.
+Strictly evaluates one Fusion MCP search query against one domain-file pattern. Do not edit files or fix the index.
 
 ## Inputs
 
-- **Query**: the `##` heading text from the domain file (used as the search query)
-- **Expectations**: the `- must ...` and `- should ...` bullets for this query
-- **Judgement instructions**: the domain-level preamble (below the `#` heading)
-- **MCP results**: the search results returned by `mcp_fusion_search_framework` or `mcp_fusion_search`
+- Query: the `##` heading text.
+- Expectations: `must` and `should` bullets.
+- Domain guidance: text below the domain `#` heading.
+- MCP results from `mcp_fusion_search_framework` or `mcp_fusion_search`.
 
 ## Workflow
 
-1. Read the domain-level judgement instructions. These apply to every query in the domain.
-2. Search MCP using the query heading text via `mcp_fusion_search_framework` (preferred) or `mcp_fusion_search`.
-3. For each `must` expectation, check whether any returned result satisfies it. Be precise — the expectation names specific symbols, packages, or concepts.
-4. For each `should` expectation, check the same way but with lighter weight.
-5. Apply the domain-level judgement instructions as a cross-cutting filter (e.g., reject results with relative imports if the domain instructions say so).
-6. Produce a verdict.
+1. Search with `mcp_fusion_search_framework`; fall back to `mcp_fusion_search` if needed.
+2. Check each `must` expectation against returned symbols, package names, concepts, and paths.
+3. Check `should` expectations with lighter weight.
+4. Apply domain guidance as a filter.
+5. Return one verdict only.
 
-## Verdict scale
+## Verdicts
 
-- **pass** — all `must` expectations met, most `should` expectations met
-- **partial** — all `must` met but `should` largely missing, OR some `must` missed but results are relevant
-- **fail** — critical `must` expectations not met, or no relevant results returned
+- `pass`: all `must` and most `should` expectations are met.
+- `partial`: results are relevant but weak, or some `must` expectations are missing.
+- `fail`: critical `must` expectations are missing or results are irrelevant.
 
-## Output contract
+## Output
 
-Return exactly:
-
-- **Query**: the heading text
-- **Verdict**: `pass`, `partial`, or `fail`
-- **Must met**: count of must expectations satisfied / total must expectations
-- **Should met**: count of should expectations satisfied / total should expectations
-- **Explanation**: one sentence noting which key expectations were met or missed
-- **Remediation** (only for `partial` or `fail`): one sentence describing what would fix the gap
+- **Query**: `<query>`
+- **Verdict**: `pass | partial | fail`
+- **Must met**: `<met>/<total>`
+- **Should met**: `<met>/<total>`
+- **Explanation**: one sentence
+- **Remediation**: one sentence, only for `partial` or `fail`

--- a/.agents/skills/custom-index-eval/assets/report-template.md
+++ b/.agents/skills/custom-index-eval/assets/report-template.md
@@ -1,31 +1,26 @@
-# Evaluation Report Template
+# Evaluation Report: {domain}
 
-Use this template when producing evaluation reports.
+- Date: {YYYY-MM-DD}
+- Strictness: {full | strict}
+- Domain file: `eval/index/{domain}.md`
 
----
+## Results
 
-## Evaluation Report: {domain}
+| # | Query | Verdict | Must | Should | Explanation |
+|---|---|---|---|---|---|
+| {n} | {heading} | {pass|partial|fail} | {met}/{total} | {met}/{total} | {summary} |
 
-**Date:** {YYYY-MM-DD}
-**Strictness:** {full | strict}
-**Domain file:** `eval/index/{domain}.md`
+## Summary
 
-### Results
+- Queries: {count}
+- Pass / partial / fail: {pass} / {partial} / {fail}
+- Must expectations met: {met}/{total} ({percent}%)
 
-| # | Query | Verdict | Explanation |
-|---|-------|---------|-------------|
-| {n} | {## heading text} | {pass\|partial\|fail} | {which must/should expectations were met or missed} |
+## Recommendations
 
-### Summary
+1. [CRITICAL] Query {n}: {fix required for must failure}
+2. [IMPROVE] Query {n}: {coverage improvement}
 
-- **Queries:** {count} | **Pass:** {count} | **Partial:** {count} | **Fail:** {count}
-- **Must expectations met:** {met}/{total} ({percent}%)
+## Notes
 
-### Recommendations
-
-1. **[CRITICAL]** Query {n}: {concrete action to fix the gap}
-2. **[IMPROVE]** Query {n}: {concrete action to improve coverage}
-
-### Notes
-
-- {optional context about MCP availability, rate limits, or evaluation conditions}
+- {MCP availability, rate limits, stale-index clues, or omitted details}

--- a/.agents/skills/custom-rebase/SKILL.md
+++ b/.agents/skills/custom-rebase/SKILL.md
@@ -1,310 +1,104 @@
 ---
 name: custom-rebase
-description: Guide for rebasing feature branches onto main in the Fusion Framework monorepo, including handling pnpm-lock.yaml conflicts
+description: 'Rebases Fusion Framework feature branches onto main and handles monorepo conflict traps. USE FOR: rebase this branch, refresh branch from main, fix pnpm-lock.yaml conflicts, resolve Version Packages conflicts, generate a rebase risk report. DO NOT USE FOR: dependency PR review, branch cleanup unrelated to rebase, or destructive reset without explicit approval.'
 ---
 
-# Custom Rebase Skill (Fusion Framework)
+# Custom Rebase
 
-This skill helps you rebase feature branches onto the latest `main` branch, handling common conflicts in a pnpm monorepo.
+## When To Use
 
-## Overview
+Use for Fusion Framework branch refreshes where the agent must rebase onto `origin/main`, resolve common monorepo conflicts, and sanity-check the result before force-pushing.
 
-When rebasing a feature branch, you'll often encounter conflicts in `pnpm-lock.yaml` due to parallel dependency changes. The correct approach is to regenerate the lockfile rather than manually resolving conflicts.
+Trigger phrases:
+- "rebase this branch onto main"
+- "refresh my branch"
+- "fix rebase conflicts"
+- "handle pnpm-lock.yaml conflicts"
+- "generate a rebase report"
 
-## Standard Rebase Workflow
+## Required Gates
 
-### 1. Prepare for rebase
+- Confirm the current branch and repository root before starting.
+- Stop if the working tree is dirty unless the user explicitly says those changes are expected.
+- Use `pnpm` only.
+- Never run `git reset --hard`, `git rebase --abort`, `git rebase --skip`, or `git push --force-with-lease` without making the action and target branch explicit.
+- Prefer `origin/main` as the rebase target unless the user gives another base.
+
+## Workflow
+
+1. Prepare:
 
 ```bash
-# Navigate to your worktree or branch
-cd /path/to/worktree
-
-# Ensure you're on the correct branch
-git branch
-
-# Fetch latest changes from origin (including main)
+git status
+git branch --show-current
 git fetch origin
 git fetch origin main:refs/remotes/origin/main
 ```
 
-### 2. Start the rebase
+2. Rebase:
 
 ```bash
-# Rebase your branch onto the latest main
 git rebase origin/main
 ```
 
-### 3. Handle pnpm-lock.yaml conflicts
+3. Resolve known conflicts:
 
-**CRITICAL: When `pnpm-lock.yaml` has conflicts during rebase:**
+| Conflict | Action |
+|---|---|
+| `pnpm-lock.yaml` | Regenerate with `pnpm install`, then `git add pnpm-lock.yaml` |
+| Version Packages `package.json` | Keep main with `git checkout --ours "packages/*/package.json"`, then stage |
+| Version Packages `CHANGELOG.md` | Keep main with `git checkout --ours "packages/*/CHANGELOG.md"`, then stage |
+| Source files | Resolve manually, preserve user intent, stage resolved files |
+
+Then continue:
 
 ```bash
-# Regenerate it from package.json files
-pnpm install
-
-# Stage the regenerated lockfile
-git add pnpm-lock.yaml
-
-# Continue the rebase
 git rebase --continue
 ```
 
-### 4. Handle "Version Packages" commit conflicts
-
-**When you encounter a "Version Packages (next)" commit with conflicts:**
-
-This happens when your feature branch has pre-release versions (e.g., `2.0.0-next.0`) but main has been updated with newer regular versions.
-
-**Resolution strategy:**
-- **package.json**: Use `--ours` (HEAD version from main)
-- **CHANGELOG.md**: Use `--ours` (HEAD changelog from main)
+4. If `.changeset/pre.json` exists, align pre-release baselines:
 
 ```bash
-# For all package.json conflicts, keep HEAD version
-git checkout --ours "packages/*/package.json"
-git add "packages/*/package.json"
-
-# For all CHANGELOG.md conflicts, keep HEAD changelog  
-git checkout --ours "packages/*/CHANGELOG.md"
-git add "packages/*/CHANGELOG.md"
-
-# Also check other affected files
-git checkout --ours "vue-press/package.json" 2>/dev/null || true
-git add "vue-press/package.json" 2>/dev/null || true
-
-# Continue the rebase
-git rebase --continue
-```
-
-**Why?** The main branch has the authoritative versions and changelogs. Your feature branch's pre-release versions will be regenerated when you create a new changeset after rebasing.
-
-### 5. Handle other conflicts
-
-For conflicts in source files (`.ts`, `.tsx`, etc.):
-
-```bash
-# Manually resolve conflicts in the files
-# Then stage the resolved files
-git add path/to/resolved-file.ts
-
-# Continue the rebase
-git rebase --continue
-```
-
-### 6. Complete the rebase
-
-After all commits are rebased successfully:
-
-```bash
-# Verify the branch is clean
-git status
-
-# Force push to update the remote branch
-git push --force-with-lease origin YOUR_BRANCH_NAME
-```
-
-### 7. Align pre.json initial versions (if in pre mode)
-
-If `.changeset/pre.json` exists (pre-release mode), align `initialVersions` to current package versions for packages changed by the rebase:
-
-```bash
-# From repo root
 node .agents/skills/custom-rebase/scripts/align-pre-initial-versions.cjs
 ```
 
-What it does:
-- Reads `.changeset/pre.json` to get the `tag` (e.g., `next`)
-- Updates `initialVersions` when the current package version does NOT end with `-TAG.NUMBER` (e.g., `2.0.0` or `2.1.0`)
-- Skips entries where the current version ends with `-TAG.NUMBER` (e.g., `2.0.0-next.0`), preserving ongoing pre state
-
-### 8. Sanity check vs remote
-
-Before pushing, verify local rebase result against the remote branch.
+5. Check the local result against the remote branch:
 
 ```bash
-# Ensure you have latest remote
-git fetch origin
-
-# Set a helper var for current branch
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-# Quick overview of what will change on the remote
+git fetch origin
 git diff --stat origin/$BRANCH...HEAD
-
-# See the file list (useful to spot unintended changes)
 git diff --name-only origin/$BRANCH...HEAD | sort
-
-# Review commit differences (left/right) without merges
 git log --oneline --left-right --cherry --no-merges origin/$BRANCH...HEAD
-
-# Optional: preview the push without sending any data
 git push --force-with-lease --dry-run origin $BRANCH
 ```
 
-Proceed to push only if the changes match expectations.
-
-### 9. Generate raw data report
-
-Run the data extraction script:
+6. Generate the raw report when risk or size warrants it:
 
 ```bash
-# From repo root
 node .agents/skills/custom-rebase/scripts/generate-rebase-report.cjs --no-fetch
 ```
 
-This generates `.tmp/skills/custom-rebase/<timestamp>-rebase-report.md` with raw data:
-- Ahead/behind counts and diff summary
-- Highlights & Anomalies: largest diffs, config changes, dependency summary
-- Full commit list (all 57+ commits with hashes and messages)
-- Changed packages and top-level folders
-- pre.json initialVersions changes (version baseline updates)
-- pnpm-lock.yaml churn
-- **Detailed Dependency Changes** - Complete breakdown per package:
-  - ⚠️ Major version bumps (e.g., `zod: ^3.23.8 → ^4.3.5`)
-  - ➕ Added dependencies (e.g., `@azure/search-documents: ^12.2.0`)
-  - ➖ Removed dependencies
-  - Minor/patch version changes
-  - Organized by section: dependencies, devDependencies, peerDependencies
-
-### 10. Generate human-readable summary (automatic)
-
-After the raw report is generated, the AI agent will automatically:
-
-1. Read the latest report from `.tmp/skills/custom-rebase/<timestamp>-rebase-report.md`
-2. Analyze the "Detailed Dependency Changes" section
-3. Create a human-readable summary with:
-   - **Breaking dependency changes** - Each major bump explained (what package, what changed, why it matters, what to test)
-   - **New dependencies added** - What was added and its purpose
-   - **Version baselines updated** - Which packages bumped and what that means
-   - **Risk assessment** - Overall risk level (🟢 LOW, 🟡 MEDIUM, 🔴 HIGH) with reasoning
-   - **Pre-push checklist** - Specific tests to run based on detected changes
-
-The summary will be displayed in the chat for review before you push.
-- **Next steps**: sanity checks and push confirmation
-
-Open the SUMMARY.md file in your editor to review before pushing.
-
-## Common Scenarios
-
-### Reset local branch to match remote
-
-If your local branch has diverged incorrectly:
-
-```bash
-# Fetch latest
-git fetch origin
-
-# Hard reset to remote branch
-git reset --hard origin/YOUR_BRANCH_NAME
-```
-
-### Abort a rebase in progress
-
-If you need to start over:
-
-```bash
-git rebase --abort
-```
-
-### Continue after fixing conflicts
-
-```bash
-# After resolving conflicts and staging changes
-git rebase --continue
-```
-
-### Skip a commit during rebase
-
-Only if the commit is no longer needed:
-
-```bash
-git rebase --skip
-```
-
-## Rebase Checklist
-
-- [ ] Fetch latest changes from origin
-- [ ] Start rebase onto `origin/main`
-- [ ] For `pnpm-lock.yaml` conflicts:
-  - [ ] Remove the file with `git rm pnpm-lock.yaml`
-  - [ ] Run `pnpm install` to regenerate
-  - [ ] Stage with `git add pnpm-lock.yaml`
-- [ ] For source file conflicts:
-  - [ ] Manually resolve conflicts
-  - [ ] Stage resolved files
-- [ ] Continue rebase with `git rebase --continue`
-- [ ] Repeat until all commits are applied
-- [ ] Force push with `--force-with-lease`
-
-## Why Regenerate pnpm-lock.yaml?
-
-The lockfile contains exact dependency resolutions for the entire monorepo. During a rebase:
-
-1. **Base branch** (main) has new/updated dependencies
-2. **Your branch** has different/updated dependencies
-3. Git cannot merge these semantically - it only sees text conflicts
-
-By regenerating with `pnpm install`:
-- pnpm reads all current `package.json` files (including your changes)
-- Resolves dependencies against the latest registry state
-- Creates a consistent lockfile that works with both sets of changes
-- Respects workspace protocols and catalog references
+Read the latest `.tmp/skills/custom-rebase/*-rebase-report.md` and summarize only the decision-relevant parts: largest diffs, dependency changes, package scope, `pre.json` changes, lockfile churn, validation to run, and push recommendation.
 
 ## Troubleshooting
 
-### "diverged and have X and Y different commits"
+| Symptom | Response |
+|---|---|
+| Rebase is going the wrong way | Stop and verify current branch plus `git rebase origin/main` direction |
+| `pnpm install` fails | Check repo root, conflicted `package.json` syntax, and unstaged package manifest changes |
+| Local branch diverged unexpectedly | Explain the divergence and ask before any reset |
+| Conflict repeats commit after commit | Resolve the recurring pattern once, continue, and re-check after completion |
 
-Your local branch has commits that aren't on remote. Common causes:
-- Previous force push to a different commit
-- Local branch accidentally pointing to wrong commit
+## Expected Output
 
-**Fix:** Reset to remote and rebase:
-```bash
-git fetch origin
-git fetch origin main:refs/remotes/origin/main
-git reset --hard origin/YOUR_BRANCH_NAME
-git rebase origin/main
-```
-
-### Rebase conflicts on every commit
-
-You may be rebasing in the wrong direction. Ensure:
-- You're ON your feature branch
-- You're rebasing ONTO main: `git rebase origin/main`
-
-### pnpm install fails during rebase
-
-Check:
-- All `package.json` changes are staged/committed
-- No syntax errors in modified `package.json` files
-- You're running from the repository root
-
-## Example: Complete rebase flow
-
-```bash
-# 1. Navigate and prepare
-cd /Users/odin.rochmann/dev/GitHub/fusion-framework.worktree/react-19
-git fetch origin
-git fetch origin main:refs/remotes/origin/main
-
-# 2. Ensure clean state
-git status  # Should show "nothing to commit, working tree clean"
-
-# 3. Start rebase
-git rebase origin/main
-
-# 4. If pnpm-lock.yaml conflict appears:
-git rm pnpm-lock.yaml
-pnpm install
-git add pnpm-lock.yaml
-git rebase --continue
-
-# 5. Repeat step 4 for each commit with lockfile conflicts
-
-# 6. When rebase completes:
-git push --force-with-lease origin react-19
-```
+- Rebased branch or clear blocker
+- Conflict decisions made explicit
+- Remote comparison before push
+- Human-readable risk summary when a report was generated
+- Suggested validation commands before the user or agent pushes
 
 ## Related Skills
 
-- `fusion-dependency-review` - Review dependency pull requests that need branch refresh or conflict follow-up
+- `fusion-dependency-review` for dependency PR analysis
+- `custom-dependency-pr-solver` for Dependabot batch processing


### PR DESCRIPTION
**Why is this change needed?**

The custom skill catalog had accumulated repeated workflow prose and oversized examples that made retrieval and agent routing noisier than necessary. This PR compresses the custom skills around activation cues, hard gates, workflow contracts, and expected outputs.

**What is the current behavior?**

`custom-rebase`, `custom-index-eval`, and `custom-dependency-pr-solver` include useful instructions, but some content is duplicated, verbose, or spread across templates in a way that increases token load without adding much decision value.

**What is the new behavior?**

The custom skill root docs and helper markdown resources are shorter and more direct. They preserve the same workflow intent while improving semantic density for agent discovery and execution.

**What is the intended behavior or invariant?**

Custom skills should retain their trigger cues, safety gates, tool paths, output contracts, and review/validation expectations while avoiding repeated background explanation. The optimizer rule is: keep decision-making context, remove prose that does not change agent behavior.

**Does this PR introduce a breaking change?**

No. This changes repository-local agent skill documentation only.

**Impact assessment:**

- Breaking changes: No
- Version bump: None
- Consumer impact: None; these skill files are repo-internal agent catalog content.
- Downstream impact: None expected for published packages.
- Changeset: Skipped because workflow contribution rules exclude repo-internal skill-catalog content that does not ship to consumers.

**Review guidance:**

Review for semantic loss rather than line count. The important checks are whether each skill still has clear activation cues, required gates, execution steps, and expected output. The rebase helper scripts were reviewed as sub-resources but not behaviorally changed.

**Additional context**

This follows the same internal-refactor rationale used to close external PR #4803. Targeted validation was run because these are repo-internal markdown customizations:

- `git diff --check -- .agents/skills/custom-rebase .agents/skills/custom-index-eval .agents/skills/custom-dependency-pr-solver`
- `node --check .agents/skills/custom-rebase/scripts/generate-rebase-report.cjs`
- `node --check .agents/skills/custom-rebase/scripts/align-pre-initial-versions.cjs`

`pnpm exec biome check` was attempted for the edited markdown, but `.agents/skills/**` is ignored by the Biome configuration, so no files were processed. Full `pnpm test && pnpm build && pnpm -w check` was intentionally not run because this PR changes only repo-internal skill markdown.

**Related issues**

ref: #4803

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
