### PR TITLE
Fix/react/app/use environment variables

### DIFF
--- a/.changeset/fusion-framework-cookbook-app-react-environment-variables_add-app-config.md
+++ b/.changeset/fusion-framework-cookbook-app-react-environment-variables_add-app-config.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-environment-variables": patch
+---
+
+Add `app.config.ts` with example `environment` values to document and demonstrate environment variable configuration in the cookbook app.

--- a/.changeset/fusion-framework-react-app_fix-env-vars-hook.md
+++ b/.changeset/fusion-framework-react-app_fix-env-vars-hook.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Fix `useAppEnvironmentVariables` to map environment values from app config through a memoized observable before subscribing with `useObservableState`, improving subscription stability.

--- a/cookbooks/app-react-environment-variables/app.config.ts
+++ b/cookbooks/app-react-environment-variables/app.config.ts
@@ -7,6 +7,7 @@ export default defineAppConfig(() => {
       features: {
         enableDarkMode: true,
         enableBetaFeatures: false,
+        enablePbiIntegration: true,
       },
     },
   };

--- a/cookbooks/app-react-environment-variables/app.config.ts
+++ b/cookbooks/app-react-environment-variables/app.config.ts
@@ -1,0 +1,13 @@
+import { defineAppConfig } from '@equinor/fusion-framework-cli/app';
+
+export default defineAppConfig(() => {
+  return {
+    environment: {
+      apiBaseUrl: 'https://api.example.com',
+      features: {
+        enableDarkMode: true,
+        enableBetaFeatures: false,
+      },
+    },
+  };
+});

--- a/packages/react/app/src/useAppEnvironmentVariables.ts
+++ b/packages/react/app/src/useAppEnvironmentVariables.ts
@@ -43,7 +43,7 @@ export const useAppEnvironmentVariables = <
     throw Error('Framework is missing app module');
   }
 
-  const config$ = useMemo(() => {
+  const env$ = useMemo(() => {
     return app.getConfig().pipe(
       map((config) => {
         return config.environment as TEnvironmentVariables;
@@ -52,10 +52,7 @@ export const useAppEnvironmentVariables = <
   }, [app]);
 
   // Return the observable state of the environment configuration
-  return useObservableState(
-    useMemo(() => config$, [config$]),
-    {
-      initial: app.config?.environment,
-    },
-  );
+  return useObservableState(env$, {
+    initial: app.config?.environment || ({} as TEnvironmentVariables),
+  });
 };

--- a/packages/react/app/src/useAppEnvironmentVariables.ts
+++ b/packages/react/app/src/useAppEnvironmentVariables.ts
@@ -1,8 +1,9 @@
+import { useMemo } from 'react';
+import { map } from 'rxjs/internal/operators/map';
 import type { ConfigEnvironment } from '@equinor/fusion-framework-module-app';
 import { useCurrentApp } from '@equinor/fusion-framework-react/app';
 import {
   type ObservableStateReturnType,
-  useObservableSelector,
   useObservableState,
 } from '@equinor/fusion-observable/react';
 
@@ -42,14 +43,19 @@ export const useAppEnvironmentVariables = <
     throw Error('Framework is missing app module');
   }
 
-  // Get the environment configuration observable from the app module
-  const env$ = useObservableSelector(
-    app.getConfig(),
-    (config) => config.environment as TEnvironmentVariables,
-  );
+  const config$ = useMemo(() => {
+    return app.getConfig().pipe(
+      map((config) => {
+        return config.environment as TEnvironmentVariables;
+      }),
+    );
+  }, [app]);
 
   // Return the observable state of the environment configuration
-  return useObservableState(env$, {
-    initial: app.config?.environment,
-  });
+  return useObservableState(
+    useMemo(() => config$, [config$]),
+    {
+      initial: app.config?.environment,
+    },
+  );
 };

--- a/packages/react/app/src/useAppEnvironmentVariables.ts
+++ b/packages/react/app/src/useAppEnvironmentVariables.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { map } from 'rxjs/internal/operators/map';
+import { map } from 'rxjs/operators';
 import type { ConfigEnvironment } from '@equinor/fusion-framework-module-app';
 import { useCurrentApp } from '@equinor/fusion-framework-react/app';
 import {


### PR DESCRIPTION
**Why is this change needed?**
The environment variables hook in the React app package was relying on selector-based observable handling that could lead to unstable subscription behavior. In addition, the environment variables cookbook lacked a concrete app-level configuration example.

**What is the current behavior?**
The hook selected environment values from app config through `useObservableSelector` and then passed that observable to `useObservableState`. The cookbook did not include an `app.config.ts` example showing how environment values are defined at app level.

**What is the new behavior?**
The hook now maps environment values from `app.getConfig()` into a memoized observable stream and subscribes through `useObservableState` with a stable observable reference and initial value fallback.
The cookbook now includes an `app.config.ts` file with example environment values, making the setup pattern explicit and easier to follow.

**What is the intended behavior or invariant?**
The hook should always expose environment variables from the current app configuration as observable state, while preserving stable stream semantics across renders and keeping initial values available before the first emission.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Consumers of `@equinor/fusion-framework-react-app` get a more stable environment variable stream behavior. Cookbook consumers get a clearer configuration example.
- Downstream impact: Affects `@equinor/fusion-framework-react-app` and `@equinor/fusion-framework-cookbook-app-react-environment-variables` (via changesets).

**Review guidance:**
- Verify hook behavior and memoization in `packages/react/app/src/useAppEnvironmentVariables.ts`.
- Verify cookbook config example in `cookbooks/app-react-environment-variables/app.config.ts`.
- Confirm changesets correctly target the two affected packages:
  - `.changeset/fusion-framework-react-app_fix-env-vars-hook.md`
  - `.changeset/fusion-framework-cookbook-app-react-environment-variables_add-app-config.md`

**Additional context**
This PR includes three commits:
- `refactor(useAppEnvironmentVariables)`: simplify observable state handling
- `fix`: environment cookbook example
- `chore`: changeset

**Related issues**
None linked.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
