### PR TITLE
fix(cli): use DefaultAzureCredential in CI when no token is provided

### DIFF
--- a/.changeset/fusion-framework-cli_ci-default-credential.md
+++ b/.changeset/fusion-framework-cli_ci-default-credential.md
@@ -1,0 +1,29 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Fix `ffc app publish` to use `DefaultAzureCredential` in CI environments when no token is provided.
+
+Previously, when `FUSION_TOKEN` was removed from CI pipelines, the CLI would fall back to interactive authentication mode, which attempted to load OS-level token cache persistence (keytar/libsecret). This native module is unavailable on GitHub-hosted runners and other headless CI environments, causing publish to fail.
+
+Now, when running in CI (detected via environment variables like `GITHUB_ACTIONS`, `CI`, etc.) and no token is provided, the CLI automatically uses `DefaultAzureCredential`, which works seamlessly with `azure/login` OIDC federation and managed identities.
+
+**Migration for affected teams:**
+Remove the `FUSION_TOKEN` acquisition step from your workflow. The CLI will now handle authentication automatically:
+
+```yaml
+# Before: explicit token acquisition
+- name: Acquire Fusion Token
+  run: |
+    TOKEN=$(az account get-access-token --scope ... --query accessToken -o tsv)
+    echo "FUSION_TOKEN=$TOKEN" >> $GITHUB_ENV
+
+- name: Publish app
+  run: ffc app publish --env ci ./dist/app.zip
+
+# After: just publish (no token needed)
+- name: Publish app
+  run: ffc app publish --env ci ./dist/app.zip
+```
+
+Fixes: https://github.com/equinor/fusion/issues/862

--- a/.changeset/fusion-framework-cli_ci-default-credential.md
+++ b/.changeset/fusion-framework-cli_ci-default-credential.md
@@ -2,7 +2,7 @@
 "@equinor/fusion-framework-cli": patch
 ---
 
-Fix `ffc app publish` to use `DefaultAzureCredential` in CI environments when no token is provided.
+Use `DefaultAzureCredential` in CI environments when no token is provided for any CLI command that initializes the framework.
 
 Previously, when `FUSION_TOKEN` was removed from CI pipelines, the CLI would fall back to interactive authentication mode, which attempted to load OS-level token cache persistence (keytar/libsecret). This native module is unavailable on GitHub-hosted runners and other headless CI environments, causing publish to fail.
 

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -97,9 +97,11 @@ ffc app dev
 > For example, before running `fusion-framework-cli app publish`, make sure you are authenticated using `fusion-framework-cli auth login`.
 
 > [!WARNING]
-> The `fusion-framework-cli auth login` command is only available in interactive environments (such as your local terminal). For CI/CD pipelines or automated deployments, you must provide a valid authentication token using the `FUSION_TOKEN` environment variable.
+> The `fusion-framework-cli auth login` command is only available in interactive environments (such as your local terminal). In CI/CD pipelines, authenticate with `azure/login` and run the CLI command directly.
 >
-> See [Authentication](auth.md#setting-the-fusion-token-in-github) for details on setting up tokens for CI/CD.
+> In CI, when no `--token` or `FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity `DefaultAzureCredential`.
+>
+> See [Authentication](auth.md#authentication-in-github-actions) for CI setup details.
 
 ```sh
 pnpm fusion-framework-cli auth login
@@ -118,7 +120,7 @@ pnpm fusion-framework-cli publish --env <environment>
 pnpm fusion-framework-cli app config --publish --env <environment>
 ```
 
-> **Tip:** For CI/CD and automation, set the `FUSION_TOKEN` environment variable. See [Authentication](auth.md) for details.
+> **Tip:** For CI/CD and automation, prefer Azure OIDC with `azure/login`; `FUSION_TOKEN` remains an optional explicit override. See [Authentication](auth.md) for details.
 
 ---
 

--- a/packages/cli/docs/application.md
+++ b/packages/cli/docs/application.md
@@ -90,20 +90,17 @@ pnpm fusion-framework-cli dev
 ffc app dev
 ```
 
-### Log in to Fusion Framework (if needed)
+### Authentication
 
 > [!NOTE]
-> __All HTTP requests to Fusion services require an authorized user.__
-> For example, before running `fusion-framework-cli app publish`, make sure you are authenticated using `fusion-framework-cli auth login`.
-
-> [!WARNING]
-> The `fusion-framework-cli auth login` command is only available in interactive environments (such as your local terminal). In CI/CD pipelines, authenticate with `azure/login` and run the CLI command directly.
+> **All HTTP requests to Fusion services require an authorized user.**
+> - **Local development:** use `fusion-framework-cli auth login` to authenticate interactively. This launches a browser-based login and caches your credentials locally — run it once before issuing other CLI commands.
+> - **CI/CD:** use `azure/login` to establish ambient credentials. The CLI picks them up automatically via `DefaultAzureCredential`. The `auth login` command requires an interactive browser session and is **not applicable** in CI.
 >
-> In CI, when no `--token` or `FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity `DefaultAzureCredential`.
->
-> See [Authentication](auth.md#authentication-in-github-actions) for CI setup details.
+> See [Authentication](auth.md) for full setup details.
 
 ```sh
+# Local development — launches interactive browser login
 pnpm fusion-framework-cli auth login
 ```
 

--- a/packages/cli/docs/auth.md
+++ b/packages/cli/docs/auth.md
@@ -99,78 +99,46 @@ ffc auth token
 
 ## CI/CD
 
-### Setting the Fusion Token in GitHub
+### Authentication in GitHub Actions
 
-To publish or deploy your Fusion Framework app, you need to authenticate and set the `FUSION_TOKEN` environment variable. This token is required for secure access to Fusion APIs during CI/CD workflows.
+For CI/CD, authenticate with Azure using `azure/login@v2` and run the CLI command directly.
 
-You can obtain and set the `FUSION_TOKEN` using the Azure CLI as part of your pipeline steps. For example:
-
-This ensures the `FUSION_TOKEN` is available as an environment variable for subsequent steps, such as publishing source code or config.
+When running in CI and no `--token`/`FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity `default_credential` (`DefaultAzureCredential`). This works with OIDC federation, managed identities, and other ambient credentials.
 
 ```yml
-# This GitHub Action authenticates with Azure and retrieves an access token for use as FUSION_TOKEN.
-#
-# - The Azure Login step uses the azure/login action to authenticate with Azure using the provided client and tenant IDs.
-# - The Get Access Token step runs the Azure CLI to acquire an access token for the specified scope, then sets it as the FUSION_TOKEN environment variable for subsequent steps.
-#
-# This makes the token available for publishing, deploying, or running Fusion CLI commands that require authentication.
-#
-# Example usage in a workflow:
-#
-# steps:
-#   - name: Acquire Fusion Token
-#     uses: ./.github/actions/fusion-token
-#   - name: Fusion CLI command
-#     run: fusion-framework-cli app check
-#
-# ---
-# How to set up a Service Principal in Azure for CI/CD:
-#
-# 1. Sign in to Azure CLI:
-#      az login
-# 2. Create a new service principal (replace <NAME> and <SCOPE> as needed):
-#      az ad sp create-for-rbac --name <NAME> --role contributor --scopes <SCOPE>
-#    - This will output appId (client-id), password (client-secret), and tenant.
-# 3. Grant the service principal API permissions if needed (e.g., to call Fusion APIs):
-#    - In Azure Portal, go to Azure Active Directory > App registrations > [Your App] > API permissions.
-#    - Add the required API permissions and grant admin consent.
-# 4. Store the client-id, client-secret, and tenant-id as GitHub Action secrets.
-# 5. Use these secrets in your workflow as shown below.
-# 6. (Optional) For more on setting up environment variables in GitHub Actions workflows, see:
-#    https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
-#
-# For more details, see:
-# https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal
-# https://learn.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli
-#
-name: Azure Login and Get Access Token
-description: Authenticates with Azure and retrieves an access token
-inputs:
-  client-id:
-    description: >
-      The Azure AD Application (client) ID to use for authentication. This should correspond to an app registration with permissions to request the required scopes.
-    required: true
-  tenant-id:
-    description: >
-      The Azure AD Tenant ID (directory) to authenticate against. This identifies the Azure AD instance where the app is registered.
-    required: true
-  scope:
-    description: >
-      The scope(s) for the access token, typically the Application ID URI of the API you want to access, followed by /.default (e.g., https://my-api/.default). Multiple scopes can be space-separated.
-    required: true
-runs:
-  using: composite
-  steps:
-    - name: Azure Login
-      uses: azure/login@v2
-      with:
-        client-id: ${{ inputs.client-id }}
-        tenant-id: ${{ inputs.tenant-id }}
-        allow-no-subscriptions: true
-    - name: Get Access Token
-      shell: bash
-      run: |
-        echo "FUSION_TOKEN=$(az account get-access-token --scope ${{ inputs.scope }} --query accessToken --output tsv)" >> $GITHUB_ENV
+name: Publish app
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Publish to Fusion
+        run: ffc app publish --env ci ./dist/app.zip
+```
+
+### Optional Explicit Token Mode
+
+You can still provide an explicit token with `--token` or `FUSION_TOKEN` when needed.
+
+```yml
+- name: Acquire token (optional)
+  run: |
+    echo "FUSION_TOKEN=$(az account get-access-token --scope ${{ vars.FUSION_SCOPE }} --query accessToken --output tsv)" >> $GITHUB_ENV
+
+- name: Publish with explicit token
+  run: ffc app publish --env ci ./dist/app.zip
+```
 
 ## Additional Resources
 

--- a/packages/cli/docs/auth.md
+++ b/packages/cli/docs/auth.md
@@ -101,7 +101,7 @@ ffc auth token
 
 ### Authentication in GitHub Actions
 
-For CI/CD, authenticate with Azure using `azure/login@v2` and run the CLI command directly.
+For CI/CD, authenticate with Azure using `azure/login@v2` and run your desired CLI command (e.g. `app publish`) directly. The `fusion-framework-cli auth login` command requires an interactive browser session and is intended for **local development only** — it is not applicable in CI environments.
 
 When running in CI and no `--token`/`FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity's `DefaultAzureCredential`. This works with OIDC federation, managed identities, and other ambient credentials.
 
@@ -123,7 +123,7 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}    # The app registration (Service Principal) client ID
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
@@ -133,7 +133,7 @@ jobs:
 
 ### Optional Explicit Token Mode
 
-You can still provide an explicit token with `--token` or `FUSION_TOKEN` when needed.
+You can still provide an explicit token with `--token` or `FUSION_TOKEN` if needed.
 
 ```yml
 - name: Acquire token (optional)

--- a/packages/cli/docs/auth.md
+++ b/packages/cli/docs/auth.md
@@ -8,7 +8,7 @@ For detailed information about the underlying authentication module, see the [Az
 ## Key features
 - **Multiple authentication modes:**
   - `interactive`: Browser-based Azure AD login with OS-level token caching (CLI tools, development).
-  - `default_credential`: Ambient credential chain — environment variables, managed identity, Azure CLI (CI/CD, infrastructure).
+  - **DefaultAzureCredential (default credential chain)**: Ambient credential chain — environment variables, managed identity, Azure CLI (CI/CD, infrastructure).
   - `token_only`: Use a pre-provided token (e.g., for CI/CD and automation).
 - **Secure token storage:** Tokens and authentication records are encrypted at rest using platform-specific mechanisms (Keychain on macOS, DPAPI on Windows, libsecret on Linux) via `@azure/msal-node-extensions`.
 - **Consistent experience:** The same authentication logic and token handling is used across CLI and app environments.
@@ -103,12 +103,16 @@ ffc auth token
 
 For CI/CD, authenticate with Azure using `azure/login@v2` and run the CLI command directly.
 
-When running in CI and no `--token`/`FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity `default_credential` (`DefaultAzureCredential`). This works with OIDC federation, managed identities, and other ambient credentials.
+When running in CI and no `--token`/`FUSION_TOKEN` is provided, the CLI automatically uses Azure Identity's `DefaultAzureCredential`. This works with OIDC federation, managed identities, and other ambient credentials.
 
 ```yml
 name: Publish app
 on:
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -124,7 +128,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: Publish to Fusion
-        run: ffc app publish --env ci ./dist/app.zip
+        run: fusion-framework-cli app publish --env ci ./dist/app.zip
 ```
 
 ### Optional Explicit Token Mode
@@ -137,7 +141,7 @@ You can still provide an explicit token with `--token` or `FUSION_TOKEN` when ne
     echo "FUSION_TOKEN=$(az account get-access-token --scope ${{ vars.FUSION_SCOPE }} --query accessToken --output tsv)" >> $GITHUB_ENV
 
 - name: Publish with explicit token
-  run: ffc app publish --env ci ./dist/app.zip
+  run: fusion-framework-cli app publish --env ci ./dist/app.zip
 ```
 
 ## Additional Resources

--- a/packages/cli/src/bin/framework.node.ts
+++ b/packages/cli/src/bin/framework.node.ts
@@ -177,6 +177,7 @@ export const configureFramework = (
       throw new Error('clientId and tenantId are required for auth module');
     }
 
+    // Interactive mode with custom server configuration
     if ('interactive' in auth && auth.interactive) {
       const { server } = auth as AuthInteractiveOptions;
       if (!server.port) {
@@ -188,15 +189,27 @@ export const configureFramework = (
         redirectPort: server.port,
         onOpen: server.onOpen,
       });
-    } else {
-      // Non-interactive callers (token, logout) — use a default port.
-      // InteractiveBrowserCredential will use cached tokens silently.
-      builder.setInteractive({
-        tenantId,
-        clientId,
-        redirectPort: 49741,
-      });
+
+      return;
     }
+
+    // In CI environments with no token provided, use DefaultAzureCredential.
+    // This avoids loading keytar/libsecret (native modules unavailable on
+    // GitHub-hosted runners and other headless CI environments) and instead
+    // uses the ambient credential chain: OIDC, managed identity, Azure CLI, etc.
+    // established by azure/login or equivalent CI tooling.
+    if (isContinuousIntegration) {
+      builder.setDefaultCredential();
+      return;
+    }
+
+    // Local non-interactive callers — use a default port.
+    // InteractiveBrowserCredential will use cached tokens silently.
+    builder.setInteractive({
+      tenantId,
+      clientId,
+      redirectPort: 49741,
+    });
   });
 
   return configurator;


### PR DESCRIPTION
## Summary
- Use `DefaultAzureCredential` automatically in CI when no `--token` / `FUSION_TOKEN` is provided.
- Keep existing behavior precedence:
  - explicit token => token auth
  - explicit `defaultCredential` => default credential auth
  - explicit interactive => interactive auth
  - implicit fallback => `DefaultAzureCredential` in CI, interactive cache locally
- Update CLI docs to reflect CI behavior and position `FUSION_TOKEN` as optional override.

## Why
Some app teams removed explicit `FUSION_TOKEN` acquisition in pipelines based on newer guidance. In CI, the previous fallback path attempted interactive cache-based auth, which can fail on hosted runners due to unavailable native cache modules (`keytar`/`libsecret`).

This change makes CI work out of the box with `azure/login` + ambient credentials.

## Files changed
- `packages/cli/src/bin/framework.node.ts`
- `packages/cli/docs/auth.md`
- `packages/cli/docs/application.md`
- `.changeset/fusion-framework-cli_ci-default-credential.md`

## Validation
- Branch builds locally after changes.
- Behavior is deterministic from `is-ci` environment detection.

Fixes: https://github.com/equinor/fusion/issues/862