### PR TITLE
fix(spa): correct subpath declaration exports

### DIFF
--- a/.changeset/fix-spa-subpath-types.md
+++ b/.changeset/fix-spa-subpath-types.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Fix TypeScript declaration paths for the `./bootstrap.js` and `./sw.js` package exports.

--- a/packages/vite-plugins/spa/package.json
+++ b/packages/vite-plugins/spa/package.json
@@ -11,11 +11,11 @@
     },
     "./bootstrap.js": {
       "import": "./dist/html/bootstrap.js",
-      "types": "./dist/types/bootstrap.d.ts"
+      "types": "./dist/types/html/bootstrap.d.ts"
     },
     "./sw.js": {
       "import": "./dist/html/sw.js",
-      "types": "./dist/types/sw.d.ts"
+      "types": "./dist/types/html/sw.d.ts"
     }
   },
   "directories": {
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "tsc -b",
     "postbuild": "rollup -c rollup.config.js",
+    "test:package": "node scripts/verify-package-exports.js",
     "test": "vitest",
     "prepack": "pnpm build"
   },

--- a/packages/vite-plugins/spa/scripts/verify-package-exports.js
+++ b/packages/vite-plugins/spa/scripts/verify-package-exports.js
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageJsonPath = new URL('../package.json', import.meta.url);
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+const targets = [pkg.types];
+
+for (const exportConfig of Object.values(pkg.exports)) {
+  if (typeof exportConfig === 'string') {
+    targets.push(exportConfig);
+    continue;
+  }
+
+  targets.push(...Object.values(exportConfig));
+}
+
+for (const target of targets) {
+  if (!fs.existsSync(new URL(`../${target}`, import.meta.url))) {
+    throw new Error(`Package export target is missing: ${target}`);
+  }
+}
+
+console.log(
+  `Verified package export targets: ${targets
+    .map((target) => path.posix.normalize(target))
+    .join(', ')}`,
+);


### PR DESCRIPTION
## Summary
- point the `./bootstrap.js` and `./sw.js` export declarations at their generated `dist/types/html/*` files
- add a package export verification script for the SPA Vite plugin
- add a patch changeset for `@equinor/fusion-framework-vite-plugin-spa`

## Why
The published `@equinor/fusion-framework-vite-plugin-spa@4.0.11` package exposes:

```json
"./bootstrap.js": {
  "import": "./dist/html/bootstrap.js",
  "types": "./dist/types/bootstrap.d.ts"
},
"./sw.js": {
  "import": "./dist/html/sw.js",
  "types": "./dist/types/sw.d.ts"
}
```

The tarball contains the runtime files, but the generated declarations live under `dist/types/html/bootstrap.d.ts` and `dist/types/html/sw.d.ts`. TypeScript consumers of those subpath exports therefore resolve missing declaration files.

## Validation
- reproduced the published package issue with `npm pack @equinor/fusion-framework-vite-plugin-spa@4.0.11` and confirmed the declared `dist/types/bootstrap.d.ts` / `dist/types/sw.d.ts` files are missing while `dist/types/html/*` exists
- added `packages/vite-plugins/spa/scripts/verify-package-exports.js` and watched it fail before the fix with `Package export target is missing: ./dist/types/bootstrap.d.ts`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 install --frozen-lockfile --ignore-scripts --config.engine-strict=false`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 --config.engine-strict=false -r exec genversion --es6 --semi src/version.ts`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 --config.engine-strict=false --dir packages/vite-plugins/spa build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 --config.engine-strict=false --dir packages/vite-plugins/spa test:package`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 --config.engine-strict=false --dir packages/vite-plugins/spa test --run`
- packed `packages/vite-plugins/spa` and verified the corrected declaration targets are included
- manually unpacked the tarball into a temporary consumer and verified TypeScript `NodeNext` resolves both `@equinor/fusion-framework-vite-plugin-spa/bootstrap.js` and `@equinor/fusion-framework-vite-plugin-spa/sw.js`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm@10.20.0 --config.engine-strict=false exec biome check packages/vite-plugins/spa/package.json packages/vite-plugins/spa/scripts/verify-package-exports.js .changeset/fix-spa-subpath-types.md`
- `git diff --check`

Note: this environment uses Node 22, while the repository now declares Node >=24. I used `--config.engine-strict=false` only to run the package-level validation commands here; the change itself is package metadata plus a small verification script.