### PR TITLE
fix: update type export paths for bootstrap and service worker entryp…

### DIFF
--- a/.changeset/vite-plugin-spa_fix-export-type-paths.md
+++ b/.changeset/vite-plugin-spa_fix-export-type-paths.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Fix type export paths for `./bootstrap.js` and `./sw.js` so TypeScript resolves the published declarations correctly.
+
+- Prevent broken type resolution when consuming the SPA bootstrap and service worker entrypoints.

--- a/packages/vite-plugins/spa/package.json
+++ b/packages/vite-plugins/spa/package.json
@@ -11,11 +11,11 @@
     },
     "./bootstrap.js": {
       "import": "./dist/html/bootstrap.js",
-      "types": "./dist/types/bootstrap.d.ts"
+      "types": "./dist/types/html/bootstrap.d.ts"
     },
     "./sw.js": {
       "import": "./dist/html/sw.js",
-      "types": "./dist/types/sw.d.ts"
+      "types": "./dist/types/html/sw.d.ts"
     }
   },
   "directories": {


### PR DESCRIPTION
**Why is this change needed?**
The SPA vite plugin publishes `./bootstrap.js` and `./sw.js` subpath exports, but their `types` entries point to the wrong declaration file locations. That causes broken TypeScript resolution for consumers importing those entrypoints.

**What is the current behavior?**
The package exports `./bootstrap.js` and `./sw.js` from `dist/html`, while the matching `types` entries point to `dist/types/bootstrap.d.ts` and `dist/types/sw.d.ts`. Those declaration paths do not match the generated output layout.

**What is the new behavior?**
The `types` entries for `./bootstrap.js` and `./sw.js` now point to `dist/types/html/bootstrap.d.ts` and `dist/types/html/sw.d.ts`, matching the generated declaration files.

**What is the intended behavior or invariant?**
Each published subpath export should reference the declaration file generated for that same entrypoint so consumers get correct TypeScript resolution from the published package.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Fixes type resolution for consumers importing the SPA bootstrap and service worker entrypoints.
- Downstream impact: Affects `@equinor/fusion-framework-vite-plugin-spa` consumers only; no API surface change.

**Review guidance:**
Verify that the published export map in `packages/vite-plugins/spa/package.json` now points both subpath `types` entries to the generated `dist/types/html/*` declarations, and that the changeset correctly describes this as a patch fix.

**Additional context**
Validation run locally:
- `pnpm build`
- `pnpm changeset status`

**Related issues**
None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - `pnpm build`
  - `pnpm changeset status`
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)