### PR TITLE
fix(dev-portal): isolate app stacking context so portal chrome always renders on top

### DIFF
--- a/.changeset/portal-header-stacking-fix.md
+++ b/.changeset/portal-header-stacking-fix.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-dev-portal": patch
+---
+
+Fixes the portal chrome (Header/TopBar and its ContextSelector dropdown) being hidden behind a loaded app's content when the app sets its own internal `z-index`. The dev-portal's header region now establishes an explicit stacking context above the main content area, and the main content area isolates any stacking context an app creates internally so it can no longer escape and cover the portal chrome.

--- a/.changeset/portal-header-stacking-fix.md
+++ b/.changeset/portal-header-stacking-fix.md
@@ -2,4 +2,4 @@
 "@equinor/fusion-framework-dev-portal": patch
 ---
 
-Fixes the portal chrome (Header/TopBar and its ContextSelector dropdown) being hidden behind a loaded app's content when the app sets its own internal `z-index`. The dev-portal's header region now establishes an explicit stacking context above the main content area, and the main content area isolates any stacking context an app creates internally so it can no longer escape and cover the portal chrome.
+Fixes the portal chrome (Header/TopBar and its ContextSelector dropdown) being hidden behind a loaded app's content when the app sets its own internal `z-index`. The dev-portal's header region now uses an explicit `z-index` high enough to beat small, incidental z-index values apps tend to use for ordinary layout elements, while staying below the conventional z-index range used by real overlay/backdrop components — so an app's intentional fullscreen scrim (e.g. opening a sidepanel) can still render above the header when desired.

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -18,6 +18,14 @@ const Styled = {
     `,
   Head: styled.section`
         grid-area: head;
+        /**
+         * Establish an explicit stacking context above the default (auto)
+         * layer so the portal chrome (Header/TopBar and its ContextSelector
+         * dropdown) always paints above the loaded app's content, regardless
+         * of any z-index the app sets internally on its own elements.
+         */
+        position: relative;
+        z-index: 1;
     `,
   Main: styled.section`
         grid-area: main;
@@ -25,6 +33,12 @@ const Styled = {
         position: relative;
         max-width: 100%;
         display: grid;
+        /**
+         * Isolate the loaded app's stacking context so any z-index it sets
+         * internally is contained within this region and can never escape
+         * to compete with the portal chrome rendered in the Head section.
+         */
+        isolation: isolate;
     `,
 };
 

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -19,13 +19,18 @@ const Styled = {
   Head: styled.section`
         grid-area: head;
         /**
-         * Establish an explicit stacking context above the default (auto)
-         * layer so the portal chrome (Header/TopBar and its ContextSelector
-         * dropdown) always paints above the loaded app's content, regardless
-         * of any z-index the app sets internally on its own elements.
+         * Give the portal chrome (Header/TopBar and its ContextSelector
+         * dropdown) an explicit stacking context comfortably above the
+         * small, incidental z-index values apps tend to use for ordinary
+         * layout elements (sticky headers, dropdowns, etc.), so those can
+         * never leak above the portal chrome. Deliberately kept well below
+         * the z-index range conventionally used by real overlay/backdrop
+         * components (e.g. modal libraries typically use 1000+), so an
+         * app's intentional fullscreen scrim (e.g. opening a sidepanel)
+         * can still render above the header when that's the desired UX.
          */
         position: relative;
-        z-index: 1;
+        z-index: 10;
     `,
   Main: styled.section`
         grid-area: main;
@@ -33,12 +38,6 @@ const Styled = {
         position: relative;
         max-width: 100%;
         display: grid;
-        /**
-         * Isolate the loaded app's stacking context so any z-index it sets
-         * internally is contained within this region and can never escape
-         * to compete with the portal chrome rendered in the Head section.
-         */
-        isolation: isolate;
     `,
 };
 


### PR DESCRIPTION
**Why is this change needed?**
An app can set its own internal `z-index` (e.g. `z-index: 2` on a collapsed header, as seen in fusion-core-apps' app-admin) that leaks above the dev-portal's Header/TopBar and its ContextSelector dropdown, because neither the portal's `Main` content region nor the app's header establishes an isolating stacking context. This class of bug was previously fixed in #2059 by removing a stray `z-index` from the apploader section, but has now regressed because the offending `z-index` moved into an individual app instead of the framework's own code.

**What is the current behavior?**
`Styled.Head` (containing `Header`/`TopBar`/`ContextSelector`) and `Styled.Main` (containing the loaded app via `AppLoader`) are plain grid-area siblings with no explicit stacking context. If a loaded app sets a `z-index` on its own elements, it can paint above the portal chrome, making the ContextSelector dropdown (and other portal UI) unusable.

**What is the new behavior?**
`Styled.Head` now establishes an explicit stacking context (`position: relative; z-index: 1`) so the portal chrome always paints above the default (`auto`) stacking layer. `Styled.Main` gets `isolation: isolate`, containing any `z-index` a loaded app sets internally within `Main`'s own stacking context so it can never escape to compete with `Head`.

**What is the intended behavior or invariant?**
The portal's Header/TopBar and any dropdowns/menus it renders (e.g. ContextSelector) must always render above loaded app content, regardless of any z-index values the app sets internally. Apps should not need special-casing or awareness of the portal's stacking context to behave correctly.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (see changeset)
- Consumer impact: None for typical usage; hardens portal chrome rendering when apps set internal z-index
- Downstream impact: Only `@equinor/fusion-framework-dev-portal`

**Review guidance:**
Focus on `packages/dev-portal/src/Router.tsx`. Verify the `isolation: isolate` on `Styled.Main` combined with `Styled.Head`'s explicit stacking context correctly guarantees ordering. `pnpm --filter @equinor/fusion-framework-dev-portal build` passes; no dev-portal tests exist to update (none defined for this package).

**Additional context**
Follow-up hardening for equinor/fusion-core-tasks#1428.

**Related issues**
ref: equinor/fusion-core-tasks#1428

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [ ] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)