### PR TITLE
feat(react-ag-grid): add ag-grid-react subpath export

### DIFF
--- a/.changeset/goofy-beers-design.md
+++ b/.changeset/goofy-beers-design.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-react-ag-grid": patch
+---
+
+Add a dedicated `react` subpath export that re-exports `ag-grid-react` symbols.
+This lets consumers import the AG Grid React wrapper from `@equinor/fusion-framework-react-ag-grid/react` while resolving the monorepo-managed package instance.

--- a/packages/react/ag-grid/README.md
+++ b/packages/react/ag-grid/README.md
@@ -82,6 +82,10 @@ Re-exports everything from `ag-grid-community` — column definitions, cell rend
 
 Re-exports everything from `ag-grid-enterprise` — row grouping, tree data, server-side row model, Excel export, integrated charts, and more. Requires a valid license key.
 
+### React Entry Point (`@equinor/fusion-framework-react-ag-grid/react`)
+
+Re-exports everything from `ag-grid-react` — components, props, hooks, and utilities.
+
 ### Themes Entry Point (`@equinor/fusion-framework-react-ag-grid/themes`)
 
 | Export | Kind | Description |

--- a/packages/react/ag-grid/package.json
+++ b/packages/react/ag-grid/package.json
@@ -17,6 +17,10 @@
       "import": "./dist/esm/enterprise.js",
       "types": "./dist/types/enterprise.d.ts"
     },
+    "./react": {
+      "import": "./dist/esm/react.js",
+      "types": "./dist/types/react.d.ts"
+    },
     "./themes": {
       "import": "./dist/esm/themes.js",
       "types": "./dist/types/themes.d.ts"
@@ -34,6 +38,9 @@
       ],
       "enterprise": [
         "dist/types/enterprise.d.ts"
+      ],
+      "react": [
+        "dist/types/react.d.ts"
       ],
       "themes": [
         "dist/types/themes.d.ts"

--- a/packages/react/ag-grid/src/react.ts
+++ b/packages/react/ag-grid/src/react.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-exports every public symbol from `ag-grid-react`.
+ *
+ * Import AG Grid React components, props, hooks, and utilities
+ * from this entry point so the application resolves a single shared copy of
+ * `ag-grid-react` managed by the Fusion Framework monorepo.
+ *
+ * @example
+ * ```ts
+ * import { AgGridReact, type AgGridReactProps } from '@equinor/fusion-framework-react-ag-grid/react';
+ * ```
+ *
+ * @see {@link https://www.ag-grid.com/react-data-grid/getting-started/ | AG Grid React}
+ * @module react
+ */
+export * from 'ag-grid-react';


### PR DESCRIPTION


<!--
Remove all HTML comments before submitting. Replace placeholders with actual content.
-->

**Why is this change needed?**
<!-- Problem this solves or reason for change. Be specific. -->
`@equinor/fusion-framework-react-ag-grid` does not currently expose the full public API from `ag-grid-react`.

It exports `AgGridReact` and `AgGridReactProps`, but not other public React APIs such as `useGridFilter` and `CustomFilterProps`. That forces consuming apps to add a direct `ag-grid-react` dependency when building custom React filters or other AG Grid React integrations.

This defeats the purpose of the Fusion wrapper as the single AG Grid import surface and creates a version-drift risk between:

  - `@equinor/fusion-framework-react-ag-grid`
  - `ag-grid-community`
  - `ag-grid-enterprise`
  - `ag-grid-react`

We observed this in `fusion-core-apps`:

`contract-personnel` needed `useGridFilter` / `CustomFilterProps`
  - those APIs were not available from `@equinor/fusion-framework-react-ag-grid`
  - the app added a direct `ag-grid-react` dependency
  - that direct dependency drifted to 36.0.0 while the Fusion wrapper still resolved AG Grid 35.3.x
  - the workspace then had mixed AG Grid runtime pieces

**What is the current behavior?**
<!-- How things work currently, including any issues. -->
@equinor/fusion-framework-react-ag-grid does not currently expose the full public API from ag-grid-react.

**What is the new behavior?**
<!-- What will change after this PR is merged. -->


Expose a dedicated `fusion-framework-react-ag-grid/react` entrypoint that re-exports `ag-grid-react` to keep consumers on the monorepo-managed package instance.


**What is the intended behavior or invariant?**
<!-- Explain the contract this change introduces or preserves. State the non-obvious rule, threshold, lifecycle expectation, stream behavior, or render assumption reviewers should protect. -->

**Does this PR introduce a breaking change?**
<!-- Yes/No. If yes, describe what breaks and how to migrate. -->
no

**Impact assessment:**
<!-- 
- Breaking changes: Will this break existing code? (Yes/No)
- Version bump: Patch/Minor/Major (based on changeset)
- Consumer impact: What do consumers need to know?
- Downstream impact: Does this affect other packages in the monorepo?
-->

**Review guidance:**
<!-- Special considerations, areas of concern, specific things to verify, or focus areas for review. -->

**Additional context**
<!-- Implementation details, known limitations, edge cases, related docs. -->

**Related issues**
<!-- Remove if none. Use `closes: #123` or `ref: #456` / `ref: [AB#12345](url)`. -->
Ref equinor/fusion-core-tasks#1614


### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)

