### PR TITLE
chore: add missing changeset for vite 8.1.5 (cli runtime dep)

### DIFF
--- a/.changeset/vite-8.1.5.md
+++ b/.changeset/vite-8.1.5.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Updated `vite` from `8.0.16` to `8.1.5`.
+
+Notable changes:
+- `server.fs.deny` extended with common sensitive files (security hardening)
+- New `caseSensitive` option for `import.meta.glob`
+- WASM ESM Integration (direct `.wasm` imports)
+- `html.additionalAssetSources` option
+- Various bug fixes across HMR, CSS, SSR, and dev server


### PR DESCRIPTION
Follows up on #4990 — `vite` is a runtime dependency of `@equinor/fusion-framework-cli`, so it warrants a patch changeset.

- **Package**: `@equinor/fusion-framework-cli`
- **Bump**: patch
- **Reason**: `vite` bumped from `8.0.16` → `8.1.5` (runtime dep, affects published package consumers)