### PR TITLE
chore: add changeset for adm-zip 0.6.0 (CVE-2026-39244)

### DIFF
--- a/.changeset/adm-zip-0.6.0.md
+++ b/.changeset/adm-zip-0.6.0.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli": patch
+---
+
+Updated `adm-zip` from `^0.5.x` to `^0.6.0`. This release includes a fix for **CVE-2026-39244** (decompression bomb — crafted archives could exhaust memory via a declared-but-absent huge uncompressed size), a prototype pollution hardening fix, and several bug fixes.


### PR DESCRIPTION
Follow-up changeset for #4979. adm-zip is bundled into the CLI output and 0.6.0 fixes CVE-2026-39244 (decompression bomb / memory DoS) and prototype pollution.