### PR TITLE
docs(skills): upgrade agent skills via npx

### DIFF
--- a/.agents/skills/fusion-github-review-resolution/CHANGELOG.md
+++ b/.agents/skills/fusion-github-review-resolution/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.8 - 2026-07-03
+
+### patch
+
+- [#197](https://github.com/equinor/fusion-skills/pull/197) [`380c0a1`](https://github.com/equinor/fusion-skills/commit/380c0a18d417f1c8003b91eae127ec9d8b450622) Thanks [@alftore](https://github.com/alftore)! - Skip the worktree question when already on the PR's head branch
+
+
+  Step 1 now checks whether the current checkout's branch matches the PR's head
+  branch before asking about a dedicated git worktree. If they match, the skill
+  proceeds directly instead of asking a redundant question; the worktree
+  question is only asked when the branch differs or the workspace is on a
+  shared/long-lived branch.
+
 ## 0.1.7 - 2026-05-07
 
 ### patch

--- a/.agents/skills/fusion-github-review-resolution/SKILL.md
+++ b/.agents/skills/fusion-github-review-resolution/SKILL.md
@@ -4,7 +4,7 @@ description: "Resolves unresolved GitHub PR review threads end-to-end: evaluates
 license: MIT
 compatibility: Requires GitHub MCP server or gh CLI, and git.
 metadata:
-   version: "0.1.7"
+   version: "0.1.8"
    status: experimental
    owner: "@equinor/fusion-core"
    tags:
@@ -59,7 +59,7 @@ Collect before execution:
 - repository owner/name
 - pull request number or URL
 - optional review id to scope comments (e.g. `pullrequestreview-<id>`)
-- branch/worktree decision
+- branch/worktree decision (skip asking if the current checkout is already on the PR's head branch — see step 1)
 - required validation commands for the repository
 
 > **When a review URL is provided** (`github.com/<owner>/<repo>/pull/<number>#pullrequestreview-<id>`),
@@ -74,8 +74,10 @@ Optional:
 
 Follow this phase order unless the user explicitly asks for a different sequence: fetch → analyze → fix → validate → push → reply → resolve → verify. Do not interleave GitHub thread mutations with code-editing retries.
 
-1. Ask whether to use a dedicated git worktree
-   - Ask this before any other workflow questions.
+1. Determine branch/worktree context
+   - Check the current checkout's branch against the PR's head branch first.
+   - If the current branch already matches the PR's head branch, proceed directly there — do not ask about a worktree.
+   - Otherwise (current branch differs, or the workspace is on a shared/long-lived branch like `main`/`master`), ask whether to use a dedicated git worktree before any other workflow questions.
    - If yes, use/create the worktree and continue there.
 
 2. Gather unresolved comments and create working tracker

--- a/.agents/skills/fusion-mcp/CHANGELOG.md
+++ b/.agents/skills/fusion-mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.2 - 2026-07-03
+
+### patch
+
+- [#197](https://github.com/equinor/fusion-skills/pull/197) [`380c0a1`](https://github.com/equinor/fusion-skills/commit/380c0a18d417f1c8003b91eae127ec9d8b450622) Thanks [@alftore](https://github.com/alftore)! - Fix outdated hosted-server config
+
+
+  The one-click install links and manual JSON config were missing the required
+  `oauth.clientId` field, and only covered Prod (no NonProd link). Both are now
+  aligned with the upstream README.
+
 ## 1.0.1 - 2026-05-07
 
 ### patch

--- a/.agents/skills/fusion-mcp/SKILL.md
+++ b/.agents/skills/fusion-mcp/SKILL.md
@@ -3,7 +3,7 @@ name: fusion-mcp
 description: Explain what Fusion MCP is and guide users through setting it up when they need Fusion-aware MCP capabilities in Copilot workflows.
 license: MIT
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
   status: experimental
   owner: "@equinor/fusion-core"
   tags:
@@ -75,12 +75,12 @@ If details are missing, ask concise follow-up questions first.
    - `401 Unauthorized` → re-authenticate via VS Code account settings; ensure Equinor Entra account is active
    - `tools/list` returns empty or tool call fails → verify MCP server entry is selected/enabled in VS Code and retry after reloading
    - partial tool behavior → check VS Code Output > Copilot for error details and restart the MCP server
-7. When MCP setup fails or user asks to file a bug, produce a bug report draft from `assets/bug-report-template.md`.
+6. When MCP setup fails or user asks to file a bug, produce a bug report draft from `assets/bug-report-template.md`.
    - default target repository: `equinor/fusion-mcp`
    - include concrete repro steps, expected vs actual behavior, and troubleshooting already attempted
    - include non-sensitive environment details (OS, VS Code version, MCP server URL, Entra account type)
    - never include secrets, tokens, or raw credential values
-8. For uncertainty or repo-private constraints, state assumptions explicitly and link to authoritative docs instead of guessing.
+7. For uncertainty or repo-private constraints, state assumptions explicitly and link to authoritative docs instead of guessing.
 
 ## Expected output
 

--- a/.agents/skills/fusion-mcp/references/vscode-mcp-config.md
+++ b/.agents/skills/fusion-mcp/references/vscode-mcp-config.md
@@ -13,7 +13,9 @@ No Docker, no API keys, no local clone required.
 
 Click the link below to add Fusion MCP to your VS Code configuration:
 
-**[Install Fusion MCP (Prod)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%7D)**
+**NonProd:** [Install Fusion MCP (NonProd)](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp-nonprod%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.test.api.fusion-dev.net%2Fmcp%22%2C%22oauth%22%3A%7B%22clientId%22%3A%22a0327fa6-975f-4ac6-a340-d173bf6b4658%22%7D%7D)
+
+**Prod:** [Install Fusion MCP](vscode:mcp/install?%7B%22name%22%3A%22fusion-mcp%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.api.fusion.equinor.com%2Fmcp%22%2C%22oauth%22%3A%7B%22clientId%22%3A%22fe06d016-0e42-452e-a3d7-f08325037122%22%7D%7D)
 
 ## Manual setup
 
@@ -24,11 +26,16 @@ Open the VS Code Command Palette and run **MCP: Open User Configuration**, then 
   "servers": {
     "fusion-mcp": {
       "type": "http",
-      "url": "https://mcp.api.fusion.equinor.com/mcp"
+      "url": "https://mcp.api.fusion.equinor.com/mcp",
+      "oauth": {
+        "clientId": "fe06d016-0e42-452e-a3d7-f08325037122"
+      }
     }
   }
 }
 ```
+
+Use `"url": "https://mcp.test.api.fusion-dev.net/mcp"` and `"clientId": "a0327fa6-975f-4ac6-a340-d173bf6b4658"` for NonProd instead. If you want both Prod and NonProd configured side-by-side, give the NonProd entry a distinct server name (e.g. `fusion-mcp-nonprod`) instead of reusing `fusion-mcp` — otherwise it overwrites your Prod entry.
 
 ## Authentication flow
 

--- a/.agents/skills/fusion-skill-authoring/CHANGELOG.md
+++ b/.agents/skills/fusion-skill-authoring/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.5 - 2026-07-03
+
+### patch
+
+- [#197](https://github.com/equinor/fusion-skills/pull/197) [`380c0a1`](https://github.com/equinor/fusion-skills/commit/380c0a18d417f1c8003b91eae127ec9d8b450622) Thanks [@alftore](https://github.com/alftore)! - Detect installed-copy provenance before editing an existing skill
+
+
+  Adds a new Step 1 that checks `skills-lock.json` before editing an existing
+  `SKILL.md` or its supporting files. If the target matches a locked entry whose
+  `source` differs from the current repository, it is an installed copy — the
+  skill now surfaces the source repo and redirects there (or offers to draft an
+  issue) instead of silently editing a copy that would be overwritten on the
+  next update.
+
 ## 0.3.4 - 2026-05-07
 
 ### patch

--- a/.agents/skills/fusion-skill-authoring/SKILL.md
+++ b/.agents/skills/fusion-skill-authoring/SKILL.md
@@ -4,7 +4,7 @@ description: 'Creates or modernizes repository skills with clear activation cues
 license: MIT
 compatibility: Works best in repositories that can inspect their local skill catalog and run catalog-specific validation commands. Optional helper agents are most useful in Anthropic-compatible runtimes or other clients that support skill-local agents/subagents.
 metadata:
-   version: "0.3.4"
+   version: "0.3.5"
    status: active
    owner: "@equinor/fusion-core"
    tags:
@@ -101,7 +101,19 @@ Repository-specific prefix rules, ownership/lifecycle requirements, release poli
 
 ## Instructions
 
-### Step 1 — Decide whether this should be a skill at all
+### Step 1 — Check for installed-copy provenance before editing
+
+Before editing an existing `SKILL.md` (or its `references/`, `assets/`, `agents/`), check `skills-lock.json` at the repository root. Its `skillPath` values are relative to the local skills root (e.g. `caveman-compress/SKILL.md`), not absolute or fully-qualified paths — strip any leading skills-root segment (such as `.agents/skills/` or `skills/`) from the target file's path before comparing. If a stripped entry's `skillPath` matches the target this way and its `source` differs from the current repository, the target is an **installed copy**, not the canonical source.
+
+**If it is an installed copy:**
+- Do not edit in place — local edits are overwritten on the next `npx skills update` and never reach other consumers.
+- Tell the user the file is installed from `<source>`; changes belong there.
+- Offer to switch to `<source>` and make the change there, or draft a bug/improvement issue against it instead.
+- Only edit locally if the user explicitly confirms a one-off override and accepts it won't persist.
+
+If no `skills-lock.json` exists, or `source` matches the current repository, proceed normally.
+
+### Step 2 — Decide whether this should be a skill at all
 
 1. Check existing catalog first:
    - If an existing skill covers the request, recommend reuse or update instead of a duplicate
@@ -112,7 +124,7 @@ Repository-specific prefix rules, ownership/lifecycle requirements, release poli
    - a standalone script with no skill-routing value, or
    - a tiny copy edit to an existing skill
 
-### Step 2 — Define representative requests before drafting
+### Step 3 — Define representative requests before drafting
 
 Capture at least three representative requests before writing long instructions:
 - the user request or trigger phrase,
@@ -121,7 +133,7 @@ Capture at least three representative requests before writing long instructions:
 
 Use these as acceptance criteria. If you can't define realistic requests, the scope is underspecified or not reusable enough to become a skill.
 
-### Step 3 — Classify the skill and choose the smallest valid structure
+### Step 4 — Classify the skill and choose the smallest valid structure
 
 Decide skill type:
 - `capability uplift`: packages domain knowledge, tools, or reference material
@@ -141,7 +153,7 @@ Choose minimum folder structure:
 
 Keep references one level deep. Don't create nested chains that force partial reads.
 
-### Step 4 — Draft the minimum viable `SKILL.md`
+### Step 5 — Draft the minimum viable `SKILL.md`
 
 Write the smallest useful main document first:
 - concise frontmatter with strong discovery cues
@@ -162,7 +174,7 @@ Set degree of freedom intentionally:
 
 Include at least one concrete example in `SKILL.md` or link to one in `references/`.
 
-### Step 5 — Add supporting files only when they reduce ambiguity
+### Step 6 — Add supporting files only when they reduce ambiguity
 
 Move long or specialized content out of `SKILL.md`:
 - `references/` for deep guidance, large examples, API/platform notes, or long checklists
@@ -180,7 +192,7 @@ If runtime ignores bundled helper agents, follow the same roles inline.
 
 If skill depends on MCP, declare in `metadata.mcp` and document client-specific tool naming in skill content.
 
-### Step 6 — Validate discovery, structure, and local policy
+### Step 7 — Validate discovery, structure, and local policy
 
 Run validation supported by the target environment after authoring changes:
 
@@ -194,7 +206,7 @@ If no dedicated skill tooling:
 - verify each representative request would trigger the skill correctly
 - verify every referenced file path and workflow assumption is valid
 
-Use representative requests from Step 2 to review:
+Use representative requests from Step 3 to review:
 - Does the description trigger on the right requests and avoid false positives?
 - Can the agent locate all directly referenced files without chasing nested links?
 - Are outputs, approval gates, and safety constraints explicit?
@@ -207,7 +219,7 @@ If subagents are available:
 
 After portable package is correct, apply any repository-specific release or versioning rules.
 
-### Step 7 — Report what changed and what still needs input
+### Step 8 — Report what changed and what still needs input
 
 Return authoring result as explicit contract:
 - what was created or updated,
@@ -219,6 +231,7 @@ Return authoring result as explicit contract:
 
 ## Core behavior to preserve
 
+- Installed-copy provenance check before editing an existing skill
 - Reuse before creation
 - Portable first, repository overlays second
 - Representative requests before long-form wordsmithing
@@ -277,6 +290,7 @@ Never:
 - Invent validation results or evaluation evidence
 - Modify unrelated files outside the requested scope
 - Add hidden network access, remote-code execution, or unsafe script guidance
+- Edit a `skills-lock.json`-tracked installed copy in place without first surfacing its source repo and getting explicit confirmation
 
 Always:
 - Keep `SKILL.md` concise; move overflow to direct references

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "equinor/fusion-skills",
       "sourceType": "github",
       "skillPath": "skills/.experimental/fusion-github-review-resolution/SKILL.md",
-      "computedHash": "eb8e917045ed8229f608683e3eb3c433ea23e75ba27ceda620d820f080d2e2d9"
+      "computedHash": "f6403d2781c63939e0648b1a6a3526ff2a90b0b64ea0bc3edc5a8adb2890bd21"
     },
     "fusion-issue-authoring": {
       "source": "equinor/fusion-skills",
@@ -41,13 +41,13 @@
       "source": "equinor/fusion-skills",
       "sourceType": "github",
       "skillPath": "skills/.experimental/fusion-mcp/SKILL.md",
-      "computedHash": "7a16c6a48ed7fce0adb05bc3356bf49264ca55ed5100339eb11e2026f057f4af"
+      "computedHash": "5262e3a7001005d54fbdae9146bcbf223a22c8af5c339cd38e60beba6dfcb8f9"
     },
     "fusion-skill-authoring": {
       "source": "equinor/fusion-skills",
       "sourceType": "github",
       "skillPath": "skills/fusion-skill-authoring/SKILL.md",
-      "computedHash": "345ccc076009bb00c933d273281ed9d04f052c684e1a9c14a180ccee863160d8"
+      "computedHash": "8870da12468879080f218f421247b158941d28d162bd7ed299b8d8f1d4501cee"
     }
   }
 }


### PR DESCRIPTION
Upgrades `fusion-github-review-resolution`, `fusion-mcp`, and `fusion-skill-authoring` from the upstream skills catalog. Updates `skills-lock.json`.