### PR TITLE
feat(react-router): expand re-exports and add useTransitions prop

### DIFF
--- a/.changeset/fusion-framework-react-router_expand-exports.md
+++ b/.changeset/fusion-framework-react-router_expand-exports.md
@@ -1,0 +1,26 @@
+---
+"@equinor/fusion-framework-react-router": minor
+---
+
+Expand re-exports so consumers don't need a direct `react-router` or `react-dom` import.
+
+**New exports from `react-router`:**
+- `BrowserRouter`
+- `createSearchParams`
+- `generatePath`
+- `isRouteErrorResponse`
+- `type PathParam`
+- `type SetURLSearchParams`
+
+**New export from `react-dom`:**
+- `createPortal`
+
+**New `Router` prop:**
+- `useTransitions?: boolean` — forwarded to `RouterProvider`. Set to `false` to disable React transition wrapping on navigation state updates (workaround for route-change UI flashing).
+
+```tsx
+// Disable transitions to suppress route-change flash
+<Router routes={routes} useTransitions={false} />
+```
+
+Fixes: https://github.com/equinor/fusion/issues/880

--- a/.changeset/fusion-framework-react-router_expand-exports.md
+++ b/.changeset/fusion-framework-react-router_expand-exports.md
@@ -24,3 +24,4 @@ Expand re-exports so consumers don't need a direct `react-router` or `react-dom`
 ```
 
 Fixes: https://github.com/equinor/fusion/issues/880
+Thanks: @edmondbaloku for the report.

--- a/.changeset/fusion-framework-react-router_expand-exports.md
+++ b/.changeset/fusion-framework-react-router_expand-exports.md
@@ -12,9 +12,6 @@ Expand re-exports so consumers don't need a direct `react-router` or `react-dom`
 - `type PathParam`
 - `type SetURLSearchParams`
 
-**New export from `react-dom`:**
-- `createPortal`
-
 **New `Router` prop:**
 - `useTransitions?: boolean` — forwarded to `RouterProvider`. Set to `false` to disable React transition wrapping on navigation state updates (workaround for route-change UI flashing).
 

--- a/packages/react/router/src/Router.tsx
+++ b/packages/react/router/src/Router.tsx
@@ -25,8 +25,9 @@ import React from 'react';
  * @property routes - A single route node, array of route nodes, or plain React Router `RouteObject` array.
  * @property loader - Optional React element shown while lazy route chunks are loading.
  * @property context - Custom object exposed as `fusion.context` in loaders, actions, and components.
- * @property useTransitions - When `false`, disables React `useTransition` wrapping on navigation state updates.
- *   Useful for apps experiencing UI flashing on route changes. Defaults to `true`.
+ * @property useTransitions - Controls whether React Router wraps navigation state updates in `React.startTransition`.
+ *   When `undefined` (the default), React Router decides based on its own internal logic.
+ *   Set to `false` to opt out of transition wrapping — useful for apps experiencing UI flashing on route changes.
  */
 type RouterProps = {
   routes: RouteNode | RouteNode[] | RouteObject | RouteObject[];
@@ -87,7 +88,12 @@ function normalizeRoutes(
  * }
  * ```
  */
-export function Router({ routes, context, loader, useTransitions }: RouterProps) {
+export function Router({
+  routes,
+  context,
+  loader,
+  useTransitions,
+}: RouterProps): React.ReactElement | null {
   const modules = useModules();
 
   const fusionRouterContext: FusionRouterContext = useMemo(() => {

--- a/packages/react/router/src/Router.tsx
+++ b/packages/react/router/src/Router.tsx
@@ -25,11 +25,14 @@ import React from 'react';
  * @property routes - A single route node, array of route nodes, or plain React Router `RouteObject` array.
  * @property loader - Optional React element shown while lazy route chunks are loading.
  * @property context - Custom object exposed as `fusion.context` in loaders, actions, and components.
+ * @property useTransitions - When `false`, disables React `useTransition` wrapping on navigation state updates.
+ *   Useful for apps experiencing UI flashing on route changes. Defaults to `true`.
  */
 type RouterProps = {
   routes: RouteNode | RouteNode[] | RouteObject | RouteObject[];
   loader?: React.ReactElement;
   context?: RouterContext;
+  useTransitions?: boolean;
 };
 
 /**
@@ -84,7 +87,7 @@ function normalizeRoutes(
  * }
  * ```
  */
-export function Router({ routes, context, loader }: RouterProps) {
+export function Router({ routes, context, loader, useTransitions }: RouterProps) {
   const modules = useModules();
 
   const fusionRouterContext: FusionRouterContext = useMemo(() => {
@@ -190,7 +193,7 @@ export function Router({ routes, context, loader }: RouterProps) {
 
   return (
     <FusionRouterContextProvider value={fusionRouterContext}>
-      <RouterProvider router={router} />
+      <RouterProvider router={router} useTransitions={useTransitions} />
     </FusionRouterContextProvider>
   );
 }

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -52,6 +52,3 @@ export {
   useSearchParams,
   useSubmit,
 } from 'react-router';
-
-// Re-export createPortal from react-dom so consumers don't need a direct react-dom import.
-export { createPortal } from 'react-dom';

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -21,15 +21,21 @@ export type {
 // Re-export commonly used React Router hooks, components, and utilities
 // so consumers don't need to install or import `react-router` directly.
 export {
+  BrowserRouter,
   Form,
   Link,
   NavLink,
   Navigate,
   Outlet,
+  createSearchParams,
+  generatePath,
+  isRouteErrorResponse,
   matchPath,
   matchRoutes,
   redirect,
   type LinkProps,
+  type PathParam,
+  type SetURLSearchParams,
   useActionData,
   useFormAction,
   useLocation,
@@ -46,3 +52,6 @@ export {
   useSearchParams,
   useSubmit,
 } from 'react-router';
+
+// Re-export createPortal from react-dom so consumers don't need a direct react-dom import.
+export { createPortal } from 'react-dom';


### PR DESCRIPTION
**Why is this change needed?**
Consumers migrating from `react-router` directly to `@equinor/fusion-framework-react-router` were blocked because several commonly used exports were not re-exported from the package, forcing them to maintain a direct `react-router` peer import alongside the framework package.

**What is the current behavior?**
`@equinor/fusion-framework-react-router` only re-exports a subset of React Router hooks and components. `BrowserRouter`, `createSearchParams`, `generatePath`, `isRouteErrorResponse`, `PathParam`, and `SetURLSearchParams` are not available from the package. The `Router` component also has no way to disable React transition wrapping, causing UI flashing on route changes for some apps.

**What is the new behavior?**
The following are now re-exported so consumers need no direct peer imports:
- `BrowserRouter`, `createSearchParams`, `generatePath`, `isRouteErrorResponse` (from `react-router`)
- `type PathParam`, `type SetURLSearchParams` (from `react-router`)

The `Router` component accepts a new optional `useTransitions?: boolean` prop that is forwarded to `RouterProvider`, allowing apps to opt out of `React.startTransition` wrapping to suppress route-change flashing.

```tsx
// Disable transitions to suppress route-change flash
<Router routes={routes} useTransitions={false} />
```

> **Note on `createPortal`:** This was requested in the original issue but is not included — it is a `react-dom` utility with no routing concern and does not belong in this package. Import it directly from `react-dom`.

**What is the intended behavior or invariant?**
`@equinor/fusion-framework-react-router` should be the single import point for all React Router utilities — consumers must not need a direct `react-router` import for standard routing use cases.

**Does this PR introduce a breaking change?**
No. All changes are additive.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-react-router`)
- Consumer impact: New exports available; `useTransitions` prop available on `Router`
- Downstream impact: None

**Review guidance:**
- Verify the new exports in `src/index.ts` are correct names from `react-router`
- Verify `useTransitions` is forwarded correctly in `src/Router.tsx`
- Changeset is included and credits the reporter

Closes https://github.com/equinor/fusion/issues/880