### PR TITLE
docs(react-router): document all supported file-route exports

### DIFF
--- a/.changeset/fusion-framework-react-router_document-file-route-exports.md
+++ b/.changeset/fusion-framework-react-router_document-file-route-exports.md
@@ -1,0 +1,21 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Document all supported file-route exports for the React Router Vite plugin.
+
+The `README.md`, `BaseFileRoute` class, and `getAvailableExports` in the Vite plugin now carry a complete reference table of the six named exports the plugin recognises and wires into the generated React Router data route:
+
+| Export | Mapped to |
+|---|---|
+| `default` | Route component (`element`) |
+| `clientLoader` | `loader` |
+| `action` | `action` |
+| `handle` | `handle` |
+| `ErrorElement` | `errorElement` |
+| `HydrateFallback` | `hydrateFallbackElement` |
+
+The README was also updated to fix incorrect prerequisites (Fusion packages are bundled dependencies, not peer dependencies), clarify the `/context` entry point, and add GFM alert callouts for common gotchas (navigation module configuration, file-path resolution, Vite plugin being required for code-splitting).
+
+Reported by: @yusijs in https://github.com/equinor/fusion/issues/870
+Closes: https://github.com/equinor/fusion-core-tasks/issues/1630

--- a/.changeset/fusion-framework-react-router_document-file-route-exports.md
+++ b/.changeset/fusion-framework-react-router_document-file-route-exports.md
@@ -8,12 +8,12 @@ The `README.md`, `BaseFileRoute` class, and `getAvailableExports` in the Vite pl
 
 | Export | Mapped to |
 |---|---|
-| `default` | Route component (`element`) |
+| `default` | `Component` |
 | `clientLoader` | `loader` |
 | `action` | `action` |
 | `handle` | `handle` |
 | `ErrorElement` | `errorElement` |
-| `HydrateFallback` | `hydrateFallbackElement` |
+| `HydrateFallback` | `HydrateFallback` |
 
 The README was also updated to fix incorrect prerequisites (Fusion packages are bundled dependencies, not peer dependencies), clarify the `/context` entry point, and add GFM alert callouts for common gotchas (navigation module configuration, file-path resolution, Vite plugin being required for code-splitting).
 

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -166,7 +166,7 @@ const schema = await toRouteSchema(pages);
 The Vite plugin is optional but strongly recommended when using the file-route DSL. At build time it resolves each file reference in your route tree, detects which named exports are present (`clientLoader`, `action`, `handle`, etc.), and rewrites the DSL calls to standard React Router lazy data routes.
 
 > [!WARNING]
-> Without the Vite plugin, routes are **not code-split**. The entire route tree is bundled into the main chunk, which defeats the purpose of file-based routing in production builds.
+> Without the Vite plugin, **the file-route DSL does not work**. The DSL objects (`layout`, `route`, `index`, etc.) carry only a `file` path string — they have no `Component`, `loader`, or `action` wired in. The Vite plugin performs that transformation at build time. Without it, routes will render blank pages. Code-splitting is an additional benefit, not the primary one.
 
 ```ts
 // vite.config.ts

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -1,6 +1,12 @@
 # @equinor/fusion-framework-react-router
 
-Integration layer between [React Router v7](https://reactrouter.com/) and the Fusion Framework. Provides automatic navigation module wiring, typed `fusion` context injection into loaders, actions, and components, a file-style route DSL, and manifest-ready route schemas.
+Opinionated React Router v7 integration for Fusion Framework applications. Rather than wiring up navigation history, basename, and request context by hand, this package does it for you and surfaces everything as a typed `fusion` object inside every loader, action, and component.
+
+The package ships three things that work together:
+
+- **`Router` component** — drop-in replacement for `RouterProvider`. Reads `history` and `basename` from the Fusion navigation module and injects `fusion.modules` and `fusion.context` into every route.
+- **File-route DSL** — `layout`, `index`, `route`, and `prefix` helpers that build a `RouteObject` tree from file paths instead of raw objects. The Vite plugin transforms them into lazy-loaded data routes at build time.
+- **Route schema generation** — `toRouteSchema` converts `handle.route` metadata into a flat, machine-readable manifest. Useful for portal navigation trees and app documentation.
 
 ## Features
 
@@ -19,15 +25,37 @@ pnpm add @equinor/fusion-framework-react-router
 
 **Prerequisites**
 
-- React 18+ / React DOM 18+
-- `@equinor/fusion-framework-react-module`
-- `@equinor/fusion-framework-module-navigation` configured in your app
+- React 18+ (`react` is a required peer dependency)
+- `react-dom` 18+ (optional peer dependency, required for browser rendering)
+
+All other Fusion Framework packages (`@equinor/fusion-framework-module-navigation`, `@equinor/fusion-framework-react-module`) are bundled dependencies — they install automatically.
+
+> [!IMPORTANT]
+> Installing `@equinor/fusion-framework-module-navigation` is not enough. It must also be **enabled in your app's configurator** via `enableNavigation(configurator, ...)`. `Router` reads `history` and `basename` from the module at runtime and will throw if the module is not present.
+> See the [getting started guide](docs/getting-started.md) for the full configurator setup.
 
 ## Quick start
 
+> [!NOTE]
+> The examples below skip the Fusion app configurator setup. See the [getting started guide](docs/getting-started.md) for full setup instructions.
+
 ### 1. Define page modules
 
-Each page module exports a default component. Optionally export `clientLoader`, `action`, `handle`, and `ErrorElement`.
+A page module is a plain TypeScript or TSX file that React Router loads lazily when its route is matched. Export a default component to render the page. The Vite plugin scans each file for additional named exports and wires them in automatically — you do not need to register them anywhere.
+
+The following named exports are recognised:
+
+| Export | Description |
+|---|---|
+| `default` | **Required.** The page component. |
+| `clientLoader` | Route loader — called before render, receives `fusion` context. |
+| `action` | Route action — handles form submissions and mutations. |
+| `handle` | Route handle metadata, available via `useMatches()`. |
+| `ErrorElement` | Error boundary component rendered when the route throws. |
+| `HydrateFallback` | Shown during hydration while `clientLoader` resolves. |
+
+> [!NOTE]
+> Any other named export is silently ignored by the plugin. You can co-locate utilities, hooks, and helpers in the same file without side effects.
 
 ```tsx
 // src/pages/ProductPage.tsx
@@ -56,6 +84,14 @@ export default function ProductPage({ loaderData }: RouteComponentProps<{ name: 
 
 ### 2. Build the route tree
 
+The route DSL lets you describe a `RouteObject` tree using file paths instead of importing every component up front. `layout` wraps children in a shared component (header, nav, shell), `index` declares the default child route, `route` maps a path segment to a file, and `prefix` groups routes under a common segment without a layout component.
+
+> [!TIP]
+> File paths are resolved **relative to the file that calls them**, not the project root. `'./ProductPage.tsx'` in `src/pages/index.ts` resolves to `src/pages/ProductPage.tsx`.
+
+> [!CAUTION]
+> Use `prefix` when you only need to group routes under a URL segment. Use `layout` only when those routes also share a wrapper component. Wrapping in a `layout` without a real layout file adds an unnecessary render boundary.
+
 ```ts
 // src/pages/index.ts
 import { layout, index, route, prefix } from '@equinor/fusion-framework-react-router/routes';
@@ -71,6 +107,8 @@ export const pages = layout('./MainLayout.tsx', [
 
 ### 3. Mount the Router
 
+`Router` is a thin wrapper around React Router's `RouterProvider`. It reads `history` and `basename` from the Fusion navigation module so you do not have to configure them manually. Pass the route tree from step 2 as `routes`.
+
 ```tsx
 // src/Router.tsx
 import { Router } from '@equinor/fusion-framework-react-router';
@@ -82,6 +120,13 @@ export default function AppRouter() {
 ```
 
 ### Passing custom context
+
+The `fusion` object available in loaders, actions, and components always contains `fusion.modules`. If you also need to pass application-level dependencies — a query client, an API instance, environment config — add them to `fusion.context` using TypeScript module augmentation and the `context` prop on `Router`.
+
+Declare additional properties on `RouterContext` in a `.d.ts` file:
+
+> [!TIP]
+> Put the augmentation in a `.d.ts` file (e.g. `router-context.d.ts`) that TypeScript picks up via your `tsconfig.json` `include` glob, **not** inside a regular `.ts` file that imports from the package. Placing it in a `.ts` file can create circular type dependencies.
 
 ```ts
 // router-context.d.ts
@@ -107,6 +152,8 @@ Loaders and components then access `fusion.context.queryClient` with full type s
 
 ### Generating route schemas
 
+`toRouteSchema` walks the route tree and converts each `handle.route` object into a flat list of route descriptors. The output is a machine-readable manifest that portals and documentation tools can consume — for example to populate a navigation sidebar or register app routes with a portal registry.
+
 ```ts
 import { toRouteSchema } from '@equinor/fusion-framework-react-router/schema';
 import { pages } from './pages';
@@ -115,6 +162,11 @@ const schema = await toRouteSchema(pages);
 ```
 
 ### Vite plugin
+
+The Vite plugin is optional but strongly recommended when using the file-route DSL. At build time it resolves each file reference in your route tree, detects which named exports are present (`clientLoader`, `action`, `handle`, etc.), and rewrites the DSL calls to standard React Router lazy data routes.
+
+> [!WARNING]
+> Without the Vite plugin, routes are **not code-split**. The entire route tree is bundled into the main chunk, which defeats the purpose of file-based routing in production builds.
 
 ```ts
 // vite.config.ts
@@ -129,10 +181,10 @@ export default defineConfig({
 
 | Entry point | Purpose |
 |---|---|
-| `@equinor/fusion-framework-react-router` | Main — `Router`, hooks, types, and React Router re-exports |
+| `@equinor/fusion-framework-react-router` | Main — `Router`, hooks, context helpers, types, and React Router re-exports |
 | `/routes` | Route DSL — `layout`, `index`, `route`, `prefix` |
 | `/schema` | Schema generation — `toRouteSchema` |
-| `/context` | Internal context — `routerContext`, `FusionRouterContextProvider`, `useRouterContext` |
+| `/context` | Direct context imports — same `routerContext`, `FusionRouterContextProvider`, `useRouterContext` as main; use when you need to import without pulling in `Router` (e.g. tests, custom providers) |
 | `/vite-plugin` | Vite build plugin |
 | `/interop` | Interop re-exports for teams mid-migration — see [docs/interop.md](docs/interop.md) |
 

--- a/packages/react/router/src/routes/BaseFileRoute.ts
+++ b/packages/react/router/src/routes/BaseFileRoute.ts
@@ -13,8 +13,8 @@ import { BaseRoute } from './BaseRoute.js';
  * | Export | Type | Description |
  * |---|---|---|
  * | `default` | `React.ComponentType` | **Required.** The page / route component. |
- * | `clientLoader` | `LoaderFunctionArgs => MaybePromise<unknown>` | Route loader — called before the component renders. Receives `fusion` context. |
- * | `action` | `ActionFunctionArgs => MaybePromise<unknown>` | Route action — handles form submissions and mutations. Receives `fusion` context. |
+ * | `clientLoader` | `LoaderFunction` | Route loader — called before the component renders. Receives `fusion` context. |
+ * | `action` | `ActionFunction` | Route action — handles form submissions and mutations. Receives `fusion` context. |
  * | `handle` | `RouterHandle` | Arbitrary route metadata attached to `useMatches()` entries. |
  * | `ErrorElement` | `React.ComponentType<ErrorElementProps>` | Component rendered when this route or a descendant throws. Receives `error` and `fusion` props. |
  * | `HydrateFallback` | `React.ComponentType` | Component rendered during client-side hydration before `clientLoader` resolves. |

--- a/packages/react/router/src/routes/BaseFileRoute.ts
+++ b/packages/react/router/src/routes/BaseFileRoute.ts
@@ -4,6 +4,36 @@ import { BaseRoute } from './BaseRoute.js';
 /**
  * Base abstract class for file-based routes.
  * Handles lazy loading of route components from file paths or import functions.
+ *
+ * ## Supported file-route exports
+ *
+ * The Vite plugin (`reactRouterPlugin`) scans each route file for the following named exports
+ * and wires them into the generated React Router data route automatically.
+ *
+ * | Export | Type | Description |
+ * |---|---|---|
+ * | `default` | `React.ComponentType` | **Required.** The page / route component. |
+ * | `clientLoader` | `LoaderFunctionArgs => MaybePromise<unknown>` | Route loader — called before the component renders. Receives `fusion` context. |
+ * | `action` | `ActionFunctionArgs => MaybePromise<unknown>` | Route action — handles form submissions and mutations. Receives `fusion` context. |
+ * | `handle` | `RouterHandle` | Arbitrary route metadata attached to `useMatches()` entries. |
+ * | `ErrorElement` | `React.ComponentType<ErrorElementProps>` | Component rendered when this route or a descendant throws. Receives `error` and `fusion` props. |
+ * | `HydrateFallback` | `React.ComponentType` | Component rendered during client-side hydration before `clientLoader` resolves. |
+ *
+ * Any export not in the table above is ignored by the plugin.
+ *
+ * @example
+ * ```tsx
+ * // src/pages/ProductPage.tsx
+ * import type { LoaderFunctionArgs, ErrorElementProps } from '@equinor/fusion-framework-react-router';
+ *
+ * export async function clientLoader({ params, fusion }: LoaderFunctionArgs) { ... }
+ *
+ * export function ErrorElement({ error }: ErrorElementProps) {
+ *   return <p>Error: {String(error)}</p>;
+ * }
+ *
+ * export default function ProductPage() { ... }
+ * ```
  */
 export abstract class BaseFileRoute extends BaseRoute implements RouteFileNode {
   /**
@@ -22,7 +52,9 @@ export abstract class BaseFileRoute extends BaseRoute implements RouteFileNode {
 
   /**
    * @param kind - The kind of route node (`'route'`, `'index'`, `'layout'`, etc.).
-   * @param file - Path to the module that exports the route component (and optionally `clientLoader`, `action`, `handle`, `ErrorElement`).
+   * @param file - Path to the module that exports the route component and any supported named exports
+   *   (`clientLoader`, `action`, `handle`, `ErrorElement`, `HydrateFallback`). See the class-level
+   *   docs for the full export table.
    * @param handle - Optional route handle metadata. Defaults to `{ route: {} }`.
    */
   constructor(

--- a/packages/react/router/src/vite-plugin/plugin.ts
+++ b/packages/react/router/src/vite-plugin/plugin.ts
@@ -165,12 +165,12 @@ function resolveFilePath(filePath: string, baseDir: string): string | null {
  *
  * | Export | Mapped to |
  * |---|---|
- * | `default` | Route component (`element`) |
+ * | `default` | `Component` |
  * | `clientLoader` | `loader` |
  * | `action` | `action` |
  * | `handle` | `handle` |
  * | `ErrorElement` | `errorElement` |
- * | `HydrateFallback` | `hydrateFallbackElement` |
+ * | `HydrateFallback` | `HydrateFallback` |
  *
  * Any other named export in the file is silently ignored.
  */

--- a/packages/react/router/src/vite-plugin/plugin.ts
+++ b/packages/react/router/src/vite-plugin/plugin.ts
@@ -159,7 +159,20 @@ function resolveFilePath(filePath: string, baseDir: string): string | null {
 }
 
 /**
- * Checks what exports exist in a file
+ * Scans a route file and returns the set of recognised export names.
+ *
+ * The following exports are detected and wired into the generated React Router data route:
+ *
+ * | Export | Mapped to |
+ * |---|---|
+ * | `default` | Route component (`element`) |
+ * | `clientLoader` | `loader` |
+ * | `action` | `action` |
+ * | `handle` | `handle` |
+ * | `ErrorElement` | `errorElement` |
+ * | `HydrateFallback` | `hydrateFallbackElement` |
+ *
+ * Any other named export in the file is silently ignored.
  */
 function getAvailableExports(filePath: string, currentFileId: string, debug: boolean): Set<string> {
   const availableExports = new Set<string>();


### PR DESCRIPTION
**Why is this change needed?**

The `@equinor/fusion-framework-react-router` Vite plugin recognises six named exports from route files (`clientLoader`, `action`, `handle`, `ErrorElement`, `HydrateFallback`) and wires them into React Router data routes at build time. This was undocumented: none of the exports were listed anywhere in the README, `BaseFileRoute` TSDoc, or the plugin source. Developers had to read the plugin source to discover what was supported.

Reported by @yusijs in equinor/fusion#870 — the Roma team noticed the gap while migrating to the file-based DSL.

**What is the current behavior?**

- `BaseFileRoute` constructor TSDoc listed only four exports (`clientLoader`, `action`, `handle`, `ErrorElement`) and omitted `HydrateFallback`.
- `getAvailableExports()` in the Vite plugin had a single-line comment ("Checks what exports exist in a file") with no mention of what exports are recognised.
- The README mentioned only `clientLoader`, `action`, `handle`, and `ErrorElement` in a prose sentence with no table.
- The README prerequisites incorrectly listed `@equinor/fusion-framework-react-module` and `@equinor/fusion-framework-module-navigation` as packages consumers must install — both are regular `dependencies` that install automatically.
- The `/context` entry point was described as "Internal context", obscuring that the same exports are already available from the main entry.

**What is the new behavior?**

- `BaseFileRoute` has a class-level TSDoc table covering all six supported exports with types, descriptions, and a `@example` block.
- `getAvailableExports()` has a full JSDoc block with an `export → route property` mapping table.
- The README has:
  - An introductory paragraph explaining what the package ships and why
  - A proper export table in the "Define page modules" section
  - Short explanatory prose before each Quick start step
  - GFM alert callouts (`[!IMPORTANT]`, `[!TIP]`, `[!WARNING]`, `[!CAUTION]`) at the spots most likely to trip up new adopters
  - Corrected prerequisites (only actual peer dependencies listed)
  - Clarified `/context` entry point description

**What is the intended behavior or invariant?**

Any export a route file can declare that the Vite plugin acts on must appear in the README export table and in the `BaseFileRoute` TSDoc. The two reference tables (class doc and plugin doc) must stay in sync with the `exportNames` array in `getAvailableExports()`.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`@equinor/fusion-framework-react-router`)
- Consumer impact: Documentation-only. No runtime or API changes.
- Downstream impact: None.

**Review guidance:**

Docs-only PR — no logic changed. Review focus:

1. Verify the export table in the README matches the `exportNames` array in `packages/react/router/src/vite-plugin/plugin.ts` (~line 305).
2. Check the GFM alert callouts are accurate (especially the `[!IMPORTANT]` on navigation module config and the `[!WARNING]` on Vite plugin code-splitting).
3. The `[!CAUTION]` on `layout` vs `prefix` — confirm it reflects actual render boundary behaviour.

**Additional context**

`shouldRevalidate` is explicitly **not** included — it is not yet wired in the plugin and is tracked separately in equinor/fusion-core-tasks#1631.

**Related issues**

closes: equinor/fusion-core-tasks#1630
ref: equinor/fusion#870

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
