### PR TITLE
feat(react-router): add shouldRevalidate support to file-route Vite plugin

### DIFF
--- a/.changeset/fusion-framework-react-router_add-should-revalidate.md
+++ b/.changeset/fusion-framework-react-router_add-should-revalidate.md
@@ -1,0 +1,22 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Add `shouldRevalidate` support to the file-route Vite plugin.
+
+The Vite plugin now detects and wires a `shouldRevalidate` named export from route files into the generated React Router data route. This allows apps to control whether a route re-runs its loader after a navigation or action — for example to prevent revalidation on search-parameter-only changes.
+
+```ts
+// src/pages/ProductsPage.tsx
+import type { ShouldRevalidateFunctionArgs } from 'react-router';
+
+export function shouldRevalidate({ currentUrl, nextUrl }: ShouldRevalidateFunctionArgs) {
+  // Only revalidate when the path segment changes, not on search param updates
+  return currentUrl.pathname !== nextUrl.pathname;
+}
+
+export default function ProductsPage() { ... }
+```
+
+Reported by: @yusijs in equinor/fusion#870
+Closes: https://github.com/equinor/fusion-core-tasks/issues/1631

--- a/packages/react/router/README.md
+++ b/packages/react/router/README.md
@@ -53,6 +53,7 @@ The following named exports are recognised:
 | `handle` | Route handle metadata, available via `useMatches()`. |
 | `ErrorElement` | Error boundary component rendered when the route throws. |
 | `HydrateFallback` | Shown during hydration while `clientLoader` resolves. |
+| `shouldRevalidate` | Controls whether the route re-runs its loader after navigation or an action. Return `false` to suppress revalidation. |
 
 > [!NOTE]
 > Any other named export is silently ignored by the plugin. You can co-locate utilities, hooks, and helpers in the same file without side effects.

--- a/packages/react/router/src/__tests__/mocks/pages/UserDetailPage.tsx
+++ b/packages/react/router/src/__tests__/mocks/pages/UserDetailPage.tsx
@@ -1,4 +1,5 @@
 import type { LoaderFunctionArgs, ErrorElementProps } from '@equinor/fusion-framework-react-router';
+import type { ShouldRevalidateFunctionArgs } from 'react-router';
 
 export async function clientLoader({ params, fusion }: LoaderFunctionArgs) {
   return { userId: params.id, loaded: true };
@@ -10,6 +11,10 @@ export function ErrorElement({ error, fusion }: ErrorElementProps) {
 
 export function HydrateFallback() {
   return <div>Loading user details...</div>;
+}
+
+export function shouldRevalidate({ currentUrl, nextUrl }: ShouldRevalidateFunctionArgs) {
+  return currentUrl.pathname !== nextUrl.pathname;
 }
 
 export default function UserDetailPage() {

--- a/packages/react/router/src/__tests__/vite-plugin.test.ts
+++ b/packages/react/router/src/__tests__/vite-plugin.test.ts
@@ -57,7 +57,7 @@ describe('reactRouterPlugin', () => {
     expect(normalizeCode(transformResult)).toBe(normalizeCode(expected));
   });
 
-  it('should transform route with clientLoader, ErrorElement, and HydrateFallback', () => {
+  it('should transform route with clientLoader, ErrorElement, HydrateFallback, and shouldRevalidate', () => {
     const inputCode = [
       `import { route } from '@equinor/fusion-framework-react-router/routes';`,
       `export const routes = route(':id', './mocks/pages/UserDetailPage.tsx');`,
@@ -75,14 +75,16 @@ describe('reactRouterPlugin', () => {
       `    default as UserDetailPage,`,
       `    clientLoader as clientLoaderUserDetailPage,`,
       `    ErrorElement as ErrorElementUserDetailPage,`,
-      `    HydrateFallback as HydrateFallbackUserDetailPage`,
+      `    HydrateFallback as HydrateFallbackUserDetailPage,`,
+      `    shouldRevalidate as shouldRevalidateUserDetailPage`,
       `} from './mocks/pages/UserDetailPage.tsx';`,
       `export const routes = [{`,
       `        path: ':id',`,
       `        Component: UserDetailPage,`,
       `        loader: clientLoaderUserDetailPage,`,
       `        errorElement: ErrorElementUserDetailPage,`,
-      `        HydrateFallback: HydrateFallbackUserDetailPage`,
+      `        HydrateFallback: HydrateFallbackUserDetailPage,`,
+      `        shouldRevalidate: shouldRevalidateUserDetailPage`,
       `    }];`,
     ].join('\n');
 

--- a/packages/react/router/src/routes/BaseFileRoute.ts
+++ b/packages/react/router/src/routes/BaseFileRoute.ts
@@ -18,6 +18,7 @@ import { BaseRoute } from './BaseRoute.js';
  * | `handle` | `RouterHandle` | Arbitrary route metadata attached to `useMatches()` entries. |
  * | `ErrorElement` | `React.ComponentType<ErrorElementProps>` | Component rendered when this route or a descendant throws. Receives `error` and `fusion` props. |
  * | `HydrateFallback` | `React.ComponentType` | Component rendered during client-side hydration before `clientLoader` resolves. |
+ * | `shouldRevalidate` | `ShouldRevalidateFunction` | Controls whether the route re-runs its loader after a navigation or action. Return `false` to suppress revalidation. |
  *
  * Any export not in the table above is ignored by the plugin.
  *

--- a/packages/react/router/src/vite-plugin/plugin.ts
+++ b/packages/react/router/src/vite-plugin/plugin.ts
@@ -200,7 +200,14 @@ function getAvailableExports(filePath: string, currentFileId: string, debug: boo
     }
 
     // Check for named exports and re-exports
-    const exportNames = ['clientLoader', 'action', 'handle', 'ErrorElement', 'HydrateFallback', 'shouldRevalidate'];
+    const exportNames = [
+      'clientLoader',
+      'action',
+      'handle',
+      'ErrorElement',
+      'HydrateFallback',
+      'shouldRevalidate',
+    ];
     for (const name of exportNames) {
       if (
         fileContent.match(EXPORT_NAMED_PATTERN(name)) ||

--- a/packages/react/router/src/vite-plugin/plugin.ts
+++ b/packages/react/router/src/vite-plugin/plugin.ts
@@ -70,6 +70,7 @@ interface RouteImports {
   handle?: string;
   errorElement?: string;
   hydrateFallback?: string;
+  shouldRevalidate?: string;
   availableExports: Set<string>;
 }
 
@@ -171,6 +172,7 @@ function resolveFilePath(filePath: string, baseDir: string): string | null {
  * | `handle` | `handle` |
  * | `ErrorElement` | `errorElement` |
  * | `HydrateFallback` | `HydrateFallback` |
+ * | `shouldRevalidate` | `shouldRevalidate` |
  *
  * Any other named export in the file is silently ignored.
  */
@@ -198,7 +200,7 @@ function getAvailableExports(filePath: string, currentFileId: string, debug: boo
     }
 
     // Check for named exports and re-exports
-    const exportNames = ['clientLoader', 'action', 'handle', 'ErrorElement', 'HydrateFallback'];
+    const exportNames = ['clientLoader', 'action', 'handle', 'ErrorElement', 'HydrateFallback', 'shouldRevalidate'];
     for (const name of exportNames) {
       if (
         fileContent.match(EXPORT_NAMED_PATTERN(name)) ||
@@ -257,6 +259,10 @@ function buildRouteProperties(imports: RouteImports): string {
     properties.push(`HydrateFallback: ${imports.hydrateFallback}`);
   }
 
+  if (imports.shouldRevalidate) {
+    properties.push(`shouldRevalidate: ${imports.shouldRevalidate}`);
+  }
+
   return properties.join(',\n        ');
 }
 
@@ -298,6 +304,9 @@ function generateImportStatements(
     }
     if (imports.hydrateFallback) {
       importParts.push(`HydrateFallback as ${imports.hydrateFallback}`);
+    }
+    if (imports.shouldRevalidate) {
+      importParts.push(`shouldRevalidate as ${imports.shouldRevalidate}`);
     }
 
     if (importParts.length > 0) {
@@ -608,6 +617,9 @@ export const reactRouterPlugin = (options: ReactRouterPluginOptions = {}): Plugi
               : undefined,
             hydrateFallback: availableExports.has('HydrateFallback')
               ? `HydrateFallback${componentName}`
+              : undefined,
+            shouldRevalidate: availableExports.has('shouldRevalidate')
+              ? `shouldRevalidate${componentName}`
               : undefined,
             availableExports,
           });


### PR DESCRIPTION
**Why is this change needed?**

Apps migrating to the file-based route DSL have no way to export `shouldRevalidate` from a route file — the Vite plugin's export scanner silently ignores it. Teams that rely on `shouldRevalidate` to suppress loader revalidation on search-parameter-only navigations are blocked from adopting the file-based DSL.

Reported by @yusijs (Roma team) in equinor/fusion#870.

**What is the current behavior?**

`getAvailableExports()` in the Vite plugin scans for `['clientLoader', 'action', 'handle', 'ErrorElement', 'HydrateFallback']`. A `shouldRevalidate` export in a route file is detected by neither the scanner nor the import generator, so it is never wired into the generated React Router route object.

**What is the new behavior?**

`shouldRevalidate` is added to the scanned export list. When present, the plugin:
- aliases it as `shouldRevalidate<ComponentName>` in the generated import statement
- emits `shouldRevalidate: shouldRevalidate<ComponentName>` in the route object

Usage in a route file:

```ts
import type { ShouldRevalidateFunctionArgs } from 'react-router';

export function shouldRevalidate({ currentUrl, nextUrl }: ShouldRevalidateFunctionArgs) {
  // Suppress revalidation when only search params change
  return currentUrl.pathname !== nextUrl.pathname;
}
```

**What is the intended behavior or invariant?**

Every named export the plugin acts on must appear in the `exportNames` array in `getAvailableExports()`, in `RouteImports`, in `buildRouteProperties()`, and in `generateImportStatements()`. All four sites are updated together.

**Does this PR introduce a breaking change?**

No. Existing route files without `shouldRevalidate` are unaffected.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (`@equinor/fusion-framework-react-router`)
- Consumer impact: Opt-in. No changes required for existing apps.
- Downstream impact: None.

**Review guidance:**

Single-concern change. Four coordinated edit sites in `plugin.ts` + mock + test + docs.

1. Verify all four plugin sites are updated consistently: `RouteImports`, `exportNames`, `buildRouteProperties`, `generateImportStatements`.
2. Check the test assertion covers the full generated output (import alias + route property).
3. `shouldRevalidate` is passed through as-is — it does not receive `fusion` context injection (correct; React Router calls it with `ShouldRevalidateFunctionArgs` only).

**Related issues**

closes: equinor/fusion-core-tasks#1631
ref: equinor/fusion#870

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
