### PR TITLE
feat(linting): search parent directories for fusion-lint config and wire it into the CLI

### DIFF
--- a/.changeset/fusion-lint-cli_initial-release.md
+++ b/.changeset/fusion-lint-cli_initial-release.md
@@ -12,3 +12,5 @@ pnpm exec fusion-lint changed      # lint only git-changed .ts/.tsx files
 ```
 
 Outputs GitHub Actions annotations (`::warning` / `::error`) when running in CI.
+
+Both commands automatically pick up a `fusion-lint.config.*` / `.fusion-lintrc.*` project file, searching upward from the current directory to the repository root, layering it over `recommendedConfig` and allowing `--rule` overrides to take final precedence.

--- a/.changeset/fusion-lint-config_initial-release.md
+++ b/.changeset/fusion-lint-config_initial-release.md
@@ -5,3 +5,5 @@
 Initial release of `@equinor/fusion-framework-lint-config`.
 
 Provides the configuration loader and `recommended` rule preset for Fusion Framework linting. Supports `fusion-lint.config.ts`, `fusion-lint.config.js`, `.fusion-lintrc.json`, and `.fusion-lintrc.yaml`.
+
+`loadLintConfig` searches from the given directory upward through parent directories until a config file is found or the repository root (the directory containing `.git`) has been checked, so a single config at your monorepo root applies to every nested package. Pass `findUp: false` to only check the given directory.

--- a/packages/linting/cli/README.md
+++ b/packages/linting/cli/README.md
@@ -81,17 +81,24 @@ itself ignores (`git ls-files --exclude-standard`), so it has no `--skip-gitigno
 
 ## Rule configuration
 
-Both commands run with the curated `recommendedRules` + `recommendedConfig` from
-[`@equinor/fusion-framework-lint-config`](../config/). Override individual rule severities
-per invocation with `--rule`:
+Both commands start from the curated `recommendedRules` + `recommendedConfig` from
+[`@equinor/fusion-framework-lint-config`](../config/), then layer in a project config file if
+one is found. Severity resolution, lowest to highest precedence:
+
+1. `recommendedConfig` / `recommendedRules`
+2. A `fusion-lint.config.*` / `.fusion-lintrc.*` file, resolved by searching from the current
+   working directory upward through parent directories until one is found or the repository
+   root (the directory containing `.git`) has been checked — so a single config at your
+   monorepo root applies to every package without duplicating it
+3. `--rule <id>=<severity>` overrides, which always win
 
 ```bash
 fusion-lint src --rule require-intent-comment=error --rule require-tsdoc=off
 ```
 
-> The CLI does not currently read a `fusion-lint.config.*` / `.fusion-lintrc.*` project file
-> (the VS Code extension and LSP server do). Use `--rule` overrides, or consume the
-> [programmatic API](#programmatic-api) directly if you need `loadLintConfig`.
+See [`@equinor/fusion-framework-lint-config`](../config/) for the supported config file
+formats (flat severity maps, rich `{ rules, customRules }` objects, and factory-style
+`defineConfig` builders).
 
 ## Reporters
 

--- a/packages/linting/cli/src/commands/changed.ts
+++ b/packages/linting/cli/src/commands/changed.ts
@@ -4,9 +4,7 @@ import { resolve, extname, basename } from 'node:path';
 import { Command } from 'commander';
 import ora from 'ora';
 import { simpleGit } from 'simple-git';
-import { LintEngine } from '@equinor/fusion-framework-lint-core';
-import type { LintConfig, Diagnostic } from '@equinor/fusion-framework-lint-core';
-import { recommendedConfig, recommendedRules } from '@equinor/fusion-framework-lint-config';
+import type { Diagnostic } from '@equinor/fusion-framework-lint-core';
 import {
   formatAnnotations,
   formatPretty,
@@ -15,6 +13,7 @@ import {
   formatJson,
   resolveReporter,
 } from '../formatter/index.js';
+import { createConfiguredEngine } from '../create-engine.js';
 
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 
@@ -114,16 +113,6 @@ async function runChanged(options: ChangedOptions): Promise<void> {
   const isCI = reporter === 'github-actions';
   const isMachineReadable = reporter === 'rdjsonl' || reporter === 'json';
 
-  // Apply per-invocation rule severity overrides on top of the recommended config
-  const config: LintConfig = { ...recommendedConfig };
-  // Process each --rule=id=severity argument
-  for (const override of options.rule ?? []) {
-    const eqIdx = override.indexOf('=');
-    // Guard: skip malformed overrides that lack a '=' separator
-    if (eqIdx === -1) continue;
-    config[override.slice(0, eqIdx)] = override.slice(eqIdx + 1) as LintConfig[string];
-  }
-
   const modeLabel = options.staged
     ? 'staged files'
     : options.against
@@ -143,7 +132,7 @@ async function runChanged(options: ChangedOptions): Promise<void> {
     return;
   }
 
-  const engine = new LintEngine(recommendedRules, config);
+  const engine = await createConfiguredEngine(options.rule);
   const results: Array<{ file: string; diagnostics: Diagnostic[] }> = [];
   let scanned = 0;
 

--- a/packages/linting/cli/src/commands/lint.ts
+++ b/packages/linting/cli/src/commands/lint.ts
@@ -3,9 +3,7 @@ import { basename } from 'node:path';
 import { Command } from 'commander';
 import { globby } from 'globby';
 import ora from 'ora';
-import { LintEngine } from '@equinor/fusion-framework-lint-core';
-import type { LintConfig, Diagnostic } from '@equinor/fusion-framework-lint-core';
-import { recommendedConfig, recommendedRules } from '@equinor/fusion-framework-lint-config';
+import type { Diagnostic } from '@equinor/fusion-framework-lint-core';
 import {
   formatAnnotations,
   formatPretty,
@@ -14,6 +12,7 @@ import {
   formatJson,
   resolveReporter,
 } from '../formatter/index.js';
+import { createConfiguredEngine } from '../create-engine.js';
 
 interface LintOptions {
   githubActions?: boolean;
@@ -63,17 +62,7 @@ async function runLint(patterns: string[], options: LintOptions): Promise<void> 
   const isCI = reporter === 'github-actions';
   const isMachineReadable = reporter === 'rdjsonl' || reporter === 'json';
 
-  // Apply per-invocation rule severity overrides on top of the recommended config
-  const config: LintConfig = { ...recommendedConfig };
-  // Process each --rule=id=severity argument
-  for (const override of options.rule ?? []) {
-    const eqIdx = override.indexOf('=');
-    // Guard: skip malformed overrides that lack a '=' separator
-    if (eqIdx === -1) continue;
-    config[override.slice(0, eqIdx)] = override.slice(eqIdx + 1) as LintConfig[string];
-  }
-
-  const engine = new LintEngine(recommendedRules, config);
+  const engine = await createConfiguredEngine(options.rule);
   const spinner =
     isCI || isMachineReadable
       ? null

--- a/packages/linting/cli/src/create-engine.ts
+++ b/packages/linting/cli/src/create-engine.ts
@@ -1,0 +1,37 @@
+import { LintEngine } from '@equinor/fusion-framework-lint-core';
+import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+import {
+  loadLintConfig,
+  recommendedConfig,
+  recommendedRules,
+} from '@equinor/fusion-framework-lint-config';
+
+/**
+ * Builds a {@link LintEngine} for the `lint` and `changed` commands.
+ *
+ * Severity resolution, lowest to highest precedence:
+ * 1. `recommendedConfig` / `recommendedRules`
+ * 2. A project `fusion-lint.config.*` / `.fusion-lintrc.*` file, found by
+ *    searching from `process.cwd()` upward to the repository root (see
+ *    {@link loadLintConfig})
+ * 3. `--rule <id>=<severity>` CLI overrides
+ *
+ * @param ruleOverrides - Raw `--rule` option values, e.g. `['require-tsdoc=off']`.
+ * @returns A configured `LintEngine`, including any custom rules registered by the project config.
+ */
+export async function createConfiguredEngine(ruleOverrides: string[] = []): Promise<LintEngine> {
+  const loaded = await loadLintConfig({ base: recommendedConfig });
+  // A project config may register custom rules alongside the recommended set
+  const rules = loaded ? [...recommendedRules, ...loaded.customRules] : recommendedRules;
+  const config: LintConfig = { ...(loaded?.config ?? recommendedConfig) };
+
+  // Process each --rule=id=severity argument, taking precedence over the project config
+  for (const override of ruleOverrides) {
+    const eqIdx = override.indexOf('=');
+    // Guard: skip malformed overrides that lack a '=' separator
+    if (eqIdx === -1) continue;
+    config[override.slice(0, eqIdx)] = override.slice(eqIdx + 1) as LintConfig[string];
+  }
+
+  return new LintEngine(rules, config);
+}

--- a/packages/linting/config/src/__tests__/fixtures/find-up/fusion-lint.config.json
+++ b/packages/linting/config/src/__tests__/fixtures/find-up/fusion-lint.config.json
@@ -1,0 +1,4 @@
+{
+  "require-tsdoc": "error",
+  "require-intent-comment": "warn"
+}

--- a/packages/linting/config/src/__tests__/load-config.test.ts
+++ b/packages/linting/config/src/__tests__/load-config.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { loadLintConfig } from '../load-config.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -101,6 +103,50 @@ describe('loadLintConfig', () => {
       const [rule] = result?.customRules ?? [];
 
       expect(rule?.check('const x = 1;', 'test.ts')).toEqual([]);
+    });
+  });
+
+  describe('find-up', () => {
+    it('finds a config file in an ancestor directory by default', async () => {
+      const result = await loadLintConfig({ cwd: fixture('find-up/nested/deep') });
+
+      expect(result).toEqual({
+        config: { 'require-tsdoc': 'error', 'require-intent-comment': 'warn' },
+        customRules: [],
+      });
+    });
+
+    it('returns null when findUp is disabled and cwd has no config of its own', async () => {
+      const result = await loadLintConfig({
+        cwd: fixture('find-up/nested/deep'),
+        findUp: false,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('stops walking up once a directory containing .git has been checked', async () => {
+      // Build a throwaway tree so this test doesn't depend on the real repo layout:
+      // <tmp>/fusion-lint.config.json   (must NOT be found)
+      // <tmp>/repo/.git                 (repo root boundary marker)
+      // <tmp>/repo/nested/              (search starts here)
+      const tmpRoot = await mkdtemp(join(tmpdir(), 'fusion-lint-find-up-'));
+      try {
+        await writeFile(
+          join(tmpRoot, 'fusion-lint.config.json'),
+          JSON.stringify({ 'require-tsdoc': 'error' }),
+        );
+        const repoDir = join(tmpRoot, 'repo');
+        const nestedDir = join(repoDir, 'nested');
+        await mkdir(nestedDir, { recursive: true });
+        await writeFile(join(repoDir, '.git'), 'gitdir: /elsewhere\n');
+
+        const result = await loadLintConfig({ cwd: nestedDir });
+
+        expect(result).toBeNull();
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/linting/config/src/load-config.ts
+++ b/packages/linting/config/src/load-config.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { importConfig, resolveConfigFile, FileNotFoundError } from '@equinor/fusion-imports';
 import type { LintConfig, Rule } from '@equinor/fusion-framework-lint-core';
@@ -17,7 +18,7 @@ const CONFIG_EXTENSIONS = ['.ts', '.js', '.json', '.yml', '.yaml'] as const;
  */
 export interface LoadLintConfigOptions {
   /**
-   * Directory to search for the configuration file.
+   * Directory to start searching for the configuration file from.
    * @default process.cwd()
    */
   cwd?: string;
@@ -27,6 +28,60 @@ export interface LoadLintConfigOptions {
    * @default {}
    */
   base?: LintConfig;
+  /**
+   * When `true`, searches parent directories for a config file if none is
+   * found in `cwd` — useful when linting a file deep inside a monorepo
+   * package that inherits its config from the repo root. The search stops
+   * after checking the directory containing `.git` (the repo root), so it
+   * never reads a config from outside the current repository.
+   * @default true
+   */
+  findUp?: boolean;
+}
+
+/**
+ * Returns `true` when `dir` contains a `.git` entry (directory or file, the
+ * latter used by git worktrees), marking it as the repository root.
+ */
+async function isRepoRoot(dir: string): Promise<boolean> {
+  try {
+    await access(join(dir, '.git'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the first accessible config file starting at `startDir`, walking
+ * up through parent directories when `findUp` is enabled. The walk stops
+ * after checking the repository root (detected via `.git`), or at the
+ * filesystem root if no `.git` is found.
+ */
+async function resolveConfigFileUpwards(startDir: string, findUp: boolean): Promise<string> {
+  let dir = resolvePath(startDir);
+
+  // Directory-walk loop: try each directory, then step up unless a boundary was hit
+  while (true) {
+    try {
+      return await resolveConfigFile([...CONFIG_BASENAMES], {
+        baseDir: dir,
+        extensions: [...CONFIG_EXTENSIONS],
+      });
+    } catch (err) {
+      // Anything other than "not found in this directory" is a real failure — propagate it
+      if (!(err instanceof FileNotFoundError)) throw err;
+    }
+    // Parent of the filesystem root is itself — that's the walk-terminating condition below
+    const parent = dirname(dir);
+    // Guard: find-up disabled, or repo/filesystem root already checked — stop searching
+    if (!findUp || parent === dir || (await isRepoRoot(dir))) {
+      throw new FileNotFoundError(
+        `No configuration file found for basename '${CONFIG_BASENAMES.join("', '")}'`,
+      );
+    }
+    dir = parent;
+  }
 }
 
 /**
@@ -53,7 +108,9 @@ function normalise(raw: FusionLintFileConfig): LoadedLintConfig {
 }
 
 /**
- * Loads a `fusion-lint` configuration file from the given directory.
+ * Loads a `fusion-lint` configuration file, searching from `cwd` upward
+ * through parent directories (stopping at the repository root) unless
+ * `findUp` is disabled.
  *
  * Searches for `fusion-lint.config` or `.fusion-lintrc` with extensions
  * `.ts`, `.js`, `.json`, `.yml`, or `.yaml` — in that order.
@@ -76,11 +133,8 @@ export async function loadLintConfig(
   let filePath: string;
 
   try {
-    // Find the first accessible config file across all basenames and extensions
-    filePath = await resolveConfigFile([...CONFIG_BASENAMES], {
-      baseDir,
-      extensions: [...CONFIG_EXTENSIONS],
-    });
+    // Find the first accessible config file, walking up to the repo root when enabled
+    filePath = await resolveConfigFileUpwards(baseDir, options.findUp ?? true);
   } catch (err) {
     // Guard: no config file present — caller falls back to defaults
     if (err instanceof FileNotFoundError) return null;


### PR DESCRIPTION
**Why is this change needed?**
#5037 (`feat(linting): add fusion-lint toolchain`) merged before this follow-up work landed. `loadLintConfig` only checked the exact directory it was given, and the `fusion-lint` CLI never called it at all — `lint`/`changed` only ever used `recommendedConfig` plus `--rule` overrides, so a project's `fusion-lint.config.*` had no effect unless you hand-wired it yourself.

**What is the current behavior?**
- `loadLintConfig({ cwd })` only looks for a config file in `cwd` itself.
- `fusion-lint lint` / `fusion-lint changed` never read a project config file at all.

**What is the new behavior?**
- `loadLintConfig` now walks upward from `cwd` through parent directories until it finds a config file or has checked the repository root (the directory containing `.git`), so one `fusion-lint.config.*` at a monorepo root applies to every nested package. Opt out with `findUp: false`.
- The CLI's `lint` and `changed` commands now call `loadLintConfig` and layer the result over `recommendedConfig`/`recommendedRules`, with `--rule` overrides still taking final precedence. The duplicated inline config-building logic in both commands was extracted into a shared `createConfiguredEngine()` helper.
- Updated the CLI README's "Rule configuration" section, which previously stated the CLI didn't read project config files.

**What is the intended behavior or invariant?**
- The upward search never crosses a repository boundary: it stops after checking the directory containing `.git`, so it can't accidentally pick up a config file from outside the current repo (e.g. a parent folder holding multiple unrelated repos).
- `--rule` CLI flags always win over a project config file, which always wins over `recommendedConfig`.

**Does this PR introduce a breaking change?**
No. `findUp` defaults to `true` but is additive — behavior for callers with no config file, or with `findUp: false`, is unchanged. The CLI previously ignored project config files entirely, so auto-loading one is a backward-compatible enhancement (nothing today relies on the CLI *not* reading a config file).

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (both `@equinor/fusion-framework-lint-config` and `@equinor/fusion-lint` are still pre-release; existing initial-release changesets updated to describe this behavior rather than adding new changesets)
- Consumer impact: Projects with a `fusion-lint.config.*` at their repo root now get it applied automatically by the CLI, without needing `--rule` flags for every override
- Downstream impact: `@equinor/fusion-framework-lint-cli` and `@equinor/fusion-framework-lint-config` only; no other packages consume `loadLintConfig` yet

**Review guidance:**
- `packages/linting/config/src/load-config.ts`: the `resolveConfigFileUpwards`/`isRepoRoot` walk logic
- `packages/linting/cli/src/create-engine.ts`: the shared engine-building/precedence logic used by both commands
- New tests in `packages/linting/config/src/__tests__/load-config.test.ts` cover ancestor discovery, `findUp: false`, and the repo-boundary stop (via a dynamically created temp directory, since git refuses to track a path literally named `.git`)
- Manually verified end-to-end with a temp mock monorepo (root config + nested package) confirming the CLI picks up and applies the ancestor config

**Additional context**
None.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
