### PR TITLE
feat(linting): rename VS Code extension to fusion-ts-lint-vscode and auto-publish to Marketplace

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,10 @@
   "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "minor",
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  },
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"

--- a/.changeset/fusion-ts-lint-vscode_initial-release.md
+++ b/.changeset/fusion-ts-lint-vscode_initial-release.md
@@ -1,7 +1,7 @@
 ---
-"fusion-lint-vscode": minor
+"fusion-ts-lint-vscode": minor
 ---
 
-Initial release of `fusion-lint-vscode` VS Code extension.
+Initial release of `fusion-ts-lint-vscode` VS Code extension.
 
 Integrates Fusion Framework lint rules into the editor via the LSP server. Squiggles appear inline on `.ts` and `.tsx` files with hover details including the rule ID and severity.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,57 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  # Publish the Fusion TS Lint VS Code extension to the Marketplace.
+  #
+  # The extension's package.json is "private" (it ships via the Marketplace,
+  # not npm). `privatePackages.tag: true` (.changeset/config.json) makes
+  # `changeset tag` create a git tag for it anyway on release. Rather than
+  # relying on changesets/action's `publishedPackages` output (which parses
+  # "New tag:" lines from that command's stdout — an implementation detail),
+  # we check directly whether that tag now points at *this* commit, i.e.
+  # whether this push is the exact release commit that bumped the extension.
+  publish-vscode-extension:
+    name: Publish VS Code extension to Marketplace
+    needs: release-pkg
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for a new release tag at this commit
+        id: check
+        run: |
+          VERSION=$(node -p "require('./packages/linting/vscode/package.json').version")
+          TAG="fusion-ts-lint-vscode@${VERSION}"
+          TAG_SHA=$(git rev-list -n 1 "$TAG" 2>/dev/null || echo "")
+          if [ "$TAG_SHA" = "$GITHUB_SHA" ]; then
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup node and install deps
+        if: steps.check.outputs.should-publish == 'true'
+        uses: ./.github/actions/node-setup
+
+      # Build the extension and its workspace dependencies (lsp, rules, core)
+      # in the correct order — vsce does not run the "prepack" build hook.
+      # The trailing "..." is required so turbo includes fusion-ts-lint-vscode's
+      # dependencies in the run, not just the extension package itself.
+      - name: Build extension
+        if: steps.check.outputs.should-publish == 'true'
+        run: pnpm turbo build --filter=fusion-ts-lint-vscode...
+
+      - name: Publish to VS Code Marketplace
+        if: steps.check.outputs.should-publish == 'true'
+        working-directory: packages/linting/vscode
+        run: pnpm exec vsce publish --no-dependencies
+        env:
+          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_PAT }}
+
   # Update documentation only when packages are published
   # Uses dispatched workflow with minimal required permissions
   documentation:

--- a/packages/linting/README.md
+++ b/packages/linting/README.md
@@ -82,4 +82,4 @@ core → rules → config → cli
 | [`@equinor/fusion-framework-lint-config`](./config/) | `recommended` preset and config loader |
 | [`@equinor/fusion-lint`](./cli/) | CLI — `fusion-lint check` and `fusion-lint changed` |
 | [`@equinor/fusion-framework-lint-lsp`](./lsp/) | LSP server for editor integration |
-| [`fusion-lint-vscode`](./vscode/) | VS Code extension — squiggles, Problems panel, hover messages |
+| [`fusion-ts-lint-vscode`](./vscode/) | VS Code extension — squiggles, Problems panel, hover messages |

--- a/packages/linting/lsp/README.md
+++ b/packages/linting/lsp/README.md
@@ -38,7 +38,7 @@ Point your editor at the server binary using `stdio` transport. Replace `fusion-
 
 ### VS Code
 
-Install the companion extension (`fusion-lint-vscode`). It handles the connection automatically. See [packages/linting/vscode](../vscode/README.md).
+Install the companion extension (`fusion-ts-lint-vscode`). It handles the connection automatically. See [packages/linting/vscode](../vscode/README.md).
 
 ### Neovim (nvim-lspconfig)
 

--- a/packages/linting/lsp/src/index.ts
+++ b/packages/linting/lsp/src/index.ts
@@ -13,5 +13,5 @@
  * ```
  *
  * See the editor-specific extension README (e.g. `packages/linting/vscode/README.md`)
- * for settings like the VS Code `fusion-lint.serverPath` override.
+ * for settings like the VS Code `fusion-ts-lint.serverPath` override.
  */

--- a/packages/linting/vscode/CONTRIBUTING.md
+++ b/packages/linting/vscode/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Fusion Lint
+# Contributing to Fusion TS Lint
 
 Thank you for your interest in contributing! This extension is part of the
 [Fusion Framework](https://github.com/equinor/fusion-framework) monorepo.
@@ -13,7 +13,7 @@ repository. Please include:
 - VS Code version
 - Extension version (shown in the Extensions panel)
 - A minimal code sample that reproduces the diagnostic (or the lack of one)
-- The contents of the **Output → Fusion Lint** channel if the server crashed
+- The contents of the **Output → Fusion TS Lint** channel if the server crashed
 
 ## Development setup
 
@@ -39,7 +39,7 @@ cd packages/linting/vscode && pnpm build
 pnpm package
 
 # Install into VS Code
-code --install-extension fusion-lint-vscode-*.vsix
+code --install-extension fusion-ts-lint-vscode-*.vsix
 ```
 
 Open `packages/linting/vscode` in VS Code and press **F5** to launch an

--- a/packages/linting/vscode/README.md
+++ b/packages/linting/vscode/README.md
@@ -1,4 +1,4 @@
-# Fusion Lint
+# Fusion TS Lint
 
 **Fusion Framework lint diagnostics inside VS Code — inline squiggles, Problems
 panel entries, and hover messages as you type.**
@@ -40,16 +40,16 @@ The language server is bundled inside the extension. Nothing extra to install.
 
 ### From the marketplace
 
-Search for **Fusion Lint** in the VS Code Extensions panel, or run:
+Search for **Fusion TS Lint** in the VS Code Extensions panel, or run:
 
 ```sh
-code --install-extension equinor.fusion-lint-vscode
+code --install-extension equinor-fusion.fusion-ts-lint-vscode
 ```
 
 ### From a VSIX file
 
 ```sh
-code --install-extension fusion-lint-vscode-0.1.0.vsix
+code --install-extension fusion-ts-lint-vscode-0.1.0.vsix
 ```
 
 Or via the VS Code UI: **Extensions → ⋯ → Install from VSIX…**
@@ -60,7 +60,7 @@ Add to `.vscode/extensions.json` so contributors are prompted to install:
 
 ```json
 {
-  "recommendations": ["equinor.fusion-lint-vscode"]
+  "recommendations": ["equinor-fusion.fusion-ts-lint-vscode"]
 }
 ```
 
@@ -72,9 +72,9 @@ All settings are optional. The defaults work without any changes.
 
 | Setting | Default | Description |
 |---|---|---|
-| `fusion-lint.runOn` | `"change"` | `"change"` — lint as you type. `"save"` — lint only on save. |
-| `fusion-lint.serverPath` | _(bundled)_ | Override the bundled server path. Useful when developing the lint engine locally. |
-| `fusion-lint.trace.server` | `"off"` | LSP message tracing. Set to `"messages"` or `"verbose"` when debugging. |
+| `fusion-ts-lint.runOn` | `"change"` | `"change"` — lint as you type. `"save"` — lint only on save. |
+| `fusion-ts-lint.serverPath` | _(bundled)_ | Override the bundled server path. Useful when developing the lint engine locally. |
+| `fusion-ts-lint.trace.server` | `"off"` | LSP message tracing. Set to `"messages"` or `"verbose"` when debugging. |
 
 To disable a rule or change its severity, add a `fusion-lint.config.js` (or
 `.fusion-lintrc.json`) to your project root:

--- a/packages/linting/vscode/images/icon.svg
+++ b/packages/linting/vscode/images/icon.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="-5 -12.5 60 60" role="img" aria-labelledby="fusion-lint-icon-title">
-  <title id="fusion-lint-icon-title">Fusion Lint</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="-5 -12.5 60 60" role="img" aria-labelledby="fusion-ts-lint-icon-title">
+  <title id="fusion-ts-lint-icon-title">Fusion TS Lint</title>
   <!-- Dark background fills the square viewBox -->
   <rect x="-5" y="-12.5" width="60" height="60" rx="4" fill="#1e1e1e"/>
   <!-- Fusion logo paths at native 50x35 coordinate space, centred by viewBox padding -->

--- a/packages/linting/vscode/package.json
+++ b/packages/linting/vscode/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "fusion-lint-vscode",
-  "displayName": "Fusion Lint",
+  "name": "fusion-ts-lint-vscode",
+  "displayName": "Fusion TS Lint",
   "description": "Real-time Fusion Framework lint diagnostics — no separate server install required",
   "version": "0.1.0",
-  "publisher": "equinor",
+  "private": true,
+  "publisher": "equinor-fusion",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"
@@ -26,14 +27,14 @@
   "main": "./dist/index.js",
   "contributes": {
     "configuration": {
-      "title": "Fusion Lint",
+      "title": "Fusion TS Lint",
       "properties": {
-        "fusion-lint.serverPath": {
+        "fusion-ts-lint.serverPath": {
           "type": "string",
           "default": "",
           "description": "Override the bundled fusion-lint-server path. Leave empty to use the version bundled with this extension."
         },
-        "fusion-lint.runOn": {
+        "fusion-ts-lint.runOn": {
           "type": "string",
           "enum": [
             "change",
@@ -46,7 +47,7 @@
           "default": "change",
           "description": "When to run the Fusion Lint engine."
         },
-        "fusion-lint.trace.server": {
+        "fusion-ts-lint.trace.server": {
           "type": "string",
           "enum": [
             "off",

--- a/packages/linting/vscode/src/index.ts
+++ b/packages/linting/vscode/src/index.ts
@@ -14,7 +14,7 @@ let client: LanguageClient | undefined;
  * Resolves the path to the `fusion-lint-server` entry point.
  *
  * Priority:
- * 1. `fusion-lint.serverPath` setting — explicit override for local builds or
+ * 1. `fusion-ts-lint.serverPath` setting — explicit override for local builds or
  *    alternative installations.
  * 2. The server bundled inside this extension's own `node_modules` — the
  *    default, requires no manual installation by the user.
@@ -23,7 +23,7 @@ let client: LanguageClient | undefined;
  * @returns Absolute path to the server module file.
  */
 function resolveServerPath(extensionPath: string): string {
-  const config = workspace.getConfiguration('fusion-lint');
+  const config = workspace.getConfiguration('fusion-ts-lint');
   const override: string = config.get('serverPath') ?? '';
   // Use the explicit override when the user has configured one
   if (override.trim().length > 0) return override.trim();
@@ -67,16 +67,19 @@ export function activate(context: ExtensionContext): void {
     ],
     synchronize: {
       // Re-lint when a config file is saved, and forward setting changes to the server
+      // NOTE: config file basenames are the shared fusion-lint convention from
+      // @equinor/fusion-framework-lint-config — do not rename these to match
+      // the extension's own fusion-ts-lint namespace, the CLI relies on them too.
       fileEvents: workspace.createFileSystemWatcher('**/{fusion-lint.config.*,.fusion-lintrc.*}'),
-      configurationSection: 'fusion-lint',
+      configurationSection: 'fusion-ts-lint',
     },
     initializationOptions: () => ({
-      runOn: workspace.getConfiguration('fusion-lint').get<string>('runOn') ?? 'change',
+      runOn: workspace.getConfiguration('fusion-ts-lint').get<string>('runOn') ?? 'change',
     }),
-    traceOutputChannel: window.createOutputChannel('Fusion Lint (LSP trace)'),
+    traceOutputChannel: window.createOutputChannel('Fusion TS Lint (LSP trace)'),
   };
 
-  client = new LanguageClient('fusion-lint', 'Fusion Lint', serverOptions, clientOptions);
+  client = new LanguageClient('fusion-ts-lint', 'Fusion TS Lint', serverOptions, clientOptions);
 
   // Register the client so VS Code disposes it on deactivation
   context.subscriptions.push(client);


### PR DESCRIPTION
**Why is this change needed?**
The Fusion Lint VS Code extension hadn't been published to the Marketplace yet. Marketplace extension identity (name, id) is permanent once published, so the naming needed to be finalized first, and we needed a repeatable way to publish future releases automatically.

**What is the current behavior?**
- Extension was named `fusion-lint-vscode` / "Fusion Lint", with `publisher: "equinor"` which doesn't match the actual Marketplace publisher (`equinor-fusion`).
- No CI job published the extension anywhere; it would need to be published manually via `vsce publish`.

**What is the new behavior?**
- Extension renamed end-to-end to `fusion-ts-lint-vscode` / "Fusion TS Lint": package name, settings namespace (`fusion-ts-lint.*`), `LanguageClient` id, output channel name, README/CONTRIBUTING/icon, and the pending initial-release changeset.
- The shared config-file convention (`fusion-lint.config.*`, `.fusion-lintrc.*`) is **intentionally left unchanged** — it's owned by `@equinor/fusion-framework-lint-config` and shared with the CLI, so renaming it would break interop.
- `package.json` marked `"private": true` (Marketplace-only, never published to npm) and `publisher` fixed to `equinor-fusion`.
- New `publish-vscode-extension` job in `ci.yml`, running after `release-pkg`, builds the extension and publishes it to the VS Code Marketplace via `vsce publish` using the `VS_MARKETPLACE_PAT` secret.
- `.changeset/config.json` now sets `privatePackages.tag: true` so changesets still creates a `fusion-ts-lint-vscode@<version>` git tag for this private package on release (it already version-bumps and changelogs private packages by default, just doesn't tag them).

**What is the intended behavior or invariant?**
Because the extension is `private`, changesets/action's own publish detection (which is npm-publish-oriented) can't be trusted at face value for gating the Marketplace publish step. Instead, `publish-vscode-extension` independently checks whether the `fusion-ts-lint-vscode@<version>` tag (read from `package.json` at HEAD) points at the exact commit that triggered the workflow run. Only then does it build and run `vsce publish`. This makes the job a safe no-op on every other push to `main` (including releases that don't touch the extension), and correctly fires on the exact commit where changesets bumps the extension's version.

**Does this PR introduce a breaking change?**
No. The extension is unpublished (v0.1.0), so renaming it now has no external impact. No published npm packages are affected.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (per the existing `fusion-ts-lint-vscode_initial-release` changeset)
- Consumer impact: None yet — this is the extension's first Marketplace release
- Downstream impact: `privatePackages.tag: true` applies repo-wide, so other private packages (e.g. cookbook apps) will also start getting git tags on version bumps. This is harmless (extra tags only) and nothing in CI reacts to them.

**Review guidance:**
- Verify the settings-namespace rename (`fusion-ts-lint.*`) didn't accidentally touch the shared config-file basenames (`fusion-lint.config.*` / `.fusion-lintrc.*`) in `src/index.ts` — those must stay as-is for CLI/extension interop.
- Verify the `publish-vscode-extension` job's tag-based gate in `ci.yml` — in particular that `turbo build --filter=fusion-ts-lint-vscode...` (trailing `...`) is used so the extension's workspace dependencies (`lint-lsp`, `lint-rules`, `lint-core`) get built too, since `vsce` doesn't run a `prepack` hook.
- This has not yet been exercised by an actual CI run (no release including this changeset has happened yet), so the workflow logic has been validated via source/documentation review rather than an end-to-end test.

**Additional context**
- Marketplace publisher `equinor-fusion` was created and a PAT verified locally (`npx vsce login equinor-fusion`, exit code 0). The `VS_MARKETPLACE_PAT` repo secret has been added.
- Confirmed via `@changesets/cli`'s bundled source that `changeset tag` logs `"New tag: <pkg>@<version>"` for private packages once `privatePackages.tag` is enabled, and that `changesets/action` pushes any such tag to `origin` before this job's checkout runs.

**Related issues**
None

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable (n/a — no React changes)
- [x] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
