### PR TITLE
docs: add Linting and Setup guides, install links for Fusion Lint

### DIFF
--- a/.changeset/docs_linting-setup-guides.md
+++ b/.changeset/docs_linting-setup-guides.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Add "Linting" and "Setup" guides under the Guide section, covering Fusion Lint, Biome, pnpm, TypeScript, and Vitest conventions for Fusion apps. Add a one-click VS Code install link to the Fusion Lint overview README.

--- a/.changeset/lint-vscode_readme-install-link.md
+++ b/.changeset/lint-vscode_readme-install-link.md
@@ -1,0 +1,5 @@
+---
+"fusion-ts-lint-vscode": patch
+---
+
+Add a one-click "Install in VS Code" link (`vscode:extension/...` URI) to the extension README for faster installs from GitHub or the docs site.

--- a/packages/linting/README.md
+++ b/packages/linting/README.md
@@ -5,6 +5,8 @@
 Squiggles in your editor. Failures in CI. Inline comments on pull requests.  
 All from one tool that understands how Fusion apps are supposed to be written.
 
+[Install in VS Code](vscode:extension/equinor-fusion.fusion-ts-lint-vscode)
+
 ---
 
 ## ✨ What makes it different
@@ -71,8 +73,7 @@ export const UserCard = ({ user }: Props): JSX.Element => ( ... );
 ## 📦 Packages
 
 ```
-core → rules → config → cli
-                      → lsp → vscode
+core → rules → config → cli → lsp → vscode
 ```
 
 | Package | What it is |

--- a/packages/linting/vscode/README.md
+++ b/packages/linting/vscode/README.md
@@ -5,6 +5,8 @@ panel entries, and hover messages as you type.**
 
 The language server is bundled inside the extension. Nothing extra to install.
 
+[Install in VS Code](vscode:extension/equinor-fusion.fusion-ts-lint-vscode)
+
 ---
 
 ## Features

--- a/vue-press/src/.vuepress/sidebar.ts
+++ b/vue-press/src/.vuepress/sidebar.ts
@@ -45,6 +45,14 @@ export default sidebar({
       link: '/cli/docs/dev-server.md',
     },
     {
+      text: 'Linting',
+      link: '/guide/linting.md',
+    },
+    {
+      text: 'Setup',
+      link: '/guide/setup.md',
+    },
+    {
       text: 'Cookbooks',
       link: '/cookbooks/index.md',
     },

--- a/vue-press/src/guide/linting.md
+++ b/vue-press/src/guide/linting.md
@@ -1,0 +1,66 @@
+---
+title: Linting
+category: Guide
+tag:
+  - lint
+  - biome
+---
+
+# Linting
+
+Fusion apps use two linters together, each catching different things:
+
+- **[Biome](https://biomejs.dev/)** — general JavaScript/TypeScript formatting and correctness (unused variables, dead code, style)
+- **[Fusion Lint](https://www.npmjs.com/package/@equinor/fusion-lint)** — Fusion Framework-specific conventions (intent comments on control flow, TSDoc on exported APIs, no class components, and more)
+
+Run both, in that order — Biome catches general issues, Fusion Lint catches Fusion-specific ones.
+
+[Install Fusion TS Lint in VS Code](vscode:extension/equinor-fusion.fusion-ts-lint-vscode) for inline squiggles as you type — no separate server to configure.
+
+<!-- @include: ../../../packages/linting/README.md -->
+
+## Biome
+
+Biome formats and lints general JS/TS issues. A Fusion app's generated `biome.json` (via `@equinor/fusion-framework-cli`) is a good starting point — extend or copy it into your own project.
+
+```jsonc
+// biome.json
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+  "formatter": {
+    "enabled": true,
+    "lineWidth": 100,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "semicolons": "always",
+      "quoteStyle": "single"
+    }
+  }
+}
+```
+
+Install the [Biome VS Code extension](vscode:extension/biomejs.biome) and set it as your default formatter:
+
+```jsonc
+// .vscode/settings.json
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true
+}
+```
+
+Useful commands once Biome is added to your `package.json` scripts:
+
+| Command | What it does |
+|---|---|
+| `biome check` | Format + lint check (read-only) |
+| `biome format --write` | Format files in place |
+| `biome lint` | Lint only |

--- a/vue-press/src/guide/setup.md
+++ b/vue-press/src/guide/setup.md
@@ -1,0 +1,83 @@
+---
+title: Setup
+category: Guide
+tag:
+  - pnpm
+  - setup
+---
+
+# Setup
+
+Recommended tooling for a Fusion app project, beyond scaffolding it with [`ffc create app`](/cli/docs/creating-apps.md).
+
+## Package manager: pnpm
+
+Fusion Framework apps use [pnpm](https://pnpm.io/). Use it for installs and scripts instead of `npm` or `yarn` — it's faster, and workspace-linked packages (`workspace:^`) only resolve correctly with pnpm.
+
+```sh
+# Install pnpm if you don't have it
+corepack enable
+corepack prepare pnpm@latest --activate
+
+# Install dependencies
+pnpm install
+
+# Run a script
+pnpm dev
+pnpm build
+```
+
+If your project is a monorepo with multiple apps/packages, declare them in `pnpm-workspace.yaml`:
+
+```yaml
+packages:
+  - 'apps/*'
+  - 'packages/*'
+```
+
+## TypeScript
+
+Fusion Framework packages ship strict TypeScript types. Keep `strict: true` in your `tsconfig.json` — Fusion's APIs are designed around it, and turning it off will surface `any`-typed gaps in your own code instead of the framework's.
+
+## Linting and formatting
+
+See [Linting](linting.md) for setting up [Biome](https://biomejs.dev/) and [Fusion Lint](https://www.npmjs.com/package/@equinor/fusion-lint) — both are recommended for any Fusion app.
+
+## Testing
+
+Fusion Framework packages are tested with [Vitest](https://vitest.dev/), and it's the recommended test runner for Fusion apps too — it shares config format with Vite, so no separate transform setup is needed.
+
+```sh
+pnpm add -D vitest
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom', // for React components
+    coverage: {
+      reporter: ['text', 'json-summary', 'json'],
+    },
+  },
+});
+```
+
+```sh
+pnpm exec vitest        # watch mode
+pnpm exec vitest run     # single run, e.g. in CI
+```
+
+## Editor
+
+Install the [Fusion TS Lint](vscode:extension/equinor-fusion.fusion-ts-lint-vscode) and [Biome](vscode:extension/biomejs.biome) VS Code extensions, and set Biome as your default formatter:
+
+```jsonc
+// .vscode/settings.json
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true
+}
+```


### PR DESCRIPTION
**Why is this change needed?**
Fusion Lint and Biome had no consumer-facing documentation, and there was no single guide covering the recommended baseline tooling (pnpm, TypeScript, linting, testing) for a new Fusion app.

**What is the current behavior?**
No dedicated docs page for Fusion Lint or Biome exists on the docs site. The Fusion Lint README and vscode extension README have no quick install link.

**What is the new behavior?**
- New `Linting` guide page (`vue-press/src/guide/linting.md`) covering Fusion Lint and Biome, included via `@include` of `packages/linting/README.md`.
- New `Setup` guide page (`vue-press/src/guide/setup.md`) covering pnpm, TypeScript, linting/formatting, testing with Vitest, and recommended editor extensions.
- Sidebar updated to surface both pages under the existing Guide section.
- One-click "Install in VS Code" links added to `packages/linting/README.md` and `packages/linting/vscode/README.md`.

**What is the intended behavior or invariant?**
These are consumer-facing docs (external developers building Fusion apps), not internal contributor/CI documentation.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (two changesets included — `fusion-ts-lint-vscode`, `@equinor/fusion-framework-docs`)
- Consumer impact: New docs pages, easier install of the Fusion Lint VS Code extension
- Downstream impact: None

**Review guidance:**
Verified locally with `pnpm exec vuepress build` — 274 pages rendered, no errors.

**Additional context**
None.

**Related issues**
None.
