### PR TITLE
fix(bookmark): show app name loading state

### DIFF
--- a/.changeset/react-components-bookmark_app-loading.md
+++ b/.changeset/react-components-bookmark_app-loading.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-components-bookmark": patch
+---
+
+Show accessible loading feedback for the app name while the edit bookmark modal resolves its app manifest.

--- a/packages/react/components/bookmark/README.md
+++ b/packages/react/components/bookmark/README.md
@@ -59,7 +59,7 @@ The provider manages modal state for creating, editing, and importing bookmarks.
 - **Filtering** — text search across bookmark names
 - **Grouping** — group bookmarks by app, creator, or other criteria
 - **Create modal** — form for creating new bookmarks
-- **Edit modal** — form for updating existing bookmarks
+- **Edit modal** — form for updating existing bookmarks with loading feedback while resolving the source app name
 - **Import modal** — import bookmarks shared via URL
 - **Clipboard sharing** — copy bookmark URL to clipboard
 

--- a/packages/react/components/bookmark/package.json
+++ b/packages/react/components/bookmark/package.json
@@ -12,7 +12,8 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "prepack": "pnpm build"
+    "prepack": "pnpm build",
+    "test": "vitest --run"
   },
   "keywords": [],
   "author": "",
@@ -42,7 +43,8 @@
     "@types/react": "^19.2.7",
     "react": "^19.2.1",
     "styled-components": "^6.3.11",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.0"
   },
   "peerDependencies": {
     "@equinor/eds-core-react": "^2.0.0",

--- a/packages/react/components/bookmark/src/__tests__/AppNameField.test.tsx
+++ b/packages/react/components/bookmark/src/__tests__/AppNameField.test.tsx
@@ -1,0 +1,37 @@
+import { isValidElement } from 'react';
+import { Input, Progress } from '@equinor/eds-core-react';
+import { describe, expect, it } from 'vitest';
+import { AppNameField } from '../components/edit-bookmark/AppNameField';
+
+describe('AppNameField', () => {
+  it('shows an accessible progress indicator while the manifest is loading', () => {
+    const field = AppNameField({ isLoading: true });
+    const loadingIndicator = field.props.rightAdornments;
+
+    expect(field.type).toBe(Input);
+    expect(field.props['aria-busy']).toBe(true);
+    expect(isValidElement(loadingIndicator)).toBe(true);
+
+    // Guard the element shape before inspecting progress-specific props.
+    if (!isValidElement(loadingIndicator)) {
+      throw new Error('Expected a valid loading indicator');
+    }
+
+    expect(loadingIndicator.type).toBe(Progress.Circular);
+    expect(loadingIndicator.props).toMatchObject({
+      'aria-label': 'Loading app name',
+      size: 16,
+    });
+  });
+
+  it('shows the resolved display name without a progress indicator', () => {
+    const field = AppNameField({
+      displayName: 'My app',
+      isLoading: false,
+    });
+
+    expect(field.props.value).toBe('My app');
+    expect(field.props['aria-busy']).toBe(false);
+    expect(field.props.rightAdornments).toBeUndefined();
+  });
+});

--- a/packages/react/components/bookmark/src/__tests__/AppNameField.test.tsx
+++ b/packages/react/components/bookmark/src/__tests__/AppNameField.test.tsx
@@ -5,10 +5,11 @@ import { AppNameField } from '../components/edit-bookmark/AppNameField';
 
 describe('AppNameField', () => {
   it('shows an accessible progress indicator while the manifest is loading', () => {
-    const field = AppNameField({ isLoading: true });
+    const field = AppNameField({ id: 'app', isLoading: true });
     const loadingIndicator = field.props.rightAdornments;
 
     expect(field.type).toBe(Input);
+    expect(field.props.id).toBe('app');
     expect(field.props['aria-busy']).toBe(true);
     expect(isValidElement(loadingIndicator)).toBe(true);
 
@@ -26,6 +27,7 @@ describe('AppNameField', () => {
 
   it('shows the resolved display name without a progress indicator', () => {
     const field = AppNameField({
+      id: 'app',
       displayName: 'My app',
       isLoading: false,
     });

--- a/packages/react/components/bookmark/src/components/edit-bookmark/AppNameField.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/AppNameField.tsx
@@ -7,14 +7,16 @@ import { Input, Progress } from '@equinor/eds-core-react';
  * @returns A read-only app name field with an accessible loading indicator when needed.
  */
 export const AppNameField = ({
+  id,
   displayName,
   isLoading,
 }: {
+  readonly id: string;
   readonly displayName?: string;
   readonly isLoading: boolean;
 }) => (
   <Input
-    id="app"
+    id={id}
     readOnly={true}
     value={displayName ?? ''}
     aria-busy={isLoading}

--- a/packages/react/components/bookmark/src/components/edit-bookmark/AppNameField.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/AppNameField.tsx
@@ -1,0 +1,25 @@
+import { Input, Progress } from '@equinor/eds-core-react';
+
+/**
+ * Renders the bookmark's app name while making manifest resolution visible.
+ *
+ * @param props - The resolved display name and whether the manifest request is pending.
+ * @returns A read-only app name field with an accessible loading indicator when needed.
+ */
+export const AppNameField = ({
+  displayName,
+  isLoading,
+}: {
+  readonly displayName?: string;
+  readonly isLoading: boolean;
+}) => (
+  <Input
+    id="app"
+    readOnly={true}
+    value={displayName ?? ''}
+    aria-busy={isLoading}
+    rightAdornments={
+      isLoading ? <Progress.Circular aria-label="Loading app name" size={16} /> : undefined
+    }
+  />
+);

--- a/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmarkModal.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmarkModal.tsx
@@ -12,6 +12,7 @@ import { Button, Checkbox, Dialog, Input, Label, Textarea } from '@equinor/eds-c
 import styled from 'styled-components';
 
 import { useBookmarkComponentContext } from '../BookmarkProvider';
+import { AppNameField } from './AppNameField';
 
 const Styled = {
   Dialog: styled(Dialog)`
@@ -81,11 +82,15 @@ export const EditBookmarkModal = ({
 
   // TODO(#5091): this should be on the bookmark object
   const appProvider = useFrameworkModule<AppModule>('app');
-  const { value: appName } = useObservableState(
+  const { value: appName, error: appNameError } = useObservableState(
     useMemo(
       () => (bookmark && appProvider ? appProvider.getAppManifest(bookmark.appKey) : of(undefined)),
       [appProvider, bookmark],
     ),
+  );
+  // Only report a pending manifest request; missing providers and failed requests are not loading.
+  const isAppNameLoading = Boolean(
+    bookmark && appProvider && appName === undefined && appNameError === null,
   );
 
   const updateBookmark = useCallback(
@@ -146,8 +151,7 @@ export const EditBookmarkModal = ({
         </div>
         <div>
           <Label htmlFor="app" label="App" />
-          {/** TODO(#5092): show ghost while loading app name  */}
-          <Input readOnly={true} value={appName?.displayName || ''} />
+          <AppNameField displayName={appName?.displayName} isLoading={isAppNameLoading} />
         </div>
 
         <Styled.CheckboxWrapper>

--- a/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmarkModal.tsx
+++ b/packages/react/components/bookmark/src/components/edit-bookmark/EditBookmarkModal.tsx
@@ -61,6 +61,7 @@ export const EditBookmarkModal = ({
 
   const nameId = useId();
   const descriptionId = useId();
+  const appId = useId();
 
   const [updatePayload, setUpdatePayload] = useState(false);
 
@@ -150,8 +151,8 @@ export const EditBookmarkModal = ({
           />
         </div>
         <div>
-          <Label htmlFor="app" label="App" />
-          <AppNameField displayName={appName?.displayName} isLoading={isAppNameLoading} />
+          <Label htmlFor={appId} label="App" />
+          <AppNameField id={appId} displayName={appName?.displayName} isLoading={isAppNameLoading} />
         </div>
 
         <Styled.CheckboxWrapper>

--- a/packages/react/components/bookmark/tsconfig.json
+++ b/packages/react/components/bookmark/tsconfig.json
@@ -14,5 +14,5 @@
     }
   ],
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib", "src/__tests__/**/*"]
 }

--- a/packages/react/components/bookmark/vitest.config.ts
+++ b/packages/react/components/bookmark/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineProject } from 'vitest/config';
+
+import { name, version } from './package.json';
+
+export default defineProject({
+  test: {
+    include: ['src/__tests__/**/*.{test,spec}.{ts,tsx}'],
+    name: `${name}@${version}`,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2311,7 +2311,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.22.5))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.23.1))
 
   packages/react/components/people-resolver:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2309,6 +2309,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.22.5))
 
   packages/react/components/people-resolver:
     dependencies:


### PR DESCRIPTION
**Why is this change needed?**

The Edit Bookmark modal leaves the read-only app name field blank while the app manifest is being resolved. That makes a normal asynchronous wait look like missing data.

**What is the current behavior?**

The modal requests the app manifest and eventually fills in its display name, but it provides no loading feedback while that request is pending.

**What is the new behavior?**

The app name field now displays an EDS circular progress indicator while the manifest request is pending. The resolved display name replaces it when available. The field also exposes its busy state and an accessible loading label.

**What is the intended behavior or invariant?**

Loading is reported only after both the bookmark and app provider exist, while the manifest value is unresolved and no request error has occurred. A missing provider or failed request must not leave the field permanently busy.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: The Edit Bookmark modal gains visual and accessible loading feedback; no API changes are required.
- Downstream impact: Limited to `@equinor/fusion-framework-react-components-bookmark`.

**Review guidance:**

Please focus on the pending-state condition in `EditBookmark.tsx` and the loading/resolved rendering contract in `AppNameField`.

Validation completed:

- focused package tests: 2 passed
- complete repository test suite: 585 passed
- complete repository build: 80 tasks passed
- affected package build: passed
- scoped Biome and Fusion lint checks: passed with no new warnings
- manual local render: loading and resolved states verified, including `aria-busy` and the progress label

**Additional context**

The implementation uses the existing EDS `Input` adornment and `Progress.Circular` components, so it adds no runtime dependency. A patch changeset and package README update are included.

The repository-wide `pnpm -w check` could not be used as a clean signal on this Windows checkout because it reports existing CRLF formatting across untouched files and a Biome configuration version mismatch. The changed TypeScript files pass a scoped Biome check and were not used to reformat unrelated files.

**Related issues**

closes: #5092

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
