### PR TITLE
chore(deps): group react-router Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
         patterns:
           - "@langchain/*"
           - "langchain"
+      react-router:
+        applies-to: version-updates
+        patterns:
+          - "react-router"
+          - "react-router-dom"
+          - "@react-router/*"
       vuepress:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## Summary

Adds a Dependabot `groups` entry for `react-router` (patterns: `react-router`, `react-router-dom`, `@react-router/*`), matching the existing pattern used for `ag-charts`, `ag-grid`, `opentelemetry`, `langchain`, and `vuepress`.

## Why

The recent react-router 7→8 major bump opened 3 separate PRs (#5058, #5031, #5032) instead of one, since react-router/`@react-router/dev` weren't covered by any group. This groups future version updates for these packages into a single PR.

## Validation

Config-only change to `.github/dependabot.yml`; no code/build impact.