### PR TITLE
feat(react-router): re-export useBlocker and useBeforeUnload

### DIFF
--- a/.changeset/react-router_add-useblocker-usebeforeunload.md
+++ b/.changeset/react-router_add-useblocker-usebeforeunload.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-react-router": minor
+---
+
+Re-export `useBlocker` and `useBeforeUnload` from `react-router` so consumers migrating from `react-router-dom` don't need a direct dependency on `react-router` for these hooks.
+
+Thanks @edmondbaloku
+
+Closes: https://github.com/equinor/fusion/issues/888

--- a/packages/react/router/src/index.ts
+++ b/packages/react/router/src/index.ts
@@ -39,6 +39,8 @@ export {
   type PathParam,
   type SetURLSearchParams,
   useActionData,
+  useBeforeUnload,
+  useBlocker,
   useFormAction,
   useLocation,
   useLoaderData,


### PR DESCRIPTION
**Why is this change needed?**
`@equinor/fusion-framework-react-router` already re-exports several `react-router` hooks so consumers don't need a direct dependency on `react-router`, but `useBlocker` and `useBeforeUnload` were missing, blocking teams mid-migration from `react-router-dom`.

**What is the current behavior?**
Teams need to import `useBlocker`/`useBeforeUnload` directly from `react-router-dom`/`react-router` alongside this package.

**What is the new behavior?**
`useBlocker` and `useBeforeUnload` are re-exported from `@equinor/fusion-framework-react-router`, alongside the other existing hook re-exports.

**What is the intended behavior or invariant?**
The main entry point re-exports common React Router hooks/components verbatim from `react-router` with no wrapping — same contract as the existing re-exports (`useNavigate`, `useLocation`, etc.).

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-react-router`)
- Consumer impact: New named exports available; no changes to existing exports
- Downstream impact: None

**Review guidance:**
Straightforward re-export addition, same pattern as existing hooks in `src/index.ts`.

**Additional context**
Validated via `tsc -b` build, `vitest run` (19/19 passing), and `biome lint` (clean) for the package.

**Related issues**
Closes: https://github.com/equinor/fusion/issues/888

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions (n/a, verbatim re-exports)
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist (n/a)
- [x] Confirm React logic and derived values are resolved before markup when applicable (n/a)
- [x] Confirm README/docs are updated for user-facing changes (n/a, follows existing re-export pattern already documented)
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
