### PR TITLE
fix(linting): add missing tsc project references between lint packages

### DIFF
--- a/.changeset/linting_fix-tsc-project-references.md
+++ b/.changeset/linting_fix-tsc-project-references.md
@@ -1,0 +1,10 @@
+---
+"@equinor/fusion-lint": patch
+"@equinor/fusion-framework-lint-lsp": patch
+"@equinor/fusion-framework-lint-config": patch
+"@equinor/fusion-framework-lint-rules": patch
+---
+
+Internal: add missing TypeScript project `references` between the linting packages (`lint-core`, `lint-rules`, `lint-config`, `fusion-lint`, `lint-lsp`).
+
+Without these references, `tsc -b` couldn't resolve `@equinor/fusion-framework-lint-core`/`lint-config` types when a package was built in isolation (as happens during `npm publish`'s `prepack` step), causing the previous release's publish to fail partway through.

--- a/packages/linting/cli/tsconfig.json
+++ b/packages/linting/cli/tsconfig.json
@@ -6,5 +6,6 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [{ "path": "../core" }, { "path": "../config" }]
 }

--- a/packages/linting/config/tsconfig.json
+++ b/packages/linting/config/tsconfig.json
@@ -6,5 +6,6 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [{ "path": "../core" }, { "path": "../rules" }]
 }

--- a/packages/linting/lsp/tsconfig.json
+++ b/packages/linting/lsp/tsconfig.json
@@ -8,5 +8,6 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [{ "path": "../core" }, { "path": "../config" }]
 }

--- a/packages/linting/rules/tsconfig.json
+++ b/packages/linting/rules/tsconfig.json
@@ -6,5 +6,6 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## Why

The [release job for PR #5166](https://github.com/equinor/fusion-framework/actions/runs/30536545605/job/90851105114) failed partway through with:

```
src/index.ts(16,28): error TS2307: Cannot find module '@equinor/fusion-framework-lint-core' or its corresponding type declarations.
```

Root cause: `packages/linting/{cli,lsp,config,rules}/tsconfig.json` were missing TypeScript project `references` to their workspace dependencies. Local/full monorepo builds masked this (dist output from a previous full build was already present), but `npm publish`'s per-package `prepack` script runs `tsc -b` in isolation, which failed to resolve types for packages it hadn't been told to build first.

**Impact of the failure**: git tags were pushed for all 23 packages in the release, but only 5 actually published to npm (`fusion-imports`, `fusion-load-env`, `fusion-log`, `vite-plugin-markdown`, `vite-plugin-routes-dsl`). The remaining 18 — including `@equinor/fusion-framework-react-router@2.4.0` and `@equinor/fusion-framework-cli@15.2.2` — are 404 on the registry despite the tags existing.

## What

Added `references` entries:
- `lint-rules` → `lint-core`
- `lint-config` → `lint-core`, `lint-rules`
- `fusion-lint` (cli) → `lint-core`, `lint-config`
- `lint-lsp` → `lint-core`, `lint-config`

(`fusion-ts-lint-vscode` uses `tsc --noEmit` and doesn't import lint-core/config types directly, so it didn't need a reference.)

## Validation

- Cleaned all `dist`/`.tsbuildinfo` output and ran `tsc -b --force` for each of `lint-core`, `lint-rules`, `lint-config`, `fusion-lint`, `lint-lsp` **individually** (simulating the isolated `prepack` build) — all succeed and correctly build their dependencies transitively.
- `fusion-ts-lint-vscode` `tsc --noEmit` — clean.
- `pnpm exec biome lint packages/linting` — 98 files, no issues.
- `npx vitest run --project '*lint*'` — 22 test files, 289 tests, all passing.

## Next step after merge

Once this merges and versions/publishes cleanly, the 18 packages that were tagged but never published in the PR #5166 release will need a follow-up release to actually reach npm.