### PR TITLE
feat(linting): add require-property-tsdoc rule

### DIFF
--- a/.changeset/require-property-tsdoc-doc-fixes.md
+++ b/.changeset/require-property-tsdoc-doc-fixes.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-router": patch
+"@equinor/fusion-framework-module-app": patch
+"@equinor/fusion-framework-module-analytics": patch
+"@equinor/fusion-framework-module-azure-identity": patch
+"@equinor/fusion-framework-module-bookmark": patch
+"@equinor/fusion-framework-module-feature-flag": patch
+"@equinor/fusion-framework-module-http": patch
+"@equinor/fusion-framework-module-services": patch
+"@equinor/fusion-query": patch
+---
+
+Added missing TSDoc comments on class fields flagged by the new `require-property-tsdoc` fusion-lint rule.

--- a/.changeset/require-property-tsdoc.md
+++ b/.changeset/require-property-tsdoc.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-framework-lint-rules": minor
+"@equinor/fusion-framework-lint-config": minor
+---
+
+Add `require-property-tsdoc` rule: requires class field (property) declarations — including Lit's `@property()` / `@state()` decorated fields — to have a preceding TSDoc block comment. `private`/`#name` and `static` fields are exempt. Included in the `recommended` rule preset.

--- a/cookbooks/app-react-router/src/api/Api.ts
+++ b/cookbooks/app-react-router/src/api/Api.ts
@@ -21,8 +21,11 @@ interface IHttpProvider {
  * Uses React Query for caching and request deduplication
  */
 export class Api {
+  /** Product-related API client. */
   readonly product: ProductApi;
+  /** People-related API client. */
   readonly people: PeopleApi;
+  /** User-related API client. */
   readonly user: UserApi;
 
   /**

--- a/packages/linting/config/src/recommended-rules.ts
+++ b/packages/linting/config/src/recommended-rules.ts
@@ -15,6 +15,7 @@ import {
   singleExportPerFile,
   requireComponentTsDoc,
   requireHookTsDoc,
+  requirePropertyTsDoc,
   filenameConvention,
 } from '@equinor/fusion-framework-lint-rules';
 
@@ -41,5 +42,6 @@ export const recommendedRules: Rule[] = [
   singleExportPerFile(),
   requireComponentTsDoc(),
   requireHookTsDoc(),
+  requirePropertyTsDoc(),
   filenameConvention(),
 ];

--- a/packages/linting/rules/src/__tests__/require-property-tsdoc.test.ts
+++ b/packages/linting/rules/src/__tests__/require-property-tsdoc.test.ts
@@ -70,6 +70,33 @@ class MyButton {
 `;
     expect(lint(source, 'fixture.ts', rule)).toHaveLength(0);
   });
+
+  it('passes: documented decorated getter accessor', () => {
+    const source = `
+class MyButton {
+  /**
+   * @deprecated use \`variant="contained"\` instead.
+   * @returns true when \`variant\` is \`contained\`
+   */
+  @property({ type: Boolean, reflect: true })
+  get raised(): boolean {
+    return this.variant === 'contained';
+  }
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: undecorated getter accessor without TSDoc', () => {
+    const source = `
+class MyButton {
+  get raised(): boolean {
+    return this.variant === 'contained';
+  }
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
 });
 
 describe('require-property-tsdoc — failing', () => {
@@ -123,5 +150,19 @@ class MyButton {
 }
 `;
     expect(lint(source)).toHaveLength(1);
+  });
+
+  it('fails: undocumented decorated getter accessor', () => {
+    const source = `
+class MyButton {
+  @property({ type: Boolean, reflect: true })
+  get raised(): boolean {
+    return this.variant === 'contained';
+  }
+}
+`;
+    const diagnostics = lint(source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("'raised'");
   });
 });

--- a/packages/linting/rules/src/__tests__/require-property-tsdoc.test.ts
+++ b/packages/linting/rules/src/__tests__/require-property-tsdoc.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { requirePropertyTsDoc } from '../require-property-tsdoc/index.js';
+import type { Diagnostic, Rule } from '@equinor/fusion-framework-lint-core';
+
+function lint(
+  source: string,
+  file = 'fixture.ts',
+  rule: Rule = requirePropertyTsDoc(),
+): Diagnostic[] {
+  // mirror the engine: skip `check` entirely when `match` opts the file out
+  if (rule.match && !rule.match(file)) return [];
+  return rule.check(source, { filePath: file });
+}
+
+describe('require-property-tsdoc — passing', () => {
+  it('passes: documented public field', () => {
+    const source = `
+class MyButton {
+  /** The visual color variant to render. */
+  color = 'primary';
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: documented decorated field', () => {
+    const source = `
+class MyButton {
+  /** The visual color variant to render. */
+  @property({ type: String })
+  color = 'primary';
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: private modifier field without TSDoc', () => {
+    const source = `
+class MyButton {
+  private internalState = 1;
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: #private field without TSDoc', () => {
+    const source = `
+class MyButton {
+  #internalState = 1;
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: static field without TSDoc', () => {
+    const source = `
+class MyButton {
+  static styles = [];
+}
+`;
+    expect(lint(source)).toHaveLength(0);
+  });
+
+  it('passes: field in non-exported class when classScope is "exported"', () => {
+    const rule = requirePropertyTsDoc({ classScope: 'exported' });
+    const source = `
+class MyButton {
+  color = 'primary';
+}
+`;
+    expect(lint(source, 'fixture.ts', rule)).toHaveLength(0);
+  });
+});
+
+describe('require-property-tsdoc — failing', () => {
+  it('fails: undocumented public field', () => {
+    const source = `
+class MyButton {
+  color = 'primary';
+}
+`;
+    const diagnostics = lint(source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("'color'");
+  });
+
+  it('fails: undocumented decorated field', () => {
+    const source = `
+class MyButton {
+  @property({ type: String })
+  color = 'primary';
+}
+`;
+    const diagnostics = lint(source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("'color'");
+  });
+
+  it('fails: undocumented protected field', () => {
+    const source = `
+class MyButton {
+  protected color = 'primary';
+}
+`;
+    expect(lint(source)).toHaveLength(1);
+  });
+
+  it('fails: undocumented field in exported class when classScope is "exported"', () => {
+    const rule = requirePropertyTsDoc({ classScope: 'exported' });
+    const source = `
+export class MyButton {
+  color = 'primary';
+}
+`;
+    expect(lint(source, 'fixture.ts', rule)).toHaveLength(1);
+  });
+
+  it('fails: non-TSDoc comment does not satisfy the rule', () => {
+    const source = `
+class MyButton {
+  // just a regular comment
+  color = 'primary';
+}
+`;
+    expect(lint(source)).toHaveLength(1);
+  });
+});

--- a/packages/linting/rules/src/index.ts
+++ b/packages/linting/rules/src/index.ts
@@ -16,4 +16,6 @@ export { noSeparateExport } from './no-separate-export/index.js';
 export { singleExportPerFile } from './single-export-per-file/index.js';
 export { requireComponentTsDoc } from './require-component-tsdoc/index.js';
 export { requireHookTsDoc } from './require-hook-tsdoc/index.js';
+export { requirePropertyTsDoc } from './require-property-tsdoc/index.js';
+export type { RequirePropertyTsDocOptions } from './require-property-tsdoc/index.js';
 export { filenameConvention } from './filename-convention/index.js';

--- a/packages/linting/rules/src/require-property-tsdoc/index.ts
+++ b/packages/linting/rules/src/require-property-tsdoc/index.ts
@@ -1,0 +1,183 @@
+import type { Node } from 'web-tree-sitter';
+import type {
+  Diagnostic,
+  Severity,
+  RuleDef,
+  RuleOptions,
+  LintContext,
+} from '@equinor/fusion-framework-lint-core';
+import { resolveMatch } from '@equinor/fusion-framework-lint-core';
+import { tsParser } from '../ts-parser.js';
+
+const RULE_ID = 'require-property-tsdoc';
+const DEFAULT_SEVERITY: Severity = 'warn';
+
+/** Matches a TSDoc block comment opener `/**` (not a plain `/*` or `//`). */
+const TSDOC_OPEN_RE = /^\/\*\*/;
+
+/** Returns `true` when `text` is a TSDoc block comment (starts with `/**`). */
+function isTsDoc(text: string): boolean {
+  return TSDOC_OPEN_RE.test(text.trimStart());
+}
+
+/**
+ * Returns `true` when the field has an `accessibility_modifier` of `private`,
+ * or uses the `#name` private-field syntax. Truly private fields carry no
+ * public API surface, so they're exempt from this rule.
+ *
+ * @param node - A `public_field_definition` node.
+ * @returns `true` if the field is private.
+ */
+function isPrivateField(node: Node): boolean {
+  const nameNode = node.childForFieldName('name');
+  // `#name` fields parse as private_property_identifier regardless of modifiers
+  if (nameNode?.type === 'private_property_identifier') return true;
+  // Check for an explicit `private` accessibility modifier
+  return node.children.some(
+    (c) => c.type === 'accessibility_modifier' && c.text === 'private',
+  );
+}
+
+/**
+ * Returns `true` when the field declares a `static` modifier. Static fields
+ * are commonly used for framework wiring (e.g. Lit's `static styles`) rather
+ * than instance-level public API, so they're exempt by default.
+ *
+ * @param node - A `public_field_definition` node.
+ * @returns `true` if the field is static.
+ */
+function isStaticField(node: Node): boolean {
+  // Check for a `static` keyword child
+  return node.children.some((c) => c.type === 'static');
+}
+
+/**
+ * Returns `true` when a `class_declaration` is directly wrapped in an
+ * `export_statement` (i.e. `export class Foo {}`).
+ *
+ * @param node - A `class_declaration` node.
+ * @returns `true` if the class is directly exported.
+ */
+function isExportedClass(node: Node): boolean {
+  return node.parent?.type === 'export_statement';
+}
+
+/**
+ * Checks a single `public_field_definition` node for a preceding TSDoc
+ * comment. Decorators (e.g. Lit's `@property()` / `@state()`) live inside
+ * the field node itself, so the anchor for the comment is the field node.
+ *
+ * @param node - The `public_field_definition` node to inspect.
+ * @param filePath - Source file path included in diagnostic output.
+ * @param severity - Severity level for the emitted diagnostic.
+ * @param out - Accumulator array for collected diagnostics.
+ */
+function checkFieldNode(node: Node, filePath: string, severity: Severity, out: Diagnostic[]): void {
+  const prev = node.previousNamedSibling;
+  const name = node.childForFieldName('name')?.text ?? '(unknown)';
+  // Require a TSDoc comment immediately preceding the field declaration
+  if (prev?.type !== 'comment' || !isTsDoc(prev.text)) {
+    out.push({
+      file: filePath,
+      line: node.startPosition.row + 1,
+      col: node.startPosition.column + 1,
+      rule: RULE_ID,
+      message: `'${name}' is missing a TSDoc comment (\`/** ... */\`)`,
+      severity,
+    });
+  }
+}
+
+/**
+ * Recursively visits every node in the AST and checks class field
+ * declarations for a preceding TSDoc comment.
+ *
+ * @param node - Current AST node being visited.
+ * @param filePath - Source file path included in diagnostic output.
+ * @param severity - Severity level for each emitted diagnostic.
+ * @param out - Accumulator array for collected diagnostics.
+ * @param classScope - Whether to check fields in all classes or only exported ones.
+ */
+function walkNode(
+  node: Node,
+  filePath: string,
+  severity: Severity,
+  out: Diagnostic[],
+  classScope: 'all' | 'exported',
+): void {
+  // Only inspect class field declarations; recurse into everything else
+  if (node.type === 'public_field_definition') {
+    const classBody = node.parent;
+    const classDecl = classBody?.type === 'class_body' ? classBody.parent : null;
+    const inScope =
+      classDecl?.type === 'class_declaration' &&
+      (classScope === 'all' || isExportedClass(classDecl));
+    // Skip private and static fields — neither carries public instance API surface
+    if (inScope && !isPrivateField(node) && !isStaticField(node)) {
+      checkFieldNode(node, filePath, severity, out);
+    }
+  }
+  // Recurse into every child to cover the full AST subtree
+  for (const child of node.children) {
+    walkNode(child, filePath, severity, out, classScope);
+  }
+}
+
+/**
+ * Options for the `require-property-tsdoc` rule.
+ */
+export interface RequirePropertyTsDocOptions extends RuleOptions {
+  /**
+   * Which class declarations require their fields to be documented.
+   * - `'all'` (default): fields in every named class, exported or not.
+   * - `'exported'`: only fields in `export class Foo {}` declarations.
+   */
+  classScope?: 'all' | 'exported';
+}
+
+/**
+ * Requires class field (property) declarations to have a TSDoc block
+ * comment — including Lit's `@property()` / `@state()` decorated fields,
+ * which form the public API surface of a web component.
+ *
+ * `private` fields (both the `private` modifier and `#name` syntax) and
+ * `static` fields are exempt — they carry no instance-level public API.
+ *
+ * @example Passing
+ * ```typescript
+ * class MyButton extends LitElement {
+ *   /**
+ *    * The visual color variant to render.
+ *    * /
+ *   @property({ type: String })
+ *   color: ButtonColor = 'primary';
+ * }
+ * ```
+ *
+ * @example Failing
+ * ```typescript
+ * class MyButton extends LitElement {
+ *   @property({ type: String })
+ *   color: ButtonColor = 'primary';
+ * }
+ * ```
+ */
+export const requirePropertyTsDoc: RuleDef<RequirePropertyTsDocOptions> = (options = {}) => {
+  const { classScope = 'all' } = options;
+  return {
+    id: RULE_ID,
+    defaultSeverity: DEFAULT_SEVERITY,
+    /** @inheritdoc Rule.match */
+    match: resolveMatch(options.match),
+    /** @inheritdoc Rule.check */
+    check(source: string, ctx: LintContext): Diagnostic[] {
+      const { filePath } = ctx;
+      const tree = tsParser.parse(source);
+      // Guard: tsParser.parse returns null for empty or unparseable source
+      if (!tree) return [];
+      const out: Diagnostic[] = [];
+      walkNode(tree.rootNode, filePath, DEFAULT_SEVERITY, out, classScope);
+      return out;
+    },
+  };
+};

--- a/packages/linting/rules/src/require-property-tsdoc/index.ts
+++ b/packages/linting/rules/src/require-property-tsdoc/index.ts
@@ -21,16 +21,16 @@ function isTsDoc(text: string): boolean {
 }
 
 /**
- * Returns `true` when the field has an `accessibility_modifier` of `private`,
- * or uses the `#name` private-field syntax. Truly private fields carry no
- * public API surface, so they're exempt from this rule.
+ * Returns `true` when a class member has an `accessibility_modifier` of
+ * `private`, or uses the `#name` private-field syntax. Truly private members
+ * carry no public API surface, so they're exempt from this rule.
  *
- * @param node - A `public_field_definition` node.
- * @returns `true` if the field is private.
+ * @param node - A `public_field_definition` or `method_definition` node.
+ * @returns `true` if the member is private.
  */
-function isPrivateField(node: Node): boolean {
+function isPrivateMember(node: Node): boolean {
   const nameNode = node.childForFieldName('name');
-  // `#name` fields parse as private_property_identifier regardless of modifiers
+  // `#name` members parse as private_property_identifier regardless of modifiers
   if (nameNode?.type === 'private_property_identifier') return true;
   // Check for an explicit `private` accessibility modifier
   return node.children.some(
@@ -39,16 +39,52 @@ function isPrivateField(node: Node): boolean {
 }
 
 /**
- * Returns `true` when the field declares a `static` modifier. Static fields
+ * Returns `true` when the member declares a `static` modifier. Static members
  * are commonly used for framework wiring (e.g. Lit's `static styles`) rather
  * than instance-level public API, so they're exempt by default.
  *
- * @param node - A `public_field_definition` node.
- * @returns `true` if the field is static.
+ * @param node - A `public_field_definition` or `method_definition` node.
+ * @returns `true` if the member is static.
  */
-function isStaticField(node: Node): boolean {
+function isStaticMember(node: Node): boolean {
   // Check for a `static` keyword child
   return node.children.some((c) => c.type === 'static');
+}
+
+/**
+ * Returns `true` when `node` is a `get`/`set` accessor `method_definition`.
+ *
+ * @param node - A `method_definition` node.
+ * @returns `true` if the method is a getter or setter.
+ */
+function isAccessor(node: Node): boolean {
+  return node.children[0]?.type === 'get' || node.children[0]?.type === 'set';
+}
+
+/**
+ * Returns `true` when `node` is directly preceded by a `decorator` node
+ * (e.g. Lit's `@property()` / `@state()` applied to a `get`/`set` accessor).
+ * Unlike fields, an accessor's decorator is a sibling in `class_body` rather
+ * than a child of the `method_definition` itself.
+ *
+ * @param node - A `method_definition` node.
+ * @returns `true` if the accessor carries a leading decorator.
+ */
+function isDecoratedAccessor(node: Node): boolean {
+  return node.previousNamedSibling?.type === 'decorator';
+}
+
+/**
+ * Resolves the node that should carry the leading TSDoc comment. For fields,
+ * this is the field node itself (decorators live inside it). For a decorated
+ * accessor, the decorator sits between the comment and the method, so the
+ * anchor is the decorator instead.
+ *
+ * @param node - A `public_field_definition` or `method_definition` node.
+ * @returns The node whose `previousNamedSibling` should be the TSDoc comment.
+ */
+function resolveCommentAnchor(node: Node): Node {
+  return node.previousNamedSibling?.type === 'decorator' ? node.previousNamedSibling : node;
 }
 
 /**
@@ -63,19 +99,18 @@ function isExportedClass(node: Node): boolean {
 }
 
 /**
- * Checks a single `public_field_definition` node for a preceding TSDoc
- * comment. Decorators (e.g. Lit's `@property()` / `@state()`) live inside
- * the field node itself, so the anchor for the comment is the field node.
+ * Checks a single `public_field_definition` or decorated accessor
+ * `method_definition` node for a preceding TSDoc comment.
  *
- * @param node - The `public_field_definition` node to inspect.
+ * @param node - The field or accessor node to inspect.
  * @param filePath - Source file path included in diagnostic output.
  * @param severity - Severity level for the emitted diagnostic.
  * @param out - Accumulator array for collected diagnostics.
  */
 function checkFieldNode(node: Node, filePath: string, severity: Severity, out: Diagnostic[]): void {
-  const prev = node.previousNamedSibling;
+  const prev = resolveCommentAnchor(node).previousNamedSibling;
   const name = node.childForFieldName('name')?.text ?? '(unknown)';
-  // Require a TSDoc comment immediately preceding the field declaration
+  // Require a TSDoc comment immediately preceding the declaration (or its decorator)
   if (prev?.type !== 'comment' || !isTsDoc(prev.text)) {
     out.push({
       file: filePath,
@@ -105,15 +140,19 @@ function walkNode(
   out: Diagnostic[],
   classScope: 'all' | 'exported',
 ): void {
-  // Only inspect class field declarations; recurse into everything else
-  if (node.type === 'public_field_definition') {
+  // Inspect class field declarations and decorated get/set accessors; recurse into everything else
+  const isFieldNode = node.type === 'public_field_definition';
+  const isDecoratedAccessorNode =
+    node.type === 'method_definition' && isAccessor(node) && isDecoratedAccessor(node);
+  // Only fields and decorated accessors carry a documentable public API surface
+  if (isFieldNode || isDecoratedAccessorNode) {
     const classBody = node.parent;
     const classDecl = classBody?.type === 'class_body' ? classBody.parent : null;
     const inScope =
       classDecl?.type === 'class_declaration' &&
       (classScope === 'all' || isExportedClass(classDecl));
-    // Skip private and static fields — neither carries public instance API surface
-    if (inScope && !isPrivateField(node) && !isStaticField(node)) {
+    // Skip private and static members — neither carries public instance API surface
+    if (inScope && !isPrivateMember(node) && !isStaticMember(node)) {
       checkFieldNode(node, filePath, severity, out);
     }
   }
@@ -137,8 +176,9 @@ export interface RequirePropertyTsDocOptions extends RuleOptions {
 
 /**
  * Requires class field (property) declarations to have a TSDoc block
- * comment — including Lit's `@property()` / `@state()` decorated fields,
- * which form the public API surface of a web component.
+ * comment — including Lit's `@property()` / `@state()` decorated fields
+ * and decorated `get`/`set` accessor pairs, which form the public API
+ * surface of a web component. Undecorated accessors are not checked.
  *
  * `private` fields (both the `private` modifier and `#name` syntax) and
  * `static` fields are exempt — they carry no instance-level public API.

--- a/packages/modules/analytics/src/AnalyticsProvider.ts
+++ b/packages/modules/analytics/src/AnalyticsProvider.ts
@@ -24,6 +24,7 @@ class DisposableSubscription extends Subscription {
     super(subscription.unsubscribe);
   }
 
+  /** TC39 `Disposable` protocol support, delegating to `unsubscribe()`. */
   [Symbol.dispose] = () => {
     this.unsubscribe();
   };

--- a/packages/modules/app/src/AppConfigurator.ts
+++ b/packages/modules/app/src/AppConfigurator.ts
@@ -59,6 +59,7 @@ export class AppConfigurator
   extends BaseConfigBuilder<AppModuleConfig>
   implements IAppConfigurator
 {
+  /** Default cache expiration time, in milliseconds, for the app service client. */
   defaultExpireTime = 1 * 60 * 1000;
 
   /**

--- a/packages/modules/app/src/app/App.ts
+++ b/packages/modules/app/src/app/App.ts
@@ -977,6 +977,7 @@ export class App<
     return operator(this.getAppModule(!allow_cache));
   }
 
+  /** Releases resources held by this app instance. */
   public dispose: VoidFunction;
 }
 

--- a/packages/modules/azure-identity/src/NoCredentialError.ts
+++ b/packages/modules/azure-identity/src/NoCredentialError.ts
@@ -6,5 +6,6 @@
  * failure without relying on brittle string matching.
  */
 export class NoCredentialError extends Error {
+  /** Discriminant used to identify this error type. */
   override readonly name = 'NoCredentialError';
 }

--- a/packages/modules/bookmark/src/BookmarkModuleConfigurator.ts
+++ b/packages/modules/bookmark/src/BookmarkModuleConfigurator.ts
@@ -43,7 +43,8 @@ const parseInitialBookmarkConfigConfig = (initial?: unknown): BookmarkModuleConf
  */
 export class BookmarkModuleConfigurator extends BaseConfigBuilder<BookmarkModuleConfig> {
   #log?: ILogger;
-  defaultExpireTime = 1 * 60 * 1000; // Default expiration time for bookmarks
+  /** Default expiration time, in milliseconds, for bookmarks. */
+  defaultExpireTime = 1 * 60 * 1000;
 
   /**
    * Constructs a new `BookmarkModuleConfigurator`.

--- a/packages/modules/feature-flag/src/FeatureFlag.ts
+++ b/packages/modules/feature-flag/src/FeatureFlag.ts
@@ -78,6 +78,7 @@ export class FeatureFlag<T = unknown> implements IFeatureFlag {
     return !!this._options.readonly;
   }
 
+  /** Marks this instance as immerable so `immer` can produce structural clones. */
   [immerable] = true;
 
   /**

--- a/packages/modules/http/src/configurator.ts
+++ b/packages/modules/http/src/configurator.ts
@@ -153,6 +153,7 @@ export interface IHttpClientConfigurator<TClient extends IHttpClient = IHttpClie
 export class HttpClientConfigurator<TClient extends IHttpClient>
   implements IHttpClientConfigurator<TClient>
 {
+  /** Named client configurations keyed by client name. */
   protected _clients: Record<string, HttpClientOptions<TClient>> = {};
 
   /**

--- a/packages/modules/http/src/errors/HttpJsonResponseError.ts
+++ b/packages/modules/http/src/errors/HttpJsonResponseError.ts
@@ -12,6 +12,7 @@ export class HttpJsonResponseError<
   TResponse = Response,
 > extends HttpResponseError<TResponse> {
   static Name = 'HttpJsonResponseError';
+  /** The parsed JSON data associated with the error response, if any. */
   public readonly data?: TType;
 
   /**

--- a/packages/modules/services/src/provider.ts
+++ b/packages/modules/services/src/provider.ts
@@ -108,6 +108,7 @@ export class ApiProvider<TClient extends IHttpClient = IHttpClient>
   extends BaseModuleProvider<ApiProviderConfig<TClient>>
   implements IApiProvider<TClient>
 {
+  /** Factory used to create the underlying HTTP client for this provider. */
   protected _createClientFn: ApiClientFactory<TClient>;
 
   /**

--- a/packages/utils/query/src/client/QueryClientError.ts
+++ b/packages/utils/query/src/client/QueryClientError.ts
@@ -30,6 +30,7 @@ type QueryClientErrorType = 'error' | 'abort';
  * ```
  */
 export class QueryClientError<TArgs = unknown> extends Error {
+  /** The request that was being processed when this error occurred, if any. */
   public readonly request?: QueryClientRequest;
 
   /**

--- a/packages/utils/query/src/client/QueryClientJob.ts
+++ b/packages/utils/query/src/client/QueryClientJob.ts
@@ -54,6 +54,7 @@ export class QueryClientJob<TType = unknown, TArgs = unknown>
     return this.#transaction;
   }
 
+  /** Timestamp, in milliseconds since epoch, when this job was created. */
   public readonly created: number = Date.now();
 
   /**


### PR DESCRIPTION
## Summary

Adds a new fusion-lint rule, `require-property-tsdoc`, that requires a TSDoc comment (`/** ... */`) immediately preceding class field declarations — including Lit `@property()`/`@state()` decorated fields.

### Exemptions
- Private fields (`private` accessibility modifier or `#name` syntax)
- Static fields

### Options
- `classScope?: 'all' | 'exported'` — limit enforcement to exported classes only (default: `all`)

The rule is included in the `recommended` preset (`recommendedRules` in `@equinor/fusion-framework-lint-config`).

## Changes
- `packages/linting/rules/src/require-property-tsdoc/index.ts` — new rule implementation
- `packages/linting/rules/src/__tests__/require-property-tsdoc.test.ts` — 11 new tests
- `packages/linting/rules/src/index.ts` — export the new rule and its options type
- `packages/linting/config/src/recommended-rules.ts` — wire into recommended preset
- `.changeset/require-property-tsdoc.md` — minor bump for `lint-rules` and `lint-config`

### Repo-wide fallout fix
Since the rule ships in `recommended`, ran a full `fusion-lint lint .` sweep across the whole
monorepo to catch pre-existing violations. Found and fixed 13 class fields missing TSDoc across
9 packages/cookbooks (all patch-level doc-only changes, no behavior change):
- `cookbooks/app-react-router` (`Api.ts`)
- `@equinor/fusion-framework-module-app` (`AppConfigurator.ts`, `App.ts`)
- `@equinor/fusion-framework-module-analytics` (`AnalyticsProvider.ts`)
- `@equinor/fusion-framework-module-azure-identity` (`NoCredentialError.ts`)
- `@equinor/fusion-framework-module-bookmark` (`BookmarkModuleConfigurator.ts`)
- `@equinor/fusion-framework-module-feature-flag` (`FeatureFlag.ts`)
- `@equinor/fusion-framework-module-http` (`configurator.ts`, `errors/HttpJsonResponseError.ts`)
- `@equinor/fusion-framework-module-services` (`provider.ts`)
- `@equinor/fusion-query` (`QueryClientError.ts`, `QueryClientJob.ts`)

Remaining ~28 warnings repo-wide are pre-existing, unrelated `require-intent-comment/*` issues in
root config scripts (`fusion-ai.config.ts`, `fusion-cli.config.ts`) and `eds/*.ts` tooling scripts —
out of scope for this PR.

## Validation
- ✅ `vitest` — 11/11 new tests passing; 51/51 tests across all touched downstream packages, no regressions
- ✅ Biome — clean on all touched files
- ✅ `fusion-lint lint .` (full repo) — 0 `require-property-tsdoc` warnings remaining
- ✅ `tsc -b --force` for `lint-rules`, `lint-config`, and all 7 touched downstream packages — clean
  (note: `@equinor/fusion-framework-module-analytics` has a pre-existing, unrelated `tsc` failure in
  `FusionOTLPLogExporter.ts` from an `@opentelemetry/*` version mismatch — confirmed via `git diff`
  that file was untouched by this PR)
