### PR TITLE
fix(dev-portal): align stacking with app portal

### DIFF
--- a/.changeset/dev-portal_fix-stacking.md
+++ b/.changeset/dev-portal_fix-stacking.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-dev-portal": patch
+---
+
+Match `app-portal` stacking behaviour.

--- a/packages/dev-portal/src/Router.tsx
+++ b/packages/dev-portal/src/Router.tsx
@@ -18,11 +18,14 @@ const Styled = {
     `,
   Head: styled.section`
         grid-area: head;
+        z-index: 2;
     `,
   Main: styled.section`
         grid-area: main;
+        --header-height: 48px;
         overflow: auto;
         position: relative;
+        z-index: 1;
         max-width: 100%;
         display: grid;
     `,


### PR DESCRIPTION
**Why is this change needed?**

Hosted applications in the dev portal should use the same overlay layering contract as `app-portal`. Without that contract, fixed overlays can obscure portal chrome and side-sheet content can begin underneath the 48px header.

**What is the current behavior?**

The dev portal header and hosted-app region do not establish the same stacking levels as `app-portal`. Hosted side sheets also fall back to the viewport origin because their app scope does not inherit the portal header offset.

**What is the new behavior?**

The header renders in stacking layer 2 and the positioned hosted-app region renders in stacking layer 1. The app region scopes a hardcoded 48px header offset so side sheets begin below the header and use the remaining viewport height, while full-viewport scrims remain behind portal chrome.

**What is the intended behavior or invariant?**

Portal chrome must remain above overlays created by hosted applications. Hosted overlays must inherit the dev portal's 48px header boundary without introducing a global CSS variable.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: Local app development now matches `app-portal` overlay placement and stacking.
- Downstream impact: Limited to `@equinor/fusion-framework-dev-portal` consumers.

**Review guidance:**

Compare the `Head` and `Main` stacking values with `app-portal`'s header (`z-index: 2`) and app mount (`z-index: 1`). In a hosted app, open a side sheet and verify its top is 48px, its bottom reaches the viewport edge, and its scrim does not cover the portal header.

**Additional context**

A patch changeset is included. Local `app-admin` verification confirmed the side sheet renders from 48px to the viewport bottom and the scrim remains below the header stacking layer.

Validation:
- `pnpm test` passed.
- `pnpm build` passed.
- Targeted Biome and Fusion lint checks passed.
- `pnpm -w check` reaches one pre-existing formatting error in unchanged `packages/linting/rules/src/require-property-tsdoc/index.ts`; that file matches `origin/main`.
- Required PR checks passed.

**Related issues**

None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)