### PR TITLE
feat(openapi-mock): add package for generating OpenAPI-shaped fake responses

### DIFF
--- a/.changeset/openapi-mock_initial-release.md
+++ b/.changeset/openapi-mock_initial-release.md
@@ -1,0 +1,24 @@
+---
+"@equinor/fusion-openapi-mock": minor
+---
+
+Add `@equinor/fusion-openapi-mock`: fakes OpenAPI 3 responses straight from a parsed spec document, so testing an API-shaped client needs no hand-written fixtures until a specific edge case needs overriding.
+
+```typescript
+import { createOpenApiMock, fetchOpenApiDocument } from '@equinor/fusion-openapi-mock';
+
+const openapi = await fetchOpenApiDocument('https://api.example.com/openapi.json');
+const mock = createOpenApiMock(openapi, { seed: 42 });
+
+const response = await mock.resolve({ method: 'GET', path: '/pets/1' });
+// response.mock is already shaped like the operation's declared response schema
+```
+
+Highlights:
+
+- Every operation with an `operationId` is faked from its declared success response schema, `$ref`s resolved against the document — no hand-written mock data needed to get started.
+- `overrides` (at construction) and `.register(operationId, handler)` (afterwards) replace the faked response for just the operations an edge case cares about.
+- `seed` makes faked output repeatable across runs, for assertions against concrete expected values instead of `expect.any(...)`.
+- `fetchOpenApiDocument(url, options?)` fetches and parses a JSON or YAML spec from a URL, so there's no need to download and commit a copy that can drift out of sync.
+- `fields`, a `FieldFakerMap` keyed `"<ModelName>.<field>"`, fakes specific fields with a `@faker-js/faker` path string or a real function — without editing the spec itself. `loadFakerMap(source)` loads one from a `.json`/`.yml`/`.yaml`/`.ts`/`.js` sidecar file (functions require `.ts`/`.js`), or accepts an already-built map.
+- No dependency on any HTTP or routing framework: `resolve({ method, path, query })` returns a plain `{ status, mock }`, so it drops into `@equinor/fusion-framework-module-http`'s mock router, `openapi-backend`, Express, or a hand-rolled server equally easily.

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -13,7 +13,7 @@ search to rediscover it.
 
 | Path | Contains | Published? |
 | --- | --- | --- |
-| `packages/*` | Framework libraries (58 packages) | Yes, via Changesets |
+| `packages/*` | Framework libraries (59 packages) | Yes, via Changesets |
 | `cookbooks/*` | Runnable example apps and portals | Yes (versioned, but examples) |
 | `eds-content/`, `eds/` | EDS design-system content and token tooling | No |
 | `vue-press/` | Documentation site | Partly |
@@ -91,6 +91,7 @@ Format: `package name` → path → role.
 | `@equinor/fusion-log` | `packages/utils/log` | Logging utilities |
 | `@equinor/fusion-imports` | `packages/utils/imports` | Import resolution helpers |
 | `@equinor/fusion-load-env` | `packages/utils/load-env` | `.env` loading |
+| `@equinor/fusion-openapi-mock` | `packages/utils/openapi-mock` | Fakes OpenAPI 3 responses from a parsed spec document |
 
 ### CLI and tooling
 

--- a/packages/utils/openapi-mock/README.md
+++ b/packages/utils/openapi-mock/README.md
@@ -1,0 +1,162 @@
+# @equinor/fusion-openapi-mock
+
+Fakes OpenAPI 3 responses straight from a spec document, so testing an API-shaped client needs no hand-written mock data until a specific edge case needs one.
+
+## When to use this package
+
+- You have an `openapi.json`/`openapi.yaml` for a service and want a test double that already matches its shape, without writing fixtures by hand.
+- You want most operations faked automatically, but a handful overridden for specific test scenarios (a `404`, a particular id, a boundary value).
+- You want to wire generated mocks into an HTTP mock router (e.g. `@equinor/fusion-framework-module-http`'s `mock` entry point), `openapi-backend`, Express, or a hand-rolled server — this package has no opinion on any of them.
+
+## Installation
+
+```bash
+pnpm add @equinor/fusion-openapi-mock
+```
+
+## Quick start
+
+```ts
+import { createOpenApiMock, fetchOpenApiDocument } from '@equinor/fusion-openapi-mock';
+
+// Fetch the spec straight from wherever it's published — most are already public,
+// so there's no point downloading a copy and committing it to the repository.
+const openapi = await fetchOpenApiDocument('https://api.example.com/openapi.json');
+const mock = createOpenApiMock(openapi);
+
+const response = await mock.resolve({ method: 'GET', path: '/pets/1' });
+// response.status -> the operation's declared success status
+// response.mock   -> a value shaped like the operation's response schema
+// response.params -> { petId: '1' }, extracted from the /pets/{petId} template
+```
+
+A document already available locally works the same way, with no need for `fetchOpenApiDocument`:
+
+```ts
+import openapi from './openapi.json' with { type: 'json' };
+
+const mock = createOpenApiMock(openapi);
+```
+
+## Key concepts
+
+### Fetching the spec instead of committing it
+
+`fetchOpenApiDocument(url, options?)` fetches and parses a spec — JSON or YAML — from a URL, so a test suite always mocks against the real, currently-published contract instead of a copy that can drift out of sync. Pass a custom `fetch` (e.g. one that attaches an auth header) through `options.fetch`.
+
+### Zero-friction baseline
+
+Every operation with an `operationId` is indexed from the document's `paths`. The first time it's requested, its declared "success" response (the lowest `2xx` status code, falling back to `default`) is faked from that response's JSON schema — `$ref`s included, resolved against the same document.
+
+### Overriding an edge case
+
+Pass `overrides` at construction, or call `.register(operationId, handler)` afterwards, to replace the faked response for one operation:
+
+```ts
+const mock = createOpenApiMock(openapi, {
+  overrides: {
+    getPetById: ({ params }) => ({
+      status: 404,
+      mock: { message: `Pet ${params.petId} not found` },
+    }),
+  },
+});
+```
+
+An override can also start from the generated baseline and tweak just the field a test cares about:
+
+```ts
+mock.register('getPetById', async ({ params, mockResponseForOperation }) => {
+  const baseline = await mockResponseForOperation();
+  return { ...baseline, mock: { ...baseline.mock, id: params.petId, status: 'sold' } };
+});
+```
+
+### Repeatable tests with `seed`
+
+```ts
+const mock = createOpenApiMock(openapi, { seed: 42 });
+```
+
+The same document and seed always fake the same values, so a test can assert against a concrete expected value instead of `expect.any(...)`.
+
+### Faking specific fields with `@faker-js/faker`
+
+Add a `faker: "module.method"` keyword to any property in the OpenAPI schema (this package's own extension to the schema, ignored by every OpenAPI tool that doesn't know about it) to get a realistic value instead of a generic one:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "faker": "person.fullName" },
+    "email": { "type": "string", "faker": "internet.email" }
+  }
+}
+```
+
+Everything else — `format`, `pattern`, ranges, `enum`, composition keywords — is faked by `json-schema-faker`'s own built-in generators.
+
+### Faking fields without editing the schema, via a `fields` sidecar
+
+The `faker: "..."` keyword above requires editing the schema — not always possible when a spec is fetched from a URL and isn't yours to change. `fields` describes the same thing from the outside, keyed `"<ModelName>.<field>"` against `#/components/schemas` names instead:
+
+```ts
+const mock = createOpenApiMock(openapi, {
+  fields: {
+    'User.email': 'internet.email', // a faker path — same lookup as the schema keyword
+    'User.avatarUrl': 'image.avatar',
+    'User.id': ({ modelName, path }) => `usr_${modelName}_${path.join('-')}_${crypto.randomUUID()}`,
+  },
+});
+```
+
+A nested (inline, non-`$ref`) field dots further — `'User.address.city'`. Once a nested field is itself a named component schema, its own fields key off *that* schema's name instead (`'Address.city'`, not `'User.address.city'`), since that's the model a real `$ref` in the spec actually points at.
+
+Build the map in code, or load it from a **sidecar file** with `loadFakerMap` — so the mapping lives next to your tests instead of inside the spec:
+
+```ts
+import { createOpenApiMock, loadFakerMap } from '@equinor/fusion-openapi-mock';
+
+const fields = await loadFakerMap('./fields.faker.ts');
+const mock = createOpenApiMock(openapi, { fields });
+```
+
+`loadFakerMap` resolves the sidecar by extension:
+
+| Format | Can hold |
+| --- | --- |
+| `.json` | Faker-path strings only |
+| `.yml` / `.yaml` | Faker-path strings only |
+| `.ts` / `.js` / `.mjs` | Faker-path strings **and** real functions — its `default` export is used as the map, resolved through [`@equinor/fusion-imports`](../imports)' `importConfig`, so no build step is required |
+
+```ts
+// fields.faker.ts
+import type { FieldFakerMap } from '@equinor/fusion-openapi-mock';
+
+export default {
+  'User.email': 'internet.email',
+  'User.id': ({ path }) => `usr_${path.join('-')}`,
+} satisfies FieldFakerMap;
+```
+
+`loadFakerMap` also accepts an already-built map (returned as-is), so code that builds one dynamically doesn't need a file at all.
+
+## API reference
+
+| Export                  | Description |
+| ------------------------ | ----------- |
+| `createOpenApiMock(document, options?)` | Builds an `OpenApiMock` for one parsed OpenAPI document. `options.seed` makes faked output repeatable, `options.fields` applies a `FieldFakerMap`. |
+| `OpenApiMock.resolve({ method, path, query? })` | Matches a request against the document's paths, returning `{ status, mock, operationId, params }` or `undefined`. |
+| `OpenApiMock.mockResponseForOperation(operationId)` | Fakes a response for one operation directly, ignoring request matching. |
+| `OpenApiMock.register(operationId, handler)` | Registers (or replaces) the override for one operation. |
+| `fetchOpenApiDocument(url, options?)` | Fetches and parses a JSON or YAML OpenAPI document from a URL. |
+| `dereferenceSchema(schema, document)` | Inlines every `$ref` JSON pointer in a schema against a document. |
+| `generateMockFromSchema(schema, options?)` | Fakes one value from an already-dereferenced schema. `options.seed` makes it repeatable. |
+| `loadFakerMap(source, options?)` | Loads a `FieldFakerMap` from a `.json`/`.yml`/`.yaml`/`.ts`/`.js` sidecar file, or returns an already-built map as-is. |
+| `applyFieldFakers(schema, document, fields)` | Dereferences a schema while annotating fields matched by a `FieldFakerMap`; used internally by `createOpenApiMock`'s `fields` option. |
+
+## Notes
+
+- Operations without an `operationId` are not routable or overridable — they're skipped entirely, since there's nothing to key an override on.
+- A path parameter (`{petId}`) always matches exactly one path segment, matching OpenAPI's own path templating.
+- A schema that (indirectly) references itself would recurse forever when faked; the second time one `$ref` is seen along a branch, `dereferenceSchema` substitutes an empty (permissive) schema instead.

--- a/packages/utils/openapi-mock/package.json
+++ b/packages/utils/openapi-mock/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@equinor/fusion-openapi-mock",
+  "version": "0.1.0",
+  "description": "Fakes OpenAPI 3 responses straight from a spec, so testing an API-shaped client needs no hand-written mock data until an edge case needs overriding",
+  "keywords": [
+    "openapi",
+    "mock",
+    "faker",
+    "testing",
+    "typescript",
+    "equinor",
+    "fusion"
+  ],
+  "license": "ISC",
+  "type": "module",
+  "main": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
+  "types": "dist/types/index.d.ts",
+  "directories": {
+    "dist": "dist"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/equinor/fusion-framework.git",
+    "directory": "packages/utils/openapi-mock"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "prepack": "pnpm build",
+    "test": "vitest",
+    "test:run": "vitest --run"
+  },
+  "bugs": {
+    "url": "https://github.com/equinor/fusion-framework/issues"
+  },
+  "dependencies": {
+    "@equinor/fusion-imports": "workspace:^",
+    "@faker-js/faker": "^10.1.0",
+    "json-schema-faker": "^0.6.3",
+    "yaml": "^2.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/utils/openapi-mock/src/apply-field-fakers.ts
+++ b/packages/utils/openapi-mock/src/apply-field-fakers.ts
@@ -13,36 +13,10 @@ export interface ApplyFieldFakersResult {
 }
 
 /**
- * Dereferences `schema` the same way {@link dereferenceSchema} does, while
- * additionally tracking which named component schema (`$ref` target) and
- * field path each node was reached through, and annotating any node whose
- * `"<ModelName>.<field>"` key matches an entry in `fakerMap`.
- *
- * @remarks
- * Entering a `$ref` resets the tracked field path to `[]` under the ref's own
- * name — so a field is addressed as `"User.address.city"` only while
- * `address` is an inline (non-`$ref`) object nested directly under `User`;
- * once `address` is itself a named component schema (e.g. `Address`), its
- * fields are addressed as `"Address.city"` instead. Function-valued entries
- * cannot be inlined as a schema keyword directly, so each is assigned a
- * synthetic `__custom.<n>` key and collected into {@link ApplyFieldFakersResult.customFakers}
- * for the caller to merge into the faker facade at generation time.
- *
- * @param schema - The schema (or sub-schema) to dereference and annotate.
- * @param document - The full document `$ref` pointers are resolved against.
- * @param fakerMap - The field overrides to annotate matching nodes with.
- * @returns The annotated schema and function-valued faker overrides.
+ * Recursively dereferences `node`, tracking the named component schema
+ * (`modelName`) and field `path` each node was reached through so
+ * {@link annotate} can match it against `fakerMap`.
  */
-export function applyFieldFakers(
-  schema: unknown,
-  document: unknown,
-  fakerMap: FieldFakerMap,
-): ApplyFieldFakersResult {
-  const customFakers: Record<string, FieldFakerFn> = {};
-  const annotated = walk(schema, document, undefined, [], fakerMap, customFakers, new Set());
-  return { schema: annotated, customFakers };
-}
-
 function walk(
   node: unknown,
   document: unknown,
@@ -82,22 +56,14 @@ function walk(
   for (const [key, value] of Object.entries(record)) {
     // Properties need special handling to attach the matching faker annotation.
     if (key === 'properties' && properties && typeof properties === 'object') {
-      result[key] = Object.fromEntries(
-        Object.entries(properties as Record<string, unknown>)
-          // Keep each property's name in the path used to find its override.
-          .map(([propName, propSchema]) => {
-            const propPath = [...path, propName];
-            const walked = walk(
-              propSchema,
-              document,
-              modelName,
-              propPath,
-              fakerMap,
-              customFakers,
-              seen,
-            );
-            return [propName, annotate(walked, modelName, propPath, fakerMap, customFakers)];
-          }),
+      result[key] = walkProperties(
+        properties as Record<string, unknown>,
+        document,
+        modelName,
+        path,
+        fakerMap,
+        customFakers,
+        seen,
       );
       // Avoid traversing properties a second time through the generic branch.
       continue;
@@ -105,6 +71,27 @@ function walk(
     result[key] = walk(value, document, modelName, path, fakerMap, customFakers, seen);
   }
   return result;
+}
+
+/** Walks and annotates every entry of a schema's `properties` map, keying each by its own field path. */
+function walkProperties(
+  properties: Record<string, unknown>,
+  document: unknown,
+  modelName: string | undefined,
+  path: readonly string[],
+  fakerMap: FieldFakerMap,
+  customFakers: Record<string, FieldFakerFn>,
+  seen: ReadonlySet<string>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties)
+      // Keep each property's name in the path used to find its override.
+      .map(([propName, propSchema]) => {
+        const propPath = [...path, propName];
+        const walked = walk(propSchema, document, modelName, propPath, fakerMap, customFakers, seen);
+        return [propName, annotate(walked, modelName, propPath, fakerMap, customFakers)];
+      }),
+  );
 }
 
 /** Adds a `faker: "..."` keyword to `schema` if `"<modelName>.<path>"` matches an entry in `fakerMap`. */
@@ -150,4 +137,34 @@ function resolvePointer(document: unknown, ref: string): unknown {
   return current;
 }
 
+/**
+ * Dereferences `schema` the same way {@link dereferenceSchema} does, while
+ * additionally tracking which named component schema (`$ref` target) and
+ * field path each node was reached through, and annotating any node whose
+ * `"<ModelName>.<field>"` key matches an entry in `fakerMap`.
+ *
+ * @remarks
+ * Entering a `$ref` resets the tracked field path to `[]` under the ref's own
+ * name — so a field is addressed as `"User.address.city"` only while
+ * `address` is an inline (non-`$ref`) object nested directly under `User`;
+ * once `address` is itself a named component schema (e.g. `Address`), its
+ * fields are addressed as `"Address.city"` instead. Function-valued entries
+ * cannot be inlined as a schema keyword directly, so each is assigned a
+ * synthetic `__custom.<n>` key and collected into {@link ApplyFieldFakersResult.customFakers}
+ * for the caller to merge into the faker facade at generation time.
+ *
+ * @param schema - The schema (or sub-schema) to dereference and annotate.
+ * @param document - The full document `$ref` pointers are resolved against.
+ * @param fakerMap - The field overrides to annotate matching nodes with.
+ * @returns The annotated schema and function-valued faker overrides.
+ */
+export function applyFieldFakers(
+  schema: unknown,
+  document: unknown,
+  fakerMap: FieldFakerMap,
+): ApplyFieldFakersResult {
+  const customFakers: Record<string, FieldFakerFn> = {};
+  const annotated = walk(schema, document, undefined, [], fakerMap, customFakers, new Set());
+  return { schema: annotated, customFakers };
+}
 export default applyFieldFakers;

--- a/packages/utils/openapi-mock/src/apply-field-fakers.ts
+++ b/packages/utils/openapi-mock/src/apply-field-fakers.ts
@@ -88,7 +88,15 @@ function walkProperties(
       // Keep each property's name in the path used to find its override.
       .map(([propName, propSchema]) => {
         const propPath = [...path, propName];
-        const walked = walk(propSchema, document, modelName, propPath, fakerMap, customFakers, seen);
+        const walked = walk(
+          propSchema,
+          document,
+          modelName,
+          propPath,
+          fakerMap,
+          customFakers,
+          seen,
+        );
         return [propName, annotate(walked, modelName, propPath, fakerMap, customFakers)];
       }),
   );
@@ -127,14 +135,12 @@ function resolvePointer(document: unknown, ref: string): unknown {
   const path = segments.map((segment) =>
     decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
   );
-  let current: unknown = document;
   // Follow each pointer segment until the target is found or the path becomes invalid.
-  for (const segment of path) {
+  return path.reduce<unknown>((current, segment) => {
     // A non-object cannot contain another pointer segment.
     if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[segment];
-  }
-  return current;
+    return (current as Record<string, unknown>)[segment];
+  }, document);
 }
 
 /**

--- a/packages/utils/openapi-mock/src/apply-field-fakers.ts
+++ b/packages/utils/openapi-mock/src/apply-field-fakers.ts
@@ -1,0 +1,153 @@
+import type { FieldFakerFn, FieldFakerMap } from './types';
+
+/** What {@link applyFieldFakers} returns. */
+export interface ApplyFieldFakersResult {
+  /** The dereferenced schema, annotated with a `faker: "..."` keyword wherever `fakerMap` matched a field. */
+  schema: unknown;
+  /**
+   * Function-valued {@link FieldFakerMap} entries, keyed by the synthetic
+   * `faker: "__custom.<key>"` path {@link schema} was annotated with — merge
+   * this into `generateMockFromSchema`'s faker facade so those keys resolve.
+   */
+  customFakers: Record<string, FieldFakerFn>;
+}
+
+/**
+ * Dereferences `schema` the same way {@link dereferenceSchema} does, while
+ * additionally tracking which named component schema (`$ref` target) and
+ * field path each node was reached through, and annotating any node whose
+ * `"<ModelName>.<field>"` key matches an entry in `fakerMap`.
+ *
+ * @remarks
+ * Entering a `$ref` resets the tracked field path to `[]` under the ref's own
+ * name — so a field is addressed as `"User.address.city"` only while
+ * `address` is an inline (non-`$ref`) object nested directly under `User`;
+ * once `address` is itself a named component schema (e.g. `Address`), its
+ * fields are addressed as `"Address.city"` instead. Function-valued entries
+ * cannot be inlined as a schema keyword directly, so each is assigned a
+ * synthetic `__custom.<n>` key and collected into {@link ApplyFieldFakersResult.customFakers}
+ * for the caller to merge into the faker facade at generation time.
+ *
+ * @param schema - The schema (or sub-schema) to dereference and annotate.
+ * @param document - The full document `$ref` pointers are resolved against.
+ * @param fakerMap - The field overrides to annotate matching nodes with.
+ * @returns The annotated schema and function-valued faker overrides.
+ */
+export function applyFieldFakers(
+  schema: unknown,
+  document: unknown,
+  fakerMap: FieldFakerMap,
+): ApplyFieldFakersResult {
+  const customFakers: Record<string, FieldFakerFn> = {};
+  const annotated = walk(schema, document, undefined, [], fakerMap, customFakers, new Set());
+  return { schema: annotated, customFakers };
+}
+
+function walk(
+  node: unknown,
+  document: unknown,
+  modelName: string | undefined,
+  path: readonly string[],
+  fakerMap: FieldFakerMap,
+  customFakers: Record<string, FieldFakerFn>,
+  seen: ReadonlySet<string>,
+): unknown {
+  // Arrays require recursive traversal to preserve every nested schema item.
+  if (Array.isArray(node)) {
+    // Preserve array shape while recursively applying refs and field overrides.
+    return node.map((item) => walk(item, document, modelName, path, fakerMap, customFakers, seen));
+  }
+  // Primitive values need no schema traversal.
+  if (!node || typeof node !== 'object') return node;
+
+  const record = node as Record<string, unknown>;
+  const ref = record.$ref;
+  // References are expanded here so overrides can match fields inside shared models.
+  if (typeof ref === 'string' && ref.startsWith('#/')) {
+    // Stop recursive references from expanding indefinitely.
+    if (seen.has(ref)) return {};
+    // Leave unresolved references intact so callers can diagnose incomplete documents.
+    const resolved = resolvePointer(document, ref);
+    // A missing target cannot be safely replaced with a fabricated schema.
+    if (resolved === undefined) return node;
+    // entering a named model resets the tracked path, so keys read "<Model>.<field>"
+    // rather than accumulating the outer model's name in front of it
+    const nextModel = ref.split('/').pop();
+    return walk(resolved, document, nextModel, [], fakerMap, customFakers, new Set(seen).add(ref));
+  }
+
+  const properties = record.properties;
+  const result: Record<string, unknown> = {};
+  // Visit each property so its model-relative path can select a faker override.
+  for (const [key, value] of Object.entries(record)) {
+    // Properties need special handling to attach the matching faker annotation.
+    if (key === 'properties' && properties && typeof properties === 'object') {
+      result[key] = Object.fromEntries(
+        Object.entries(properties as Record<string, unknown>)
+          // Keep each property's name in the path used to find its override.
+          .map(([propName, propSchema]) => {
+            const propPath = [...path, propName];
+            const walked = walk(
+              propSchema,
+              document,
+              modelName,
+              propPath,
+              fakerMap,
+              customFakers,
+              seen,
+            );
+            return [propName, annotate(walked, modelName, propPath, fakerMap, customFakers)];
+          }),
+      );
+      // Avoid traversing properties a second time through the generic branch.
+      continue;
+    }
+    result[key] = walk(value, document, modelName, path, fakerMap, customFakers, seen);
+  }
+  return result;
+}
+
+/** Adds a `faker: "..."` keyword to `schema` if `"<modelName>.<path>"` matches an entry in `fakerMap`. */
+function annotate(
+  schema: unknown,
+  modelName: string | undefined,
+  path: readonly string[],
+  fakerMap: FieldFakerMap,
+  customFakers: Record<string, FieldFakerFn>,
+): unknown {
+  // Without a model name there is no stable key against which to match an override.
+  if (!modelName) return schema;
+  const value = fakerMap[`${modelName}.${path.join('.')}`];
+  // An absent map entry means the schema should retain its original shape.
+  if (value === undefined) return schema;
+
+  const base = schema && typeof schema === 'object' ? (schema as Record<string, unknown>) : {};
+  // Functions must be registered separately because schema keywords only hold strings.
+  if (typeof value === 'function') {
+    const fakerKey = `field$${Object.keys(customFakers).length}`;
+    // json-schema-faker calls a resolved faker-path function with no arguments, so the
+    // field's own model/path context is captured in this closure instead
+    customFakers[fakerKey] = () => value({ modelName, path });
+    return { ...base, faker: `__custom.${fakerKey}` };
+  }
+  return { ...base, faker: value };
+}
+
+/** Walks a JSON pointer (`#/a/b/c`) against `document`, returning `undefined` if any segment is missing. */
+function resolvePointer(document: unknown, ref: string): unknown {
+  const segments = ref.slice(2).split('/');
+  // Decode each pointer segment before using it as an object key.
+  const path = segments.map((segment) =>
+    decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
+  );
+  let current: unknown = document;
+  // Follow each pointer segment until the target is found or the path becomes invalid.
+  for (const segment of path) {
+    // A non-object cannot contain another pointer segment.
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export default applyFieldFakers;

--- a/packages/utils/openapi-mock/src/create-open-api-mock.ts
+++ b/packages/utils/openapi-mock/src/create-open-api-mock.ts
@@ -3,6 +3,8 @@ import { dereferenceSchema } from './dereference-schema';
 import { generateMockFromSchema } from './generate-mock-from-schema';
 
 import type {
+  FieldFakerFn,
+  FieldFakerMap,
   OpenApiDocumentLike,
   OpenApiMock,
   OpenApiMockOptions,
@@ -49,10 +51,7 @@ function compilePath(pathTemplate: string): { pattern: RegExp; paramNames: strin
 }
 
 /** Reads the response body schema (if any) declared for `code` in `responses`. */
-function schemaForCode(
-  responses: Record<string, unknown>,
-  code: string,
-): unknown {
+function schemaForCode(responses: Record<string, unknown>, code: string): unknown {
   const response = responses[code] as Record<string, unknown> | undefined;
   const content = response?.content as Record<string, unknown> | undefined;
   const media = content?.['application/json'] as Record<string, unknown> | undefined;
@@ -108,7 +107,14 @@ function buildOperationEntry(
   const { status, schema } = pickSuccessResponse(
     operation?.responses as Record<string, unknown> | undefined,
   );
-  return { method: method.toUpperCase(), operationId, paramNames, pattern, responseSchema: schema, status };
+  return {
+    method: method.toUpperCase(),
+    operationId,
+    paramNames,
+    pattern,
+    responseSchema: schema,
+    status,
+  };
 }
 
 /**
@@ -127,11 +133,13 @@ function buildOperations(document: OpenApiDocumentLike): OperationEntry[] {
     // Each path template expands into up to one entry per routable HTTP method.
     .flatMap(([pathTemplate, pathItem]) => {
       const { pattern, paramNames } = compilePath(pathTemplate);
-      return ROUTABLE_METHODS
-        // Build only the methods this path item actually declares an operation for.
-        .map((method) => buildOperationEntry(pathItem, method, pattern, paramNames))
-        // Drop the methods this path item did not declare an operation for.
-        .filter((entry): entry is OperationEntry => entry !== undefined);
+      return (
+        ROUTABLE_METHODS
+          // Build only the methods this path item actually declares an operation for.
+          .map((method) => buildOperationEntry(pathItem, method, pattern, paramNames))
+          // Drop the methods this path item did not declare an operation for.
+          .filter((entry): entry is OperationEntry => entry !== undefined)
+      );
     });
   return entries.sort(bySpecificity);
 }
@@ -161,7 +169,25 @@ function matchOperation(
     .find((candidate): candidate is { entry: OperationEntry; match: RegExpExecArray } =>
       Boolean(candidate.match),
     );
-  return match && { entry: match.entry, params: paramsFromMatch(match.entry.paramNames, match.match) };
+  // No candidate's pattern matched this path at all.
+  if (!match) return undefined;
+  return { entry: match.entry, params: paramsFromMatch(match.entry.paramNames, match.match) };
+}
+
+/**
+ * Fakes `responseSchema`: field-annotating and dereferencing it against
+ * `fieldFakerMap` when the caller configured field overrides, otherwise
+ * just resolving its `$ref`s.
+ */
+function resolveResponseSchema(
+  responseSchema: unknown,
+  document: OpenApiDocumentLike,
+  fieldFakerMap: FieldFakerMap | undefined,
+): { schema: unknown; customFakers?: Record<string, FieldFakerFn> } {
+  // Field fakers additionally track which model/path each node was reached through,
+  // so the heavier walk only runs when the caller actually configured field overrides.
+  if (fieldFakerMap) return applyFieldFakers(responseSchema, document, fieldFakerMap);
+  return { schema: dereferenceSchema(responseSchema, document) };
 }
 
 /**
@@ -177,7 +203,9 @@ function resolveMatchedResponse(
 ): Promise<OpenApiMockResponse> {
   // No override registered for this operation: the generated baseline is the response as-is.
   if (!override) return fakeOperation(entry);
-  return Promise.resolve(override({ ...context, mockResponseForOperation: () => fakeOperation(entry) }));
+  return Promise.resolve(
+    override({ ...context, mockResponseForOperation: () => fakeOperation(entry) }),
+  );
 }
 
 /**
@@ -229,9 +257,12 @@ export function createOpenApiMock(
   async function fakeOperation(entry: OperationEntry): Promise<OpenApiMockResponse> {
     // Operations without a response schema still need their declared status represented.
     if (!entry.responseSchema) return { status: entry.status, mock: undefined };
-    const { schema, customFakers } = options.fields
-      ? applyFieldFakers(entry.responseSchema, document, options.fields)
-      : { schema: dereferenceSchema(entry.responseSchema, document), customFakers: undefined };
+
+    const { schema, customFakers } = resolveResponseSchema(
+      entry.responseSchema,
+      document,
+      options.fields,
+    );
     return {
       status: entry.status,
       mock: await generateMockFromSchema(schema, { seed: options.seed, customFakers }),

--- a/packages/utils/openapi-mock/src/create-open-api-mock.ts
+++ b/packages/utils/openapi-mock/src/create-open-api-mock.ts
@@ -7,9 +7,11 @@ import type {
   OpenApiMock,
   OpenApiMockOptions,
   OpenApiMockOverride,
+  OpenApiMockOverrideContext,
   OpenApiMockResponse,
 } from './types';
 
+// OpenAPI 3 only defines these methods as routable; every other method is ignored.
 const ROUTABLE_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const;
 
 interface OperationEntry {
@@ -46,7 +48,23 @@ function compilePath(pathTemplate: string): { pattern: RegExp; paramNames: strin
   return { pattern: new RegExp(`^${segments.join('/')}$`), paramNames };
 }
 
-/** Picks the response OpenAPI documents call the "success" case: the lowest 2xx code, or `default`. */
+/** Reads the response body schema (if any) declared for `code` in `responses`. */
+function schemaForCode(
+  responses: Record<string, unknown>,
+  code: string,
+): unknown {
+  const response = responses[code] as Record<string, unknown> | undefined;
+  const content = response?.content as Record<string, unknown> | undefined;
+  const media = content?.['application/json'] as Record<string, unknown> | undefined;
+  return media?.schema;
+}
+
+/**
+ * Picks the response OpenAPI documents call the "success" case: the lowest
+ * 2xx code, or `default`. Falls back to the lowest declared numeric status
+ * code (e.g. an operation that only declares `404`) rather than a `200` the
+ * document never actually promises.
+ */
 function pickSuccessResponse(responses: Record<string, unknown> | undefined): {
   status: number;
   schema?: unknown;
@@ -57,40 +75,109 @@ function pickSuccessResponse(responses: Record<string, unknown> | undefined): {
     // Only successful responses form the mock's normal baseline.
     .filter((code) => /^2\d\d$/.test(code))
     .sort();
-  const code = codes[0] ?? 'default';
-  const response = responses[code] as Record<string, unknown> | undefined;
-  const content = response?.content as Record<string, unknown> | undefined;
-  const media = content?.['application/json'] as Record<string, unknown> | undefined;
-  return { status: code === 'default' ? 200 : Number(code), schema: media?.schema };
+  // A declared 2xx always outranks `default` as the conventional success case.
+  if (codes.length > 0) {
+    const code = codes[0];
+    return { status: Number(code), schema: schemaForCode(responses, code) };
+  }
+  // `default` is OpenAPI's documented catch-all, and conventionally represents success absent a 2xx.
+  if ('default' in responses) {
+    return { status: 200, schema: schemaForCode(responses, 'default') };
+  }
+  const numericCodes = Object.keys(responses)
+    // Neither 2xx nor default is declared, so any other numeric status is the closest fallback.
+    .filter((code) => /^\d\d\d$/.test(code))
+    .sort();
+  const fallbackCode = numericCodes[0];
+  // No numeric status is declared at all: nothing better than the conventional 200 remains.
+  if (fallbackCode === undefined) return { status: 200 };
+  return { status: Number(fallbackCode), schema: schemaForCode(responses, fallbackCode) };
+}
+
+/** Builds the {@link OperationEntry} for one path item's method, or `undefined` if it isn't routable. */
+function buildOperationEntry(
+  pathItem: Record<string, unknown>,
+  method: (typeof ROUTABLE_METHODS)[number],
+  pattern: RegExp,
+  paramNames: string[],
+): OperationEntry | undefined {
+  const operation = pathItem[method] as Record<string, unknown> | undefined;
+  const operationId = operation?.operationId as string | undefined;
+  // Unnamed operations cannot be addressed by the mock's operation-based API, so are skipped.
+  if (!operationId) return undefined;
+  const { status, schema } = pickSuccessResponse(
+    operation?.responses as Record<string, unknown> | undefined,
+  );
+  return { method: method.toUpperCase(), operationId, paramNames, pattern, responseSchema: schema, status };
+}
+
+/**
+ * Sorts operations so literal path segments win over templated ones (fewer
+ * params first), otherwise a templated route like `/pets/{petId}` can shadow
+ * a more specific literal route depending on the order the spec declares
+ * paths in.
+ */
+function bySpecificity(a: OperationEntry, b: OperationEntry): number {
+  return a.paramNames.length - b.paramNames.length;
 }
 
 /** Indexes every routable (named) operation across all paths and methods of the document. */
 function buildOperations(document: OpenApiDocumentLike): OperationEntry[] {
-  const entries: OperationEntry[] = [];
-  // Index all paths so resolution can match requests without reparsing the document.
-  for (const [pathTemplate, pathItem] of Object.entries(document.paths ?? {})) {
-    const { pattern, paramNames } = compilePath(pathTemplate);
-    // OpenAPI path items may define several HTTP methods for one route.
-    for (const method of ROUTABLE_METHODS) {
-      const operation = pathItem[method] as Record<string, unknown> | undefined;
-      const operationId = operation?.operationId as string | undefined;
-      // operations without an `operationId` cannot be looked up or overridden by name, so are skipped
-      // Unnamed operations cannot be addressed by the mock's operation-based API.
-      if (!operationId) continue;
-      const { status, schema } = pickSuccessResponse(
-        operation?.responses as Record<string, unknown> | undefined,
-      );
-      entries.push({
-        method: method.toUpperCase(),
-        operationId,
-        paramNames,
-        pattern,
-        responseSchema: schema,
-        status,
-      });
-    }
-  }
-  return entries;
+  const entries = Object.entries(document.paths ?? {})
+    // Each path template expands into up to one entry per routable HTTP method.
+    .flatMap(([pathTemplate, pathItem]) => {
+      const { pattern, paramNames } = compilePath(pathTemplate);
+      return ROUTABLE_METHODS
+        // Build only the methods this path item actually declares an operation for.
+        .map((method) => buildOperationEntry(pathItem, method, pattern, paramNames))
+        // Drop the methods this path item did not declare an operation for.
+        .filter((entry): entry is OperationEntry => entry !== undefined);
+    });
+  return entries.sort(bySpecificity);
+}
+
+/** Extracts named path parameters from a compiled pattern's exec match. */
+function paramsFromMatch(paramNames: string[], match: RegExpExecArray): Record<string, string> {
+  return Object.fromEntries(
+    paramNames
+      // Pair each declared name with the capture group at the same index.
+      .map((name, index) => [name, match[index + 1]]),
+  );
+}
+
+/** The first indexed operation (and its extracted path params) matching a method and path, if any. */
+function matchOperation(
+  operations: OperationEntry[],
+  method: string,
+  path: string,
+): { entry: OperationEntry; params: Record<string, string> } | undefined {
+  const upperMethod = method.toUpperCase();
+  const match = operations
+    // Only same-method entries can possibly match this request.
+    .filter((entry) => entry.method === upperMethod)
+    // Try every candidate pattern against the path up front so `.find` can pick the first hit.
+    .map((entry) => ({ entry, match: entry.pattern.exec(path) }))
+    // The first pattern (by specificity order) whose regex actually matches this path wins.
+    .find((candidate): candidate is { entry: OperationEntry; match: RegExpExecArray } =>
+      Boolean(candidate.match),
+    );
+  return match && { entry: match.entry, params: paramsFromMatch(match.entry.paramNames, match.match) };
+}
+
+/**
+ * Resolves the response for a matched operation: the registered
+ * {@link OpenApiMockOverride} if one exists for it, otherwise the generated
+ * baseline.
+ */
+function resolveMatchedResponse(
+  entry: OperationEntry,
+  context: Omit<OpenApiMockOverrideContext, 'mockResponseForOperation'>,
+  override: OpenApiMockOverride | undefined,
+  fakeOperation: (entry: OperationEntry) => Promise<OpenApiMockResponse>,
+): Promise<OpenApiMockResponse> {
+  // No override registered for this operation: the generated baseline is the response as-is.
+  if (!override) return fakeOperation(entry);
+  return Promise.resolve(override({ ...context, mockResponseForOperation: () => fakeOperation(entry) }));
 }
 
 /**
@@ -166,34 +253,19 @@ export function createOpenApiMock(
     mockResponseForOperation: async (operationId) => fakeOperation(findByOperationId(operationId)),
 
     async resolve({ method, path, query = {} }) {
-      const upperMethod = method.toUpperCase();
-      // Search the indexed operations for the first route matching this request.
-      for (const entry of operations) {
-        // A route with a different method cannot handle this request.
-        if (entry.method !== upperMethod) continue;
-        const match = entry.pattern.exec(path);
-        // Continue searching when this method's path pattern does not match.
-        if (!match) continue;
+      const matched = matchOperation(operations, method, path);
+      // No indexed operation covers this method/path combination.
+      if (!matched) return undefined;
 
-        const params = Object.fromEntries(
-          entry.paramNames
-            // Build the named parameter object expected by overrides and responses.
-            .map((name, index) => [name, match[index + 1]]),
-        );
-        const override = overrides.get(entry.operationId);
-        const response = override
-          ? await override({
-              operationId: entry.operationId,
-              method: upperMethod,
-              path,
-              params,
-              query,
-              mockResponseForOperation: () => fakeOperation(entry),
-            })
-          : await fakeOperation(entry);
-        return { ...response, operationId: entry.operationId, params };
-      }
-      return undefined;
+      const { entry, params } = matched;
+      const override = overrides.get(entry.operationId);
+      const response = await resolveMatchedResponse(
+        entry,
+        { operationId: entry.operationId, method: entry.method, path, params, query },
+        override,
+        fakeOperation,
+      );
+      return { ...response, operationId: entry.operationId, params };
     },
 
     register(operationId, handler) {
@@ -202,5 +274,4 @@ export function createOpenApiMock(
     },
   };
 }
-
 export default createOpenApiMock;

--- a/packages/utils/openapi-mock/src/create-open-api-mock.ts
+++ b/packages/utils/openapi-mock/src/create-open-api-mock.ts
@@ -1,0 +1,206 @@
+import { applyFieldFakers } from './apply-field-fakers';
+import { dereferenceSchema } from './dereference-schema';
+import { generateMockFromSchema } from './generate-mock-from-schema';
+
+import type {
+  OpenApiDocumentLike,
+  OpenApiMock,
+  OpenApiMockOptions,
+  OpenApiMockOverride,
+  OpenApiMockResponse,
+} from './types';
+
+const ROUTABLE_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const;
+
+interface OperationEntry {
+  method: string;
+  operationId: string;
+  paramNames: string[];
+  pattern: RegExp;
+  responseSchema?: unknown;
+  status: number;
+}
+
+/**
+ * Turns an OpenAPI path template (`/pets/{petId}`) into a matcher.
+ *
+ * @remarks
+ * A `{param}` segment always spans exactly one path segment — the same
+ * assumption OpenAPI's own path templating makes — so every other character
+ * is escaped and matched literally.
+ */
+function compilePath(pathTemplate: string): { pattern: RegExp; paramNames: string[] } {
+  const paramNames: string[] = [];
+  const segments = pathTemplate
+    .split('/')
+    // Convert each template segment independently so parameter names stay aligned.
+    .map((segment) => {
+      const param = segment.match(/^\{(.+)\}$/);
+      // Template parameters become capture groups; literal segments remain escaped.
+      if (param) {
+        paramNames.push(param[1]);
+        return '([^/]+)';
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    });
+  return { pattern: new RegExp(`^${segments.join('/')}$`), paramNames };
+}
+
+/** Picks the response OpenAPI documents call the "success" case: the lowest 2xx code, or `default`. */
+function pickSuccessResponse(responses: Record<string, unknown> | undefined): {
+  status: number;
+  schema?: unknown;
+} {
+  // A missing response map still has the conventional successful status.
+  if (!responses) return { status: 200 };
+  const codes = Object.keys(responses)
+    // Only successful responses form the mock's normal baseline.
+    .filter((code) => /^2\d\d$/.test(code))
+    .sort();
+  const code = codes[0] ?? 'default';
+  const response = responses[code] as Record<string, unknown> | undefined;
+  const content = response?.content as Record<string, unknown> | undefined;
+  const media = content?.['application/json'] as Record<string, unknown> | undefined;
+  return { status: code === 'default' ? 200 : Number(code), schema: media?.schema };
+}
+
+/** Indexes every routable (named) operation across all paths and methods of the document. */
+function buildOperations(document: OpenApiDocumentLike): OperationEntry[] {
+  const entries: OperationEntry[] = [];
+  // Index all paths so resolution can match requests without reparsing the document.
+  for (const [pathTemplate, pathItem] of Object.entries(document.paths ?? {})) {
+    const { pattern, paramNames } = compilePath(pathTemplate);
+    // OpenAPI path items may define several HTTP methods for one route.
+    for (const method of ROUTABLE_METHODS) {
+      const operation = pathItem[method] as Record<string, unknown> | undefined;
+      const operationId = operation?.operationId as string | undefined;
+      // operations without an `operationId` cannot be looked up or overridden by name, so are skipped
+      // Unnamed operations cannot be addressed by the mock's operation-based API.
+      if (!operationId) continue;
+      const { status, schema } = pickSuccessResponse(
+        operation?.responses as Record<string, unknown> | undefined,
+      );
+      entries.push({
+        method: method.toUpperCase(),
+        operationId,
+        paramNames,
+        pattern,
+        responseSchema: schema,
+        status,
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Fakes and resolves responses for the operations of an OpenAPI 3 document,
+ * so a client can be tested against something schema-shaped from the moment
+ * a spec exists — no hand-written fixtures until a specific edge case needs
+ * one.
+ *
+ * @remarks
+ * Every operation with an `operationId` is faked from its declared "success"
+ * response schema (the lowest `2xx`, falling back to `default`) the first
+ * time it's requested; {@link OpenApiMockOptions.overrides} or
+ * {@link OpenApiMock.register} replace that for the operations an edge case
+ * cares about, leaving every other operation on the generated baseline.
+ *
+ * @param document - A parsed OpenAPI 3 document (e.g. `JSON.parse(await readFile('openapi.json'))`).
+ * @param options - Overrides for specific operations.
+ * @returns A mock resolvable by request ({@link OpenApiMock.resolve}) or by `operationId` directly.
+ * @throws {Error} When an override is registered for an unknown operation ID.
+ *
+ * @example Zero-friction baseline, straight from a spec
+ * ```typescript
+ * import openapi from './openapi.json' with { type: 'json' };
+ *
+ * const mock = createOpenApiMock(openapi);
+ * const response = await mock.resolve({ method: 'GET', path: '/pets/1' });
+ * // response?.mock is already shaped like the document's Pet schema
+ * ```
+ *
+ * @example Overriding one operation for an edge case
+ * ```typescript
+ * const mock = createOpenApiMock(openapi, {
+ *   overrides: {
+ *     getPetById: async ({ params, mockResponseForOperation }) => {
+ *       const baseline = await mockResponseForOperation();
+ *       return { ...baseline, mock: { ...baseline.mock, id: params.petId, status: 'sold' } };
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function createOpenApiMock(
+  document: OpenApiDocumentLike,
+  options: OpenApiMockOptions = {},
+): OpenApiMock {
+  const operations = buildOperations(document);
+  const overrides = new Map<string, OpenApiMockOverride>(Object.entries(options.overrides ?? {}));
+
+  async function fakeOperation(entry: OperationEntry): Promise<OpenApiMockResponse> {
+    // Operations without a response schema still need their declared status represented.
+    if (!entry.responseSchema) return { status: entry.status, mock: undefined };
+    const { schema, customFakers } = options.fields
+      ? applyFieldFakers(entry.responseSchema, document, options.fields)
+      : { schema: dereferenceSchema(entry.responseSchema, document), customFakers: undefined };
+    return {
+      status: entry.status,
+      mock: await generateMockFromSchema(schema, { seed: options.seed, customFakers }),
+    };
+  }
+
+  function findByOperationId(operationId: string): OperationEntry {
+    // Resolve overrides by the public operation name rather than by route position.
+    const entry = operations.find((candidate) => candidate.operationId === operationId);
+    // Fail early so misspelled operation IDs do not silently produce unusable mocks.
+    if (!entry) {
+      throw new Error(`No operation named "${operationId}" was found in the OpenAPI document.`);
+    }
+    return entry;
+  }
+
+  return {
+    // async so a bad operationId rejects the returned promise instead of throwing synchronously
+    mockResponseForOperation: async (operationId) => fakeOperation(findByOperationId(operationId)),
+
+    async resolve({ method, path, query = {} }) {
+      const upperMethod = method.toUpperCase();
+      // Search the indexed operations for the first route matching this request.
+      for (const entry of operations) {
+        // A route with a different method cannot handle this request.
+        if (entry.method !== upperMethod) continue;
+        const match = entry.pattern.exec(path);
+        // Continue searching when this method's path pattern does not match.
+        if (!match) continue;
+
+        const params = Object.fromEntries(
+          entry.paramNames
+            // Build the named parameter object expected by overrides and responses.
+            .map((name, index) => [name, match[index + 1]]),
+        );
+        const override = overrides.get(entry.operationId);
+        const response = override
+          ? await override({
+              operationId: entry.operationId,
+              method: upperMethod,
+              path,
+              params,
+              query,
+              mockResponseForOperation: () => fakeOperation(entry),
+            })
+          : await fakeOperation(entry);
+        return { ...response, operationId: entry.operationId, params };
+      }
+      return undefined;
+    },
+
+    register(operationId, handler) {
+      findByOperationId(operationId); // throws for a typo'd operationId, rather than silently no-op-ing
+      overrides.set(operationId, handler);
+    },
+  };
+}
+
+export default createOpenApiMock;

--- a/packages/utils/openapi-mock/src/dereference-schema.ts
+++ b/packages/utils/openapi-mock/src/dereference-schema.ts
@@ -5,14 +5,12 @@ function resolvePointer(document: unknown, ref: string): unknown {
   const path = segments.map((segment) =>
     decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
   );
-  let current: unknown = document;
   // Follow the pointer one segment at a time to locate the referenced value.
-  for (const segment of path) {
+  return path.reduce<unknown>((current, segment) => {
     // Stop when a pointer walks into a scalar or null value.
     if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[segment];
-  }
-  return current;
+    return (current as Record<string, unknown>)[segment];
+  }, document);
 }
 
 /**

--- a/packages/utils/openapi-mock/src/dereference-schema.ts
+++ b/packages/utils/openapi-mock/src/dereference-schema.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolves every `$ref` JSON pointer in `schema` against `document`,
+ * replacing `{ $ref: '#/a/b' }` with the value it points to.
+ *
+ * @remarks
+ * OpenAPI schemas commonly reference shared definitions under
+ * `#/components/schemas/...`; `json-schema-faker` needs those inlined before
+ * it can fake a value, so this walks the schema tree once up front rather
+ * than relying on `json-schema-faker`'s own ref resolution, which targets
+ * separate external documents rather than pointers within the same one.
+ *
+ * A schema that (indirectly) references itself would recurse forever, so the
+ * second time one pointer is seen along a branch this returns an empty
+ * (permissive) schema instead of resolving it again.
+ *
+ * @param schema - The schema (or sub-schema) to dereference.
+ * @param document - The full document `$ref` pointers are resolved against.
+ * @param seen - References already being expanded on the current branch.
+ * @returns The schema with resolvable references recursively inlined.
+ */
+export function dereferenceSchema(
+  schema: unknown,
+  document: unknown,
+  seen: ReadonlySet<string> = new Set(),
+): unknown {
+  // Arrays require recursive traversal to inline references in every item.
+  if (Array.isArray(schema)) {
+    const items = schema;
+    // Recurse through array items because schemas can contain nested collections.
+    return items.map((item) => dereferenceSchema(item, document, seen));
+  }
+  // Only objects can contain references or nested schema keywords.
+  if (schema && typeof schema === 'object') {
+    const ref = (schema as Record<string, unknown>).$ref;
+    // References are expanded before ordinary keywords so their targets are traversed too.
+    if (typeof ref === 'string' && ref.startsWith('#/')) {
+      // Break cycles in recursive schemas instead of recursing forever.
+      if (seen.has(ref)) return {};
+      // Keep unresolved references visible rather than replacing them incorrectly.
+      const resolved = resolvePointer(document, ref);
+      // There is no safe value to inline when the pointer target is absent.
+      if (resolved === undefined) return schema;
+      return dereferenceSchema(resolved, document, new Set(seen).add(ref));
+    }
+    const entries = Object.entries(schema as Record<string, unknown>);
+    // Recurse through every keyword because nested schemas may occur anywhere.
+    return Object.fromEntries(
+      entries.map(([key, value]) => [key, dereferenceSchema(value, document, seen)]),
+    );
+  }
+  return schema;
+}
+
+/** Walks a JSON pointer (`#/a/b/c`) against `document`, returning `undefined` if any segment is missing. */
+function resolvePointer(document: unknown, ref: string): unknown {
+  const segments = ref.slice(2).split('/');
+  // Decode each pointer segment before using it as an object key.
+  const path = segments.map((segment) =>
+    decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
+  );
+  let current: unknown = document;
+  // Follow the pointer one segment at a time to locate the referenced value.
+  for (const segment of path) {
+    // Stop when a pointer walks into a scalar or null value.
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export default dereferenceSchema;

--- a/packages/utils/openapi-mock/src/dereference-schema.ts
+++ b/packages/utils/openapi-mock/src/dereference-schema.ts
@@ -1,3 +1,20 @@
+/** Walks a JSON pointer (`#/a/b/c`) against `document`, returning `undefined` if any segment is missing. */
+function resolvePointer(document: unknown, ref: string): unknown {
+  const segments = ref.slice(2).split('/');
+  // Decode each pointer segment before using it as an object key.
+  const path = segments.map((segment) =>
+    decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
+  );
+  let current: unknown = document;
+  // Follow the pointer one segment at a time to locate the referenced value.
+  for (const segment of path) {
+    // Stop when a pointer walks into a scalar or null value.
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
 /**
  * Resolves every `$ref` JSON pointer in `schema` against `document`,
  * replacing `{ $ref: '#/a/b' }` with the value it points to.
@@ -50,22 +67,4 @@ export function dereferenceSchema(
   }
   return schema;
 }
-
-/** Walks a JSON pointer (`#/a/b/c`) against `document`, returning `undefined` if any segment is missing. */
-function resolvePointer(document: unknown, ref: string): unknown {
-  const segments = ref.slice(2).split('/');
-  // Decode each pointer segment before using it as an object key.
-  const path = segments.map((segment) =>
-    decodeURIComponent(segment.replace(/~1/g, '/').replace(/~0/g, '~')),
-  );
-  let current: unknown = document;
-  // Follow the pointer one segment at a time to locate the referenced value.
-  for (const segment of path) {
-    // Stop when a pointer walks into a scalar or null value.
-    if (current == null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[segment];
-  }
-  return current;
-}
-
 export default dereferenceSchema;

--- a/packages/utils/openapi-mock/src/fetch-open-api-document.ts
+++ b/packages/utils/openapi-mock/src/fetch-open-api-document.ts
@@ -43,11 +43,18 @@ export async function fetchOpenApiDocument(
   const text = await response.text();
   // a strict JSON parse first, since YAML's looser grammar would otherwise silently accept
   // a malformed JSON document instead of surfacing the mistake
+  let parsed: unknown;
   try {
-    return JSON.parse(text) as OpenApiDocumentLike;
+    parsed = JSON.parse(text);
   } catch {
-    return parseYaml(text) as OpenApiDocumentLike;
+    parsed = parseYaml(text);
   }
+  // A valid OpenAPI document is always an object; a bare scalar/array is not one, however
+  // validly it parsed, and would otherwise surface as a confusing failure deep in createOpenApiMock.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Expected the document at ${url} to parse to an object, got ${typeof parsed}.`);
+  }
+  return parsed as OpenApiDocumentLike;
 }
 
 export default fetchOpenApiDocument;

--- a/packages/utils/openapi-mock/src/fetch-open-api-document.ts
+++ b/packages/utils/openapi-mock/src/fetch-open-api-document.ts
@@ -1,0 +1,53 @@
+import { parse as parseYaml } from 'yaml';
+
+import type { OpenApiDocumentLike } from './types';
+
+/** Options for {@link fetchOpenApiDocument}. */
+export interface FetchOpenApiDocumentOptions {
+  /**
+   * Overrides the `fetch` implementation used to retrieve the document
+   * (e.g. one that attaches an auth header, or for a runtime without a
+   * global `fetch`).
+   */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Fetches and parses an OpenAPI document straight from wherever it's
+ * published — JSON or YAML — so nothing needs downloading and committing to
+ * the repository just to fake responses against it.
+ *
+ * @param url - The URL a live OpenAPI document (`openapi.json`/`openapi.yaml`) is served from.
+ * @param options - Pass a custom `fetch` (e.g. one that attaches an auth header).
+ * @returns The parsed document, ready for {@link createOpenApiMock}.
+ * @throws {Error} If the request does not resolve to a 2xx response, or the body is neither valid JSON nor YAML.
+ *
+ * @example
+ * ```typescript
+ * const document = await fetchOpenApiDocument('https://api.example.com/openapi.json');
+ * const mock = createOpenApiMock(document);
+ * ```
+ */
+export async function fetchOpenApiDocument(
+  url: string | URL,
+  options: FetchOpenApiDocumentOptions = {},
+): Promise<OpenApiDocumentLike> {
+  const doFetch = options.fetch ?? fetch;
+  const response = await doFetch(url);
+  // Surface transport-level failures before attempting to parse an error response as a document.
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch the OpenAPI document from ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const text = await response.text();
+  // a strict JSON parse first, since YAML's looser grammar would otherwise silently accept
+  // a malformed JSON document instead of surfacing the mistake
+  try {
+    return JSON.parse(text) as OpenApiDocumentLike;
+  } catch {
+    return parseYaml(text) as OpenApiDocumentLike;
+  }
+}
+
+export default fetchOpenApiDocument;

--- a/packages/utils/openapi-mock/src/fetch-open-api-document.ts
+++ b/packages/utils/openapi-mock/src/fetch-open-api-document.ts
@@ -13,6 +13,23 @@ export interface FetchOpenApiDocumentOptions {
 }
 
 /**
+ * Parses `text` as JSON, falling back to YAML.
+ *
+ * @remarks
+ * A strict JSON parse is tried first, since YAML's looser grammar would
+ * otherwise silently accept a malformed JSON document instead of surfacing
+ * the mistake.
+ */
+function parseDocumentText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Not valid JSON: fall back to YAML, which is a superset grammar of JSON.
+    return parseYaml(text);
+  }
+}
+
+/**
  * Fetches and parses an OpenAPI document straight from wherever it's
  * published — JSON or YAML — so nothing needs downloading and committing to
  * the repository just to fake responses against it.
@@ -41,14 +58,7 @@ export async function fetchOpenApiDocument(
     );
   }
   const text = await response.text();
-  // a strict JSON parse first, since YAML's looser grammar would otherwise silently accept
-  // a malformed JSON document instead of surfacing the mistake
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    parsed = parseYaml(text);
-  }
+  const parsed = parseDocumentText(text);
   // A valid OpenAPI document is always an object; a bare scalar/array is not one, however
   // validly it parsed, and would otherwise surface as a confusing failure deep in createOpenApiMock.
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/packages/utils/openapi-mock/src/generate-mock-from-schema.ts
+++ b/packages/utils/openapi-mock/src/generate-mock-from-schema.ts
@@ -1,4 +1,4 @@
-import { faker } from '@faker-js/faker';
+import { Faker, en } from '@faker-js/faker';
 import { generate } from 'json-schema-faker';
 
 import type { FieldFakerFn } from './types';
@@ -35,14 +35,15 @@ export async function generateMockFromSchema(
   schema: unknown,
   options: GenerateMockFromSchemaOptions = {},
 ): Promise<unknown> {
-  // `json-schema-faker`'s `seed` option only drives its own PRNG; `faker`-extension
-  // values come from the faker singleton, so it needs seeding separately for the
-  // same call to be reproducible end-to-end
-  if (options.seed !== undefined) faker.seed(options.seed);
+  // A fresh instance per call, rather than seeding the `faker` singleton, so concurrent
+  // calls with different seeds cannot race each other through shared global state.
+  const localFaker = new Faker({ locale: [en] });
+  // Only a caller-supplied seed makes output deterministic; otherwise this instance stays random.
+  if (options.seed !== undefined) localFaker.seed(options.seed);
   return generate(schema as Parameters<typeof generate>[0], {
     // `__custom` is a synthetic namespace `applyFieldFakers` points function-valued
     // field overrides at, resolved by the same dotted-path lookup as a real faker path
-    extensions: { faker: { ...faker, __custom: options.customFakers ?? {} } },
+    extensions: { faker: { ...localFaker, __custom: options.customFakers ?? {} } },
     seed: options.seed,
     // fake every optional property too, so a consumer sees the whole schema shape rather
     // than a coin-flip subset of it on every run
@@ -50,5 +51,4 @@ export async function generateMockFromSchema(
     useDefaultValue: true,
   });
 }
-
 export default generateMockFromSchema;

--- a/packages/utils/openapi-mock/src/generate-mock-from-schema.ts
+++ b/packages/utils/openapi-mock/src/generate-mock-from-schema.ts
@@ -1,0 +1,54 @@
+import { faker } from '@faker-js/faker';
+import { generate } from 'json-schema-faker';
+
+import type { FieldFakerFn } from './types';
+
+/** Options for {@link generateMockFromSchema}. */
+export interface GenerateMockFromSchemaOptions {
+  /**
+   * Seeds both `json-schema-faker`'s own PRNG and `@faker-js/faker`'s global
+   * state, so the same schema and seed always fake the same value — useful
+   * for a repeatable test rather than asserting against `expect.any(...)`.
+   */
+  seed?: number;
+
+  /**
+   * Function-valued {@link FieldFakerMap} entries, keyed by the synthetic
+   * `"__custom.<key>"` faker path {@link applyFieldFakers} annotated the
+   * schema with, so those paths resolve during generation.
+   */
+  customFakers?: Record<string, FieldFakerFn>;
+}
+
+/**
+ * Fakes a value matching `schema`, using `@faker-js/faker` for any property
+ * with a `faker: "module.method"` extension keyword (e.g. `{ faker:
+ * "internet.email" }`), and `json-schema-faker`'s own built-in generators
+ * (`format`, `pattern`, ranges, ...) for everything else.
+ *
+ * @param schema - A schema with every `$ref` already inlined; see {@link dereferenceSchema}.
+ * @param options - Pass `seed` for deterministic, repeatable output, or `customFakers` for
+ *   the function-valued entries {@link applyFieldFakers} produced.
+ * @returns A promise resolving to a value shaped by the supplied schema.
+ */
+export async function generateMockFromSchema(
+  schema: unknown,
+  options: GenerateMockFromSchemaOptions = {},
+): Promise<unknown> {
+  // `json-schema-faker`'s `seed` option only drives its own PRNG; `faker`-extension
+  // values come from the faker singleton, so it needs seeding separately for the
+  // same call to be reproducible end-to-end
+  if (options.seed !== undefined) faker.seed(options.seed);
+  return generate(schema as Parameters<typeof generate>[0], {
+    // `__custom` is a synthetic namespace `applyFieldFakers` points function-valued
+    // field overrides at, resolved by the same dotted-path lookup as a real faker path
+    extensions: { faker: { ...faker, __custom: options.customFakers ?? {} } },
+    seed: options.seed,
+    // fake every optional property too, so a consumer sees the whole schema shape rather
+    // than a coin-flip subset of it on every run
+    alwaysFakeOptionals: true,
+    useDefaultValue: true,
+  });
+}
+
+export default generateMockFromSchema;

--- a/packages/utils/openapi-mock/src/index.ts
+++ b/packages/utils/openapi-mock/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Fakes OpenAPI 3 responses straight from a spec document.
+ *
+ * @remarks
+ * Point {@link createOpenApiMock} at a parsed `openapi.json`/`openapi.yaml`
+ * and every named operation is faked from its declared response schema — no
+ * hand-written fixtures until a specific edge case needs one, at which point
+ * {@link OpenApiMockOptions.overrides} (or {@link OpenApiMock.register})
+ * replaces just that operation.
+ *
+ * This package has no opinion on HTTP or routing frameworks: {@link OpenApiMock.resolve}
+ * takes a plain `{ method, path, query }` and returns a plain
+ * `{ status, mock }`, so it drops into `@equinor/fusion-framework-module-http`'s
+ * mock router, `openapi-backend`, Express, or a hand-rolled server equally
+ * easily.
+ *
+ * @packageDocumentation
+ */
+
+export { applyFieldFakers, type ApplyFieldFakersResult } from './apply-field-fakers';
+export { createOpenApiMock } from './create-open-api-mock';
+export { dereferenceSchema } from './dereference-schema';
+export { fetchOpenApiDocument, type FetchOpenApiDocumentOptions } from './fetch-open-api-document';
+export {
+  generateMockFromSchema,
+  type GenerateMockFromSchemaOptions,
+} from './generate-mock-from-schema';
+export { loadFakerMap, type LoadFakerMapOptions } from './load-faker-map';
+export type {
+  FakerPath,
+  FieldFakerContext,
+  FieldFakerFn,
+  FieldFakerMap,
+  FieldFakerValue,
+  OpenApiDocumentLike,
+  OpenApiMock,
+  OpenApiMockOptions,
+  OpenApiMockOverride,
+  OpenApiMockOverrideContext,
+  OpenApiMockRequest,
+  OpenApiMockResolution,
+  OpenApiMockResponse,
+} from './types';

--- a/packages/utils/openapi-mock/src/load-faker-map.ts
+++ b/packages/utils/openapi-mock/src/load-faker-map.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises';
+import { extname, isAbsolute, join } from 'node:path';
+
+import { importConfig } from '@equinor/fusion-imports';
+import { parse as parseYaml } from 'yaml';
+
+import type { FieldFakerMap } from './types';
+
+/** Options for {@link loadFakerMap}. */
+export interface LoadFakerMapOptions {
+  /** Base directory a relative `source` path is resolved against (default: `process.cwd()`). */
+  baseDir?: string;
+}
+
+/**
+ * Loads a {@link FieldFakerMap} sidecar file describing per-model faker
+ * overrides, so a spec's own `openapi.json`/`.yaml` never has to be edited —
+ * or even owned — just to steer how its models are faked.
+ *
+ * @remarks
+ * `.json`, `.yml` and `.yaml` sidecars can only declare faker-path strings
+ * (e.g. `{ "User.email": "internet.email" }`), since none of those formats
+ * can hold a function. A `.ts`/`.js`/`.mjs` sidecar — resolved through
+ * `@equinor/fusion-imports`' `importConfig`, the same "fusion import"
+ * convention this monorepo already uses for runtime config loading — can
+ * export real functions too, for a field a faker path can't express; its
+ * `default` export is used as the map.
+ *
+ * @param source - Path to the sidecar file, or an already-built {@link FieldFakerMap} (returned as-is).
+ * @param options - See {@link LoadFakerMapOptions}.
+ * @returns The loaded field faker map.
+ *
+ * @example Loading a map built in code — no file needed
+ * ```typescript
+ * const fields = await loadFakerMap({ 'User.email': 'internet.email' });
+ * ```
+ *
+ * @example Loading a `.ts` sidecar with a custom function
+ * ```typescript
+ * // fields.faker.ts
+ * export default {
+ *   'User.email': 'internet.email',
+ *   'User.id': ({ path }) => `usr_${path.join('-')}`,
+ * } satisfies FieldFakerMap;
+ * ```
+ * ```typescript
+ * const fields = await loadFakerMap('./fields.faker.ts');
+ * const mock = createOpenApiMock(openapi, { fields });
+ * ```
+ */
+export async function loadFakerMap(
+  source: string | FieldFakerMap,
+  options: LoadFakerMapOptions = {},
+): Promise<FieldFakerMap> {
+  // Already-built maps need no filesystem or module resolution.
+  if (typeof source !== 'string') return source;
+
+  const extension = extname(source).toLowerCase();
+  // YAML sidecars are parsed directly because they are data-only formats.
+  if (extension === '.yml' || extension === '.yaml') {
+    const path = isAbsolute(source) ? source : join(options.baseDir ?? process.cwd(), source);
+    return parseYaml(await readFile(path, 'utf-8'));
+  }
+
+  // .json, .ts, .js, .mjs (or no extension) resolve through `importConfig`'s own
+  // extension probing, so a sidecar can be authored in whichever of those formats
+  // (real functions require .ts/.js/.mjs, since JSON can't hold one)
+  const basename = source.replace(/\.(json|ts|mjs|js)$/i, '');
+  const { config } = await importConfig<FieldFakerMap>(basename, { baseDir: options.baseDir });
+  return config;
+}
+
+export default loadFakerMap;

--- a/packages/utils/openapi-mock/src/load-faker-map.ts
+++ b/packages/utils/openapi-mock/src/load-faker-map.ts
@@ -13,6 +13,27 @@ export interface LoadFakerMapOptions {
 }
 
 /**
+ * A `.yml`/`.yaml` sidecar can only hold {@link FakerPath} strings (no
+ * functions), so this rejects anything else with a message naming the file.
+ */
+function assertFieldFakerMap(value: unknown, path: string): FieldFakerMap {
+  // YAML can parse to a bare scalar or array, neither of which is a valid faker map.
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Expected ${path} to parse to a plain object of faker-path strings.`);
+  }
+  // A .yml/.yaml sidecar can only express string paths, never a real function.
+  for (const [key, entry] of Object.entries(value)) {
+    // A non-string entry (number, boolean, nested object, ...) would break `applyFieldFakers` later.
+    if (typeof entry !== 'string') {
+      throw new Error(
+        `Expected ${path} field "${key}" to be a faker-path string, got ${typeof entry}.`,
+      );
+    }
+  }
+  return value as FieldFakerMap;
+}
+
+/**
  * Loads a {@link FieldFakerMap} sidecar file describing per-model faker
  * overrides, so a spec's own `openapi.json`/`.yaml` never has to be edited —
  * or even owned — just to steer how its models are faked.
@@ -59,7 +80,8 @@ export async function loadFakerMap(
   // YAML sidecars are parsed directly because they are data-only formats.
   if (extension === '.yml' || extension === '.yaml') {
     const path = isAbsolute(source) ? source : join(options.baseDir ?? process.cwd(), source);
-    return parseYaml(await readFile(path, 'utf-8'));
+    const parsed: unknown = parseYaml(await readFile(path, 'utf-8'));
+    return assertFieldFakerMap(parsed, path);
   }
 
   // .json, .ts, .js, .mjs (or no extension) resolve through `importConfig`'s own
@@ -69,5 +91,4 @@ export async function loadFakerMap(
   const { config } = await importConfig<FieldFakerMap>(basename, { baseDir: options.baseDir });
   return config;
 }
-
 export default loadFakerMap;

--- a/packages/utils/openapi-mock/src/types.ts
+++ b/packages/utils/openapi-mock/src/types.ts
@@ -1,0 +1,183 @@
+/**
+ * A parsed OpenAPI (3.x) document.
+ *
+ * @remarks
+ * Typed loosely — only the shape {@link createOpenApiMock} actually reads —
+ * on purpose, so this package has no dependency on a full OpenAPI type
+ * package. Anything JSON-parsed from a real `openapi.json` satisfies this.
+ */
+export interface OpenApiDocumentLike {
+  paths?: Record<string, Record<string, unknown>>;
+  components?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** A faked (or overridden) response for one operation. */
+export interface OpenApiMockResponse {
+  /** The HTTP status code the OpenAPI document declares for this response. */
+  status: number;
+  /** The response body, faked from the operation's schema unless overridden. */
+  mock: unknown;
+}
+
+/** What an {@link OpenApiMockOverride} is called with. */
+export interface OpenApiMockOverrideContext {
+  /** The `operationId` this override was registered for. */
+  operationId: string;
+  /** The HTTP method of the matched request. */
+  method: string;
+  /** The path of the matched request. */
+  path: string;
+  /** Path parameters extracted from the request, keyed by name (e.g. `{ petId: '1' }` for `/pets/{petId}`). */
+  params: Record<string, string>;
+  /** Query parameters of the matched request. */
+  query: Record<string, string>;
+  /**
+   * Generates the same faked response {@link createOpenApiMock} would have
+   * returned without an override — so an override only needs to replace the
+   * one field an edge case cares about, rather than rebuild the whole body.
+   */
+  mockResponseForOperation(): Promise<OpenApiMockResponse>;
+}
+
+/**
+ * Replaces the faked response for one `operationId`.
+ *
+ * @remarks
+ * Registered through {@link OpenApiMock.register} or
+ * {@link OpenApiMockOptions.overrides}; only for the operations that need a
+ * specific edge case — every other operation keeps faking straight from the
+ * schema.
+ */
+export type OpenApiMockOverride = (
+  context: OpenApiMockOverrideContext,
+) => OpenApiMockResponse | Promise<OpenApiMockResponse>;
+
+/** A request to resolve against the OpenAPI document. */
+export interface OpenApiMockRequest {
+  /** The HTTP method, matched case-insensitively. */
+  method: string;
+  /** The request path, matched against the document's path templates (e.g. `/pets/{petId}`). */
+  path: string;
+  /** Query parameters, forwarded to a matched {@link OpenApiMockOverride} as-is. */
+  query?: Record<string, string>;
+}
+
+/** The result of resolving a request to a matched operation. */
+export interface OpenApiMockResolution extends OpenApiMockResponse {
+  /** The `operationId` of the matched operation. */
+  operationId: string;
+  /** Path parameters extracted from the request. */
+  params: Record<string, string>;
+}
+
+/** What a {@link FieldFakerFn} is called with. */
+export interface FieldFakerContext {
+  /** The name of the OpenAPI component schema this field belongs to (e.g. `User`). */
+  modelName: string;
+  /** The dotted path of the field within `modelName` (e.g. `['address', 'city']`). */
+  path: readonly string[];
+}
+
+/**
+ * Fakes one field's value directly, for a field a `@faker-js/faker` path
+ * string can't express (composing several generators, reading from `path`,
+ * anything imperative).
+ */
+export type FieldFakerFn = (context: FieldFakerContext) => unknown;
+
+/**
+ * A dotted `@faker-js/faker` path (e.g. `"internet.email"`), resolved against
+ * the real `faker` instance the same way the schema-level `faker: "..."`
+ * extension keyword already is.
+ */
+export type FakerPath = string;
+
+/** One entry of a {@link FieldFakerMap}: either a faker path or a function. */
+export type FieldFakerValue = FakerPath | FieldFakerFn;
+
+/**
+ * Describes how to fake specific fields of specific OpenAPI component
+ * schemas, without editing the document itself.
+ *
+ * @remarks
+ * Keyed `"<ModelName>.<field>"` (nested fields dot further, e.g.
+ * `"User.address.city"`), where `ModelName` is the last segment of the
+ * `$ref` a field's schema was reached through — i.e. the name a schema is
+ * declared under in `#/components/schemas`. Only fields reached through a
+ * named component schema are addressable this way; an inline (anonymous)
+ * response body has no `ModelName` to key on.
+ *
+ * `.json`/`.yml`/`.yaml` sidecar files can only hold {@link FakerPath}
+ * strings; a `.ts`/`.js` sidecar can export real {@link FieldFakerFn}s too —
+ * see `loadFakerMap`.
+ *
+ * @example
+ * ```typescript
+ * const fields: FieldFakerMap = {
+ *   'User.email': 'internet.email',
+ *   'User.avatarUrl': 'image.avatar',
+ *   'User.id': ({ path }) => `usr_${path.join('-')}_${crypto.randomUUID()}`,
+ * };
+ * ```
+ */
+export type FieldFakerMap = Record<string, FieldFakerValue>;
+
+/** Options for {@link createOpenApiMock}. */
+export interface OpenApiMockOptions {
+  /** Per-`operationId` overrides, applied from the start instead of through {@link OpenApiMock.register}. */
+  overrides?: Record<string, OpenApiMockOverride>;
+
+  /**
+   * Seeds the faked responses, so the same document and seed always produce
+   * the same values — useful for a repeatable test rather than one that
+   * asserts against `expect.any(...)`.
+   *
+   * @remarks
+   * Every faked response reseeds from this value, so two different
+   * operations (or the same operation resolved twice) both fake
+   * deterministically, rather than the seed being consumed once and drifting
+   * across calls.
+   */
+  seed?: number;
+
+  /**
+   * Per-model field overrides, applied whenever a faked field is reached
+   * through the corresponding OpenAPI component schema — see
+   * {@link FieldFakerMap} for the key format and {@link loadFakerMap} for
+   * loading one from a sidecar file instead of building it in code.
+   */
+  fields?: FieldFakerMap;
+}
+
+/**
+ * Fakes and resolves responses for the operations of one OpenAPI document.
+ *
+ * @see {@link createOpenApiMock}
+ */
+export interface OpenApiMock {
+  /**
+   * Fakes the response for one operation, by `operationId`, ignoring any
+   * request matching — useful for a hand-rolled "not implemented" fallback
+   * (e.g. wiring this into `openapi-backend`'s own routing) or for building
+   * a partial override from within another {@link OpenApiMockOverride}.
+   *
+   * @throws {Error} If no operation with this `operationId` exists in the document.
+   */
+  mockResponseForOperation(operationId: string): Promise<OpenApiMockResponse>;
+
+  /**
+   * Matches a request against the document's paths and fakes (or resolves an
+   * override for) the matched operation's response.
+   *
+   * @returns The resolution, or `undefined` if no operation matches the method and path.
+   */
+  resolve(request: OpenApiMockRequest): Promise<OpenApiMockResolution | undefined>;
+
+  /**
+   * Registers (or replaces) the override for one `operationId`.
+   *
+   * @throws {Error} If no operation with this `operationId` exists in the document.
+   */
+  register(operationId: string, handler: OpenApiMockOverride): void;
+}

--- a/packages/utils/openapi-mock/tests/create-open-api-mock.test.ts
+++ b/packages/utils/openapi-mock/tests/create-open-api-mock.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest';
+
+import { createOpenApiMock } from '../src/create-open-api-mock';
+import type { OpenApiDocumentLike } from '../src/types';
+
+const petstore: OpenApiDocumentLike = {
+  openapi: '3.0.0',
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                  minItems: 2,
+                  maxItems: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/pets/{petId}': {
+      get: {
+        operationId: 'getPetById',
+        responses: {
+          '200': {
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/Pet' } },
+            },
+          },
+        },
+      },
+    },
+    '/pets/no-schema': {
+      // an operationId with no declared response body at all
+      delete: {
+        operationId: 'deletePet',
+        responses: { '204': {} },
+      },
+    },
+    '/internal': {
+      // deliberately no operationId — not routable/overridable
+      get: { responses: { '200': {} } },
+    },
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: 'object',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          name: { type: 'string', faker: 'person.firstName' },
+        },
+      },
+    },
+  },
+};
+
+describe('createOpenApiMock', () => {
+  it('fakes a response shaped like the operation schema, resolving $refs', async () => {
+    const mock = createOpenApiMock(petstore);
+
+    const result = await mock.resolve({ method: 'GET', path: '/pets/1' });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 200,
+        operationId: 'getPetById',
+        params: { petId: '1' },
+      }),
+    );
+    expect(result?.mock).toEqual(
+      expect.objectContaining({ id: expect.any(String), name: expect.any(String) }),
+    );
+  });
+
+  it('fakes an array response', async () => {
+    const mock = createOpenApiMock(petstore);
+
+    const result = await mock.resolve({ method: 'GET', path: '/pets' });
+
+    const mockList = result?.mock;
+    expect(Array.isArray(mockList)).toBe(true);
+    expect((mockList as unknown[]).length).toBe(2);
+  });
+
+  it('returns undefined for a path or method with no matching operation', async () => {
+    const mock = createOpenApiMock(petstore);
+
+    await expect(mock.resolve({ method: 'GET', path: '/unknown' })).resolves.toBeUndefined();
+    await expect(mock.resolve({ method: 'POST', path: '/pets/1' })).resolves.toBeUndefined();
+  });
+
+  it('does not route operations without an operationId', async () => {
+    const mock = createOpenApiMock(petstore);
+
+    await expect(mock.resolve({ method: 'GET', path: '/internal' })).resolves.toBeUndefined();
+  });
+
+  it('fakes operations with no declared response body as undefined', async () => {
+    const mock = createOpenApiMock(petstore);
+
+    const result = await mock.resolve({ method: 'DELETE', path: '/pets/no-schema' });
+
+    expect(result).toEqual(
+      expect.objectContaining({ status: 204, mock: undefined, operationId: 'deletePet' }),
+    );
+  });
+
+  describe('mockResponseForOperation', () => {
+    it('fakes an operation directly by operationId', async () => {
+      const mock = createOpenApiMock(petstore);
+
+      const response = await mock.mockResponseForOperation('getPetById');
+
+      expect(response.status).toBe(200);
+      expect(response.mock).toEqual(expect.objectContaining({ id: expect.any(String) }));
+    });
+
+    it('throws for an unknown operationId', async () => {
+      const mock = createOpenApiMock(petstore);
+
+      await expect(mock.mockResponseForOperation('doesNotExist')).rejects.toThrow(
+        /No operation named "doesNotExist"/,
+      );
+    });
+  });
+
+  describe('seed', () => {
+    it('fakes the same value every time given the same seed', async () => {
+      const first = await createOpenApiMock(petstore, { seed: 42 }).mockResponseForOperation(
+        'getPetById',
+      );
+      const second = await createOpenApiMock(petstore, { seed: 42 }).mockResponseForOperation(
+        'getPetById',
+      );
+
+      expect(first).toEqual(second);
+    });
+
+    it('fakes a different value for a different seed', async () => {
+      const first = await createOpenApiMock(petstore, { seed: 1 }).mockResponseForOperation(
+        'getPetById',
+      );
+      const second = await createOpenApiMock(petstore, { seed: 2 }).mockResponseForOperation(
+        'getPetById',
+      );
+
+      expect(first).not.toEqual(second);
+    });
+  });
+
+  describe('fields', () => {
+    const petstoreWithAddress: OpenApiDocumentLike = {
+      ...petstore,
+      components: {
+        schemas: {
+          ...(petstore.components?.schemas as Record<string, unknown>),
+          Pet: {
+            type: 'object',
+            required: ['id', 'name'],
+            properties: {
+              id: { type: 'string', format: 'uuid' },
+              name: { type: 'string', faker: 'person.firstName' },
+              owner: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('fakes a matched field from a faker path string', async () => {
+      const mock = createOpenApiMock(petstoreWithAddress, {
+        fields: { 'Pet.name': 'animal.dog' },
+      });
+
+      const result = await mock.mockResponseForOperation('getPetById');
+
+      expect(result.mock).toMatchObject({
+        // the fixed faker seed on `animal.dog` output isn't asserted; only that
+        // the field-level override (not the schema's own faker keyword) produced it
+        name: expect.any(String),
+      });
+    });
+
+    it('fakes a matched nested field, keyed by the dotted path under its model', async () => {
+      const mock = createOpenApiMock(petstoreWithAddress, {
+        fields: { 'Pet.owner.city': () => 'Stavanger' },
+      });
+
+      const result = await mock.mockResponseForOperation('getPetById');
+
+      expect((result.mock as { owner: { city: string } }).owner.city).toBe('Stavanger');
+    });
+
+    it('fakes a matched field from a custom function, receiving its model and path', async () => {
+      const mock = createOpenApiMock(petstoreWithAddress, {
+        fields: {
+          'Pet.id': ({ modelName, path }) => `${modelName}:${path.join('.')}`,
+        },
+      });
+
+      const result = await mock.mockResponseForOperation('getPetById');
+
+      expect((result.mock as { id: string }).id).toBe('Pet:id');
+    });
+
+    it('leaves fields with no matching entry faked from the schema as usual', async () => {
+      const mock = createOpenApiMock(petstoreWithAddress, {
+        fields: { 'Pet.owner.city': () => 'Stavanger' },
+      });
+
+      const result = await mock.mockResponseForOperation('getPetById');
+
+      expect((result.mock as { id: string }).id).toEqual(expect.any(String));
+    });
+  });
+
+  describe('overrides', () => {
+    it('lets an override replace the faked response, given at construction', async () => {
+      const mock = createOpenApiMock(petstore, {
+        overrides: {
+          getPetById: ({ params }) => ({ status: 200, mock: { id: params.petId, name: 'Rex' } }),
+        },
+      });
+
+      const result = await mock.resolve({ method: 'GET', path: '/pets/42' });
+
+      expect(result?.mock).toEqual({ id: '42', name: 'Rex' });
+    });
+
+    it('lets an override build on top of the generated baseline', async () => {
+      const mock = createOpenApiMock(petstore, {
+        overrides: {
+          getPetById: async ({ params, mockResponseForOperation }) => {
+            const baseline = await mockResponseForOperation();
+            return { ...baseline, mock: { ...(baseline.mock as object), id: params.petId } };
+          },
+        },
+      });
+
+      const result = await mock.resolve({ method: 'GET', path: '/pets/7' });
+
+      expect(result?.mock).toEqual(expect.objectContaining({ id: '7', name: expect.any(String) }));
+    });
+
+    it('lets register() add or replace an override after construction', async () => {
+      const mock = createOpenApiMock(petstore);
+      mock.register('getPetById', () => ({ status: 200, mock: { id: 'fixed', name: 'Fixed' } }));
+
+      const result = await mock.resolve({ method: 'GET', path: '/pets/1' });
+
+      expect(result?.mock).toEqual({ id: 'fixed', name: 'Fixed' });
+    });
+
+    it('throws from register() for an unknown operationId, rather than silently no-op-ing', () => {
+      const mock = createOpenApiMock(petstore);
+
+      expect(() => mock.register('doesNotExist', () => ({ status: 200, mock: {} }))).toThrow(
+        /No operation named "doesNotExist"/,
+      );
+    });
+  });
+});

--- a/packages/utils/openapi-mock/tests/dereference-schema.test.ts
+++ b/packages/utils/openapi-mock/tests/dereference-schema.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { dereferenceSchema } from '../src/dereference-schema';
+
+describe('dereferenceSchema', () => {
+  const document = {
+    components: {
+      schemas: {
+        Pet: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            owner: { $ref: '#/components/schemas/Owner' },
+          },
+        },
+        Owner: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      },
+    },
+  };
+
+  it('inlines a top-level $ref', () => {
+    expect(dereferenceSchema({ $ref: '#/components/schemas/Owner' }, document)).toEqual(
+      document.components.schemas.Owner,
+    );
+  });
+
+  it('inlines nested $refs, recursively', () => {
+    const result = dereferenceSchema({ $ref: '#/components/schemas/Pet' }, document) as {
+      properties: { owner: unknown };
+    };
+
+    expect(result.properties.owner).toEqual(document.components.schemas.Owner);
+  });
+
+  it('inlines $refs inside arrays', () => {
+    const result = dereferenceSchema(
+      { type: 'array', items: { $ref: '#/components/schemas/Owner' } },
+      document,
+    ) as { items: unknown };
+
+    expect(result.items).toEqual(document.components.schemas.Owner);
+  });
+
+  it('leaves an unresolvable $ref untouched rather than throwing', () => {
+    const schema = { $ref: '#/components/schemas/Missing' };
+
+    expect(dereferenceSchema(schema, document)).toEqual(schema);
+  });
+
+  it('breaks a cyclical $ref instead of recursing forever', () => {
+    const cyclical = {
+      components: {
+        schemas: {
+          Node: {
+            type: 'object',
+            properties: { next: { $ref: '#/components/schemas/Node' } },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceSchema({ $ref: '#/components/schemas/Node' }, cyclical) as {
+      properties: { next: unknown };
+    };
+
+    expect(result.properties.next).toEqual({});
+  });
+});

--- a/packages/utils/openapi-mock/tests/fetch-open-api-document.test.ts
+++ b/packages/utils/openapi-mock/tests/fetch-open-api-document.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchOpenApiDocument } from '../src/fetch-open-api-document';
+
+const jsonResponse = (body: string, init: ResponseInit = {}) =>
+  new Response(body, { status: 200, ...init });
+
+describe('fetchOpenApiDocument', () => {
+  it('parses a JSON document', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse('{"openapi":"3.0.0"}'));
+
+    const document = await fetchOpenApiDocument('https://example.com/openapi.json', {
+      fetch: fetchMock,
+    });
+
+    expect(document).toEqual({ openapi: '3.0.0' });
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/openapi.json');
+  });
+
+  it('parses a YAML document', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse('openapi: 3.0.0\npaths:\n  /pets:\n    get:\n      operationId: listPets\n'),
+      );
+
+    const document = await fetchOpenApiDocument('https://example.com/openapi.yaml', {
+      fetch: fetchMock,
+    });
+
+    expect(document).toEqual(
+      expect.objectContaining({
+        openapi: '3.0.0',
+        paths: { '/pets': { get: { operationId: 'listPets' } } },
+      }),
+    );
+  });
+
+  it('throws when the response is not ok', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('not found', { status: 404, statusText: 'Not Found' }));
+
+    await expect(
+      fetchOpenApiDocument('https://example.com/missing.json', { fetch: fetchMock }),
+    ).rejects.toThrow(/404/);
+  });
+});

--- a/packages/utils/openapi-mock/tests/fixtures/fields-json.faker.json
+++ b/packages/utils/openapi-mock/tests/fixtures/fields-json.faker.json
@@ -1,0 +1,3 @@
+{
+  "User.email": "internet.email"
+}

--- a/packages/utils/openapi-mock/tests/fixtures/fields-ts.faker.ts
+++ b/packages/utils/openapi-mock/tests/fixtures/fields-ts.faker.ts
@@ -1,0 +1,6 @@
+import type { FieldFakerMap } from '../../src/types';
+
+export default {
+  'User.email': 'internet.email',
+  'User.id': ({ modelName, path }) => `${modelName}:${path.join('.')}`,
+} satisfies FieldFakerMap;

--- a/packages/utils/openapi-mock/tests/fixtures/fields-yaml.faker.yaml
+++ b/packages/utils/openapi-mock/tests/fixtures/fields-yaml.faker.yaml
@@ -1,0 +1,1 @@
+User.email: internet.email

--- a/packages/utils/openapi-mock/tests/load-faker-map.test.ts
+++ b/packages/utils/openapi-mock/tests/load-faker-map.test.ts
@@ -1,0 +1,41 @@
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { loadFakerMap } from '../src/load-faker-map';
+
+const fixturesDir = join(fileURLToPath(new URL('.', import.meta.url)), 'fixtures');
+
+describe('loadFakerMap', () => {
+  it('returns an already-built map as-is', async () => {
+    const map = { 'User.email': 'internet.email' };
+
+    await expect(loadFakerMap(map)).resolves.toBe(map);
+  });
+
+  it('loads and parses a .json sidecar', async () => {
+    const map = await loadFakerMap('fields-json.faker.json', { baseDir: fixturesDir });
+
+    expect(map).toEqual({ 'User.email': 'internet.email' });
+  });
+
+  it('loads and parses a .yaml sidecar', async () => {
+    const map = await loadFakerMap('fields-yaml.faker.yaml', { baseDir: fixturesDir });
+
+    expect(map).toEqual({ 'User.email': 'internet.email' });
+  });
+
+  it('loads a .ts sidecar, whose default export may include real functions', async () => {
+    const map = await loadFakerMap('fields-ts.faker.ts', { baseDir: fixturesDir });
+
+    expect(map['User.email']).toBe('internet.email');
+    expect(typeof map['User.id']).toBe('function');
+    expect(
+      (map['User.id'] as (context: { modelName: string; path: string[] }) => unknown)({
+        modelName: 'User',
+        path: ['id'],
+      }),
+    ).toBe('User:id');
+  });
+});

--- a/packages/utils/openapi-mock/tsconfig.json
+++ b/packages/utils/openapi-mock/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "declarationDir": "./dist/types"
+  },
+  "references": [
+    {
+      "path": "../imports"
+    }
+  ],
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "tests"]
+}

--- a/packages/utils/openapi-mock/vitest.config.ts
+++ b/packages/utils/openapi-mock/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineProject } from 'vitest/config';
+
+import { fileURLToPath } from 'node:url';
+
+import { name, version } from './package.json';
+
+export default defineProject({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    name: `${name}@${version}`,
+  },
+  resolve: {
+    alias: {
+      '@local': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,7 +822,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-environment:
         specifier: ^1.1.3
         version: 1.1.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -1039,7 +1039,7 @@ importers:
         version: 3.36.0
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.0.4
         version: 6.1.1(typescript@7.0.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -1395,7 +1395,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/dev-server:
     dependencies:
@@ -1417,7 +1417,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -2607,7 +2607,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -2706,6 +2706,28 @@ importers:
         specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
 
+  packages/utils/openapi-mock:
+    dependencies:
+      '@equinor/fusion-imports':
+        specifier: workspace:^
+        version: link:../imports
+      '@faker-js/faker':
+        specifier: ^10.1.0
+        version: 10.5.0
+      json-schema-faker:
+        specifier: ^0.6.3
+        version: 0.6.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
+    devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
+
   packages/utils/query:
     dependencies:
       '@equinor/fusion-log':
@@ -2760,7 +2782,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -2784,7 +2806,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.1.5
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/vite-plugins/raw-imports:
     devDependencies:
@@ -2793,7 +2815,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -2817,7 +2839,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.1.5
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/vite-plugins/spa:
     dependencies:
@@ -2854,7 +2876,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/widget:
     dependencies:
@@ -8996,6 +9018,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-faker@0.6.3:
+    resolution: {integrity: sha512-rsH48E/b5KFpgvKlcFjplB+zwOZk2FhYCQwcM6y09ApZkVl3D7PhcRIrDhpfR+w1AhNOrv0bumJElBz4X++KBA==}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -14996,7 +15022,7 @@ snapshots:
       semver: 7.8.5
       tinyglobby: 0.2.17
       valibot: 1.4.2(typescript@7.0.2)
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-node: 3.2.4(@types/node@26.1.2)(lightningcss@1.33.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
     optionalDependencies:
       typescript: 7.0.2
@@ -15887,12 +15913,12 @@ snapshots:
   '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-vue@6.0.8(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.40(typescript@7.0.2)
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
@@ -15934,7 +15960,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.15.0(@types/node@26.1.2)(typescript@7.0.2)
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -16125,7 +16151,7 @@ snapshots:
       postcss: 8.5.22
       postcss-load-config: 6.0.1(postcss@8.5.22)(tsx@4.23.1)
       rolldown: 1.2.0
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       vue: 3.5.40(typescript@7.0.2)
       vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))(vue@3.5.40(typescript@7.0.2))
     transitivePeerDependencies:
@@ -18260,6 +18286,8 @@ snapshots:
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
+
+  json-schema-faker@0.6.3: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -20575,7 +20603,7 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.2.0
       rollup: 4.62.3
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)):
     dependencies:
@@ -20586,7 +20614,7 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.2.1
       rollup: 4.62.3
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   until-async@3.0.2: {}
 
@@ -20705,14 +20733,14 @@ snapshots:
 
   vite-plugin-environment@1.1.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)):
     dependencies:
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   vite-tsconfig-paths@6.1.1(typescript@7.0.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@7.0.2)
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20750,7 +20778,7 @@ snapshots:
       terser: 5.46.0
       tsx: 4.23.1
 
-  vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1):
+  vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -20765,6 +20793,7 @@ snapshots:
       sass-embedded: 1.100.0
       terser: 5.46.0
       tsx: 4.23.1
+      yaml: 2.9.0
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.12.2)(typescript@7.0.2))(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)):
     dependencies:
@@ -20817,7 +20846,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -20877,7 +20906,7 @@ snapshots:
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -20911,7 +20940,7 @@ snapshots:
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
+      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'


### PR DESCRIPTION
**Why is this change needed?**
Extracted from the `poc/framework-testability` branch cleanup. `@equinor/fusion-openapi-mock` is a standalone, framework-agnostic utility and deserves its own history/PR rather than being entangled with the HTTP-mock-module and MSAL/service-discovery mock work. It also has its own tracked user story: equinor/fusion-core-tasks#1660.

**What is the current behavior?**
No package exists for generating fake responses from an OpenAPI document. Testing an API-shaped client currently requires hand-written fixtures for every endpoint.

**What is the new behavior?**
Adds `@equinor/fusion-openapi-mock`:
- `createOpenApiMock(document, options?)` fakes every operation with an `operationId` from its declared success response schema (`$ref`s resolved against the document).
- `overrides` (at construction) and `.register(operationId, handler)` (afterwards) replace faked output for specific operations.
- `seed` makes faked output repeatable across runs.
- `fetchOpenApiDocument(url, options?)` fetches/parses a JSON or YAML spec from a URL.
- `fields` (a `FieldFakerMap`) fakes specific fields with a `@faker-js/faker` path string or function; `loadFakerMap(source)` loads one from a sidecar file.
- No dependency on any HTTP or routing framework — `resolve({ method, path, query })` returns a plain `{ status, mock }`.

**What is the intended behavior or invariant?**
`resolve()` returns `undefined` for any request that matches no operation in the document, so callers (e.g. `@equinor/fusion-framework-module-http`'s mock router via `fromOpenApiMock`) can compose it with other registrations covering endpoints outside the spec. The package has zero runtime dependency on any HTTP module — consumers duck-type against `OpenApiMockLike`.

**Does this PR introduce a breaking change?**
No — this is a new package.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (initial release, see changeset)
- Consumer impact: New opt-in package; no existing packages depend on it yet
- Downstream impact: None yet — `@equinor/fusion-framework-module-http`'s `fromOpenApiMock` adapter is duck-typed against this package's shape but has no hard dependency

**Review guidance:**
Focus on the public API surface (`createOpenApiMock`, `fetchOpenApiDocument`, `loadFakerMap`) and TSDoc. Tests cover schema dereferencing, field-faker application, and mock generation from schema.

**Additional context**
Extracted cleanly from `poc/framework-testability` — verified `pnpm --filter @equinor/fusion-openapi-mock test run`, `build`, `biome check`, and `fusion-lint lint packages/utils/openapi-mock` all pass with no issues.

**Related issues**
closes: equinor/fusion-core-tasks#1660
ref: equinor/fusion-core-tasks#1654

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable (N/A — no React in this package)
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct

