### PR TITLE
fix(api-service): include request method in proxy log messages

### DIFF
--- a/.changeset/vite-plugin-api-service_proxy-log-method.md
+++ b/.changeset/vite-plugin-api-service_proxy-log-method.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vite-plugin-api-service": patch
+---
+
+Include the HTTP request method in proxy request/response log messages, so multiple requests to the same URL (e.g. `GET` vs `POST`) can be distinguished in dev-server logs.

--- a/packages/vite-plugins/api-service/src/process-routes.ts
+++ b/packages/vite-plugins/api-service/src/process-routes.ts
@@ -103,13 +103,13 @@ function processesRoute(
   proxyServer.on('proxyReq', (proxyReq, req: IncomingRequest) => {
     // Set the original request URL
     logger?.info(
-      `Proxying ${req.originalUrl} -> ${proxyReq.protocol}//${proxyReq.host}${proxyReq.path}`,
+      `Proxying ${req.method} ${req.originalUrl} -> ${proxyReq.protocol}//${proxyReq.host}${proxyReq.path}`,
     );
   });
 
   proxyServer.on('proxyRes', (proxyRes, req: IncomingRequest) => {
     const { headers, statusMessage, statusCode = 500 } = proxyRes;
-    const message = `Received response for ${req.originalUrl} -> ${statusCode} ${statusMessage}`;
+    const message = `Received response for ${req.method} ${req.originalUrl} -> ${statusCode} ${statusMessage}`;
 
     res.writeHead(statusCode, {
       ...headers,


### PR DESCRIPTION
**Why is this change needed?**
The dev-server's API proxy logs every proxied request/response, but the log lines only include the URL, not the HTTP method. Multiple requests to the same URL with different methods (e.g. `GET` vs `POST /same/path`) were indistinguishable in the logs.

**What is the current behavior?**
`proxyReq`/`proxyRes` log lines read `Proxying <url> -> ...` / `Received response for <url> -> ...`, with no method.

**What is the new behavior?**
Both log lines now include `req.method`, e.g. `Proxying GET /foo -> ...`.

**What is the intended behavior or invariant?**
Purely additive to log output; no behavior change to the actual proxying.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: None (dev-server logging only)
- Downstream impact: None

**Review guidance**
Small, log-message-only change split out of an unrelated feature branch.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR_
- [x] Confirm adherence to code of conduct
