### PR TITLE
fix(spa): forward cache mode in service worker fetch passthrough

### DIFF
--- a/.changeset/vite-plugin-spa_sw-forward-cache-mode.md
+++ b/.changeset/vite-plugin-spa_sw-forward-cache-mode.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vite-plugin-spa": patch
+---
+
+Forward the original request's `cache` mode when the service worker re-fetches a proxied request. Previously a caller requesting `cache: 'no-store'` (e.g. a polling endpoint) would silently fall back to the default HTTP cache once passed through the service worker.

--- a/packages/vite-plugins/spa/src/html/sw.ts
+++ b/packages/vite-plugins/spa/src/html/sw.ts
@@ -224,10 +224,13 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 
       // fetch the request with the modified url and headers, preserving the original HTTP method and body
       // This ensures OPTIONS, PATCH, DELETE and other methods are forwarded correctly
+      // `cache` is forwarded explicitly - otherwise callers requesting `no-store` (e.g. polling
+      // endpoints) would silently fall back to the default HTTP cache once re-fetched here.
       return fetch(url, {
         method: request.method,
         headers: requestHeaders,
         body: body || undefined,
+        cache: request.cache,
       });
     };
     event.respondWith(handleRequest());


### PR DESCRIPTION
**Why is this change needed?**
The SPA vite-plugin's service worker re-fetches requests it intercepts, but was not forwarding the original request's `cache` mode. A caller that explicitly requested `cache: 'no-store'` (e.g. a polling endpoint) would silently fall back to the default HTTP cache once the request passed through the service worker.

**What is the current behavior?**
`self.addEventListener('fetch', ...)`'s `handleRequest` rebuilds the request with `method`, `headers`, and `body`, but omits `cache`, so it always uses the browser's default caching behavior.

**What is the new behavior?**
The rebuilt request now forwards `cache: request.cache`, preserving the original request's caching intent.

**What is the intended behavior or invariant?**
The service worker's fetch passthrough must not silently change a request's caching semantics.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: Requests that rely on `no-store`/`no-cache` will now behave as intended when proxied through this service worker.
- Downstream impact: None

**Review guidance**
Small, single-line fix split out of an unrelated feature branch.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR_
- [x] Confirm adherence to code of conduct
