### PR TITLE
feat(module-services): add App State API client

### DIFF
--- a/.changeset/module-services_add-app-state-client.md
+++ b/.changeset/module-services_add-app-state-client.md
@@ -8,9 +8,9 @@ The client follows the same versioned method pattern as `bookmarks`/`context`/`n
 
 ```typescript
 import { AppStateApiClient } from '@equinor/fusion-framework-module-services/app-state';
-import { HttpClient } from '@equinor/fusion-framework-module-http';
+import { HttpClient } from '@equinor/fusion-framework-module-http/client';
 
-const httpClient = new HttpClient({ baseUri: 'https://app-state-api.example.com/' });
+const httpClient = new HttpClient('https://app-state-api.example.com/');
 const client = new AppStateApiClient(httpClient, 'json');
 
 const apps = await client.listMyApps('v1');

--- a/.changeset/module-services_add-app-state-client.md
+++ b/.changeset/module-services_add-app-state-client.md
@@ -1,0 +1,20 @@
+---
+"@equinor/fusion-framework-module-services": minor
+---
+
+Add `AppStateApiClient` for the Fusion App State API, exposed via a new `./app-state` subpath export and `ApiProvider.createAppStateClient()`.
+
+The client follows the same versioned method pattern as `bookmarks`/`context`/`notification`: every method takes an API version as its first argument (currently only `'v1'` is supported).
+
+```typescript
+import { AppStateApiClient } from '@equinor/fusion-framework-module-services/app-state';
+import { HttpClient } from '@equinor/fusion-framework-module-http';
+
+const httpClient = new HttpClient({ baseUri: 'https://app-state-api.example.com/' });
+const client = new AppStateApiClient(httpClient, 'json');
+
+const apps = await client.listMyApps('v1');
+await client.wipeMyAppState('v1', { appKey: 'my-app' });
+```
+
+Supported operations: `listMyApps`, `getMyAppState`, `wipeMyAppState`, `wipeAllMyState`, `listAppUsers`, `getUserAppState`, `wipeUserAppState`, `wipeAllAppUsersState`.

--- a/packages/modules/services/README.md
+++ b/packages/modules/services/README.md
@@ -1,10 +1,10 @@
 # @equinor/fusion-framework-module-services
 
-Typed API service clients for the Fusion Framework. Provides factory-based access to platform backend services (bookmarks, context, notification, people) with versioned endpoints, automatic HTTP client resolution, and response validation.
+Typed API service clients for the Fusion Framework. Provides factory-based access to platform backend services (app state, bookmarks, context, notification, people) with versioned endpoints, automatic HTTP client resolution, and response validation.
 
 ## Features
 
-- **Domain-specific API clients** — `BookmarksApiClient`, `ContextApiClient`, `NotificationApiClient`, `PeopleApiClient`
+- **Domain-specific API clients** — `AppStateApiClient`, `BookmarksApiClient`, `ContextApiClient`, `NotificationApiClient`, `PeopleApiClient`
 - **Versioned endpoints** — each service exposes version-aware methods (e.g. `v1`, `v2`, `v4`) with type-safe request/response shapes
 - **Dual consumption patterns** — every endpoint supports both `Promise` (`json`) and observable (`json$`) return types
 - **Automatic HTTP client resolution** — resolves named clients through the HTTP module, falling back to service-discovery
@@ -53,6 +53,11 @@ export const configure = (configurator) => {
 Access the services provider at runtime to create domain clients:
 
 ```ts
+// App State
+const appState = await provider.services.createAppStateClient('json');
+const apps = await appState.listMyApps('v1');
+await appState.wipeMyAppState('v1', { appKey: 'my-app' });
+
 // Bookmarks
 const bookmarks = await provider.services.createBookmarksClient('json');
 const allBookmarks = await bookmarks.query('v1');
@@ -96,6 +101,7 @@ const photo = await people.photo('v2', 'blob', { azureId: 'azure-unique-id' });
 
 | Client | Import path | Services |
 |---|---|---|
+| `AppStateApiClient` | `@equinor/fusion-framework-module-services/app-state` | Get/wipe own app state, admin get/wipe per-user or per-app state |
 | `BookmarksApiClient` | `@equinor/fusion-framework-module-services/bookmarks` | CRUD bookmarks, favourites |
 | `ContextApiClient` | `@equinor/fusion-framework-module-services/context` | Get, query, related contexts |
 | `NotificationApiClient` | `@equinor/fusion-framework-module-services/notification` | CRUD notifications, settings |

--- a/packages/modules/services/package.json
+++ b/packages/modules/services/package.json
@@ -66,6 +66,10 @@
       "import": "./dist/esm/people/person-photo/index.js",
       "types": "./dist/types/people/person-photo/index.d.ts"
     },
+    "./app-state": {
+      "import": "./dist/esm/app-state/index.js",
+      "types": "./dist/types/app-state/index.d.ts"
+    },
     "./errors": {
       "import": "./dist/esm/errors.js",
       "types": "./dist/types/errors.d.ts"
@@ -118,6 +122,9 @@
       ],
       "people/photo": [
         "./dist/types/people/person-photo/index.d.ts"
+      ],
+      "app-state": [
+        "./dist/types/app-state/index.d.ts"
       ],
       "errors": [
         "./dist/types/errors.d.ts"

--- a/packages/modules/services/src/app-state/client.ts
+++ b/packages/modules/services/src/app-state/client.ts
@@ -1,0 +1,290 @@
+import type { ClientRequestInit, IHttpClient } from '@equinor/fusion-framework-module-http/client';
+import type { ClientMethod } from '../types';
+
+import {
+  type ListMyAppsVersion,
+  type ListMyAppsResponse,
+  type ListMyAppsResult,
+  listMyApps,
+} from './endpoints/me-apps.get';
+import {
+  type GetMyAppStateVersion,
+  type GetMyAppStateArg,
+  type GetMyAppStateResponse,
+  type GetMyAppStateResult,
+  getMyAppState,
+} from './endpoints/me-app.get';
+import {
+  type WipeMyAppStateVersion,
+  type WipeMyAppStateArg,
+  type WipeMyAppStateResponse,
+  type WipeMyAppStateResult,
+  wipeMyAppState,
+} from './endpoints/me-app.delete';
+import {
+  type WipeAllMyStateVersion,
+  type WipeAllMyStateResponse,
+  type WipeAllMyStateResult,
+  wipeAllMyState,
+} from './endpoints/me.delete';
+import {
+  type ListAppUsersVersion,
+  type ListAppUsersArg,
+  type ListAppUsersResponse,
+  type ListAppUsersResult,
+  listAppUsers,
+} from './endpoints/admin-app-users.get';
+import {
+  type GetUserAppStateVersion,
+  type GetUserAppStateArg,
+  type GetUserAppStateResponse,
+  type GetUserAppStateResult,
+  getUserAppState,
+} from './endpoints/admin-app-user.get';
+import {
+  type WipeUserAppStateVersion,
+  type WipeUserAppStateArg,
+  type WipeUserAppStateResponse,
+  type WipeUserAppStateResult,
+  wipeUserAppState,
+} from './endpoints/admin-app-user.delete';
+import {
+  type WipeAllAppUsersStateVersion,
+  type WipeAllAppUsersStateArg,
+  type WipeAllAppUsersStateResponse,
+  type WipeAllAppUsersStateResult,
+  wipeAllAppUsersState,
+} from './endpoints/admin-app.delete';
+
+/**
+ * Provides a client interface for interacting with the App State API.
+ *
+ * Exposes the current user's own per-app state under `/persons/me/...`, and,
+ * for callers holding the `Fusion.AppState.AppAdmin` (scoped to an app) or
+ * `Fusion.AppState.Admin` role, per-user administrative state management
+ * under `/admin/...`.
+ *
+ * The upstream OpenAPI spec does not publish response body schemas — only
+ * status-code descriptions — so every method's response defaults to
+ * `unknown`. Supply a `TResponse` type argument on the individual method call
+ * to narrow the parsed response.
+ *
+ * @example
+ * ```typescript
+ * import { AppStateApiClient } from '@equinor/fusion-framework-module-services/app-state';
+ * import { HttpClient } from '@equinor/fusion-framework-module-http';
+ *
+ * const httpClient = new HttpClient({ baseUri: 'https://my-app-state-api.com/' });
+ * const client = new AppStateApiClient(httpClient, 'json');
+ *
+ * const apps = await client.listMyApps('v1');
+ * await client.wipeMyAppState('v1', { appKey: 'my-app' });
+ * ```
+ *
+ * @template TMethod - The client method to use for the request, defaults to 'json'.
+ * @template TClient - The HTTP client to use for executing the request.
+ */
+export class AppStateApiClient<
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TClient extends IHttpClient = IHttpClient,
+> {
+  /**
+   * Constructs a new instance of the AppStateApiClient class.
+   *
+   * @param _client - The client instance to use for making API requests.
+   * @param _method - The client method to use for API requests.
+   */
+  constructor(
+    protected _client: TClient,
+    protected _method: TMethod,
+  ) {}
+
+  /**
+   * Lists all apps that hold state for the current user, including a
+   * document count and storage size per app.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `listMyApps` function.
+   * @param version - The API version to use.
+   * @param init - Optional request initialization options.
+   * @returns The list of apps with stored state for the current user.
+   */
+  public listMyApps<TVersion extends ListMyAppsVersion, TResponse = ListMyAppsResponse<TVersion>>(
+    version: TVersion,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): ListMyAppsResult<TVersion, TMethod, TResponse> {
+    const fn = listMyApps(version, this._client, this._method);
+    return fn(init);
+  }
+
+  /**
+   * Gets the current user's state info for a single app.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `getMyAppState` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key identifying the app.
+   * @param init - Optional request initialization options.
+   * @returns The current user's state info for the given app.
+   */
+  public getMyAppState<
+    TVersion extends GetMyAppStateVersion,
+    TResponse = GetMyAppStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: GetMyAppStateArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): GetMyAppStateResult<TVersion, TMethod, TResponse> {
+    const fn = getMyAppState(version, this._client, this._method);
+    return fn(args, init);
+  }
+
+  /**
+   * Wipes the current user's state for a single app (deletes and recreates
+   * the user's state database for that app).
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `wipeMyAppState` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key identifying the app.
+   * @param init - Optional request initialization options.
+   * @returns The result of the wipe operation.
+   */
+  public wipeMyAppState<
+    TVersion extends WipeMyAppStateVersion,
+    TResponse = WipeMyAppStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: WipeMyAppStateArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): WipeMyAppStateResult<TVersion, TMethod, TResponse> {
+    const fn = wipeMyAppState(version, this._client, this._method);
+    return fn(args, init);
+  }
+
+  /**
+   * Wipes all of the current user's state across every app (GDPR erasure).
+   *
+   * Always sends the `X-Confirm-Wipe: true` header the API requires for
+   * this operation; pass `init.headers` to add further headers.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `wipeAllMyState` function.
+   * @param version - The API version to use.
+   * @param init - Optional request initialization options.
+   * @returns The result of the wipe operation.
+   */
+  public wipeAllMyState<
+    TVersion extends WipeAllMyStateVersion,
+    TResponse = WipeAllMyStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): WipeAllMyStateResult<TVersion, TMethod, TResponse> {
+    const fn = wipeAllMyState(version, this._client, this._method);
+    return fn(init);
+  }
+
+  /**
+   * Lists the users who hold state for a given app.
+   *
+   * Requires the `Fusion.AppState.AppAdmin` (scoped to the app) or
+   * `Fusion.AppState.Admin` role.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `listAppUsers` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key identifying the app.
+   * @param init - Optional request initialization options.
+   * @returns The list of users with stored state for the given app.
+   */
+  public listAppUsers<
+    TVersion extends ListAppUsersVersion,
+    TResponse = ListAppUsersResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: ListAppUsersArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): ListAppUsersResult<TVersion, TMethod, TResponse> {
+    const fn = listAppUsers(version, this._client, this._method);
+    return fn(args, init);
+  }
+
+  /**
+   * Gets a specific user's state info for a given app.
+   *
+   * Requires the `Fusion.AppState.AppAdmin` (scoped to the app) or
+   * `Fusion.AppState.Admin` role.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `getUserAppState` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key and user object ID (OID).
+   * @param init - Optional request initialization options.
+   * @returns The user's state info for the given app.
+   */
+  public getUserAppState<
+    TVersion extends GetUserAppStateVersion,
+    TResponse = GetUserAppStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: GetUserAppStateArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): GetUserAppStateResult<TVersion, TMethod, TResponse> {
+    const fn = getUserAppState(version, this._client, this._method);
+    return fn(args, init);
+  }
+
+  /**
+   * Wipes a specific user's state for a given app.
+   *
+   * Requires the `Fusion.AppState.AppAdmin` (scoped to the app) or
+   * `Fusion.AppState.Admin` role.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `wipeUserAppState` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key and user object ID (OID).
+   * @param init - Optional request initialization options.
+   * @returns The result of the wipe operation.
+   */
+  public wipeUserAppState<
+    TVersion extends WipeUserAppStateVersion,
+    TResponse = WipeUserAppStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: WipeUserAppStateArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): WipeUserAppStateResult<TVersion, TMethod, TResponse> {
+    const fn = wipeUserAppState(version, this._client, this._method);
+    return fn(args, init);
+  }
+
+  /**
+   * Wipes all users' state for a given app.
+   *
+   * Requires the `Fusion.AppState.AppAdmin` (scoped to the app) or
+   * `Fusion.AppState.Admin` role, and always sends the `X-Confirm-Wipe: true`
+   * header the API requires for this operation.
+   *
+   * @template TVersion - The version of the API to call.
+   * @template TResponse - The type of the result of the `wipeAllAppUsersState` function.
+   * @param version - The API version to use.
+   * @param args - The app-registration key identifying the app.
+   * @param init - Optional request initialization options.
+   * @returns The result of the wipe operation.
+   */
+  public wipeAllAppUsersState<
+    TVersion extends WipeAllAppUsersStateVersion,
+    TResponse = WipeAllAppUsersStateResponse<TVersion>,
+  >(
+    version: TVersion,
+    args: WipeAllAppUsersStateArg<TVersion>,
+    init?: ClientRequestInit<TClient, TResponse>,
+  ): WipeAllAppUsersStateResult<TVersion, TMethod, TResponse> {
+    const fn = wipeAllAppUsersState(version, this._client, this._method);
+    return fn(args, init);
+  }
+}
+
+export default AppStateApiClient;

--- a/packages/modules/services/src/app-state/client.ts
+++ b/packages/modules/services/src/app-state/client.ts
@@ -72,16 +72,16 @@ import {
  * @example
  * ```typescript
  * import { AppStateApiClient } from '@equinor/fusion-framework-module-services/app-state';
- * import { HttpClient } from '@equinor/fusion-framework-module-http';
+ * import { HttpClient } from '@equinor/fusion-framework-module-http/client';
  *
- * const httpClient = new HttpClient({ baseUri: 'https://my-app-state-api.com/' });
+ * const httpClient = new HttpClient('https://my-app-state-api.com/');
  * const client = new AppStateApiClient(httpClient, 'json');
  *
  * const apps = await client.listMyApps('v1');
  * await client.wipeMyAppState('v1', { appKey: 'my-app' });
  * ```
  *
- * @template TMethod - The client method to use for the request, defaults to 'json'.
+ * @template TMethod - The client method to use for the request.
  * @template TClient - The HTTP client to use for executing the request.
  */
 export class AppStateApiClient<

--- a/packages/modules/services/src/app-state/endpoints/admin-app-user.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/admin-app-user.delete.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+    userId: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        method: 'DELETE',
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/admin/apps/${args.appKey}/users/${args.userId}?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as WipeUserAppStateVersion,
+  type MethodArg as WipeUserAppStateArg,
+  type ApiResponse as WipeUserAppStateResponse,
+  type MethodResult as WipeUserAppStateResult,
+  executeApiCall as wipeUserAppState,
+};

--- a/packages/modules/services/src/app-state/endpoints/admin-app-user.get.ts
+++ b/packages/modules/services/src/app-state/endpoints/admin-app-user.get.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+    userId: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/admin/apps/${args.appKey}/users/${args.userId}?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as GetUserAppStateVersion,
+  type MethodArg as GetUserAppStateArg,
+  type ApiResponse as GetUserAppStateResponse,
+  type MethodResult as GetUserAppStateResult,
+  executeApiCall as getUserAppState,
+};

--- a/packages/modules/services/src/app-state/endpoints/admin-app-users.get.ts
+++ b/packages/modules/services/src/app-state/endpoints/admin-app-users.get.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/admin/apps/${args.appKey}/users?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as ListAppUsersVersion,
+  type MethodArg as ListAppUsersArg,
+  type ApiResponse as ListAppUsersResponse,
+  type MethodResult as ListAppUsersResult,
+  executeApiCall as listAppUsers,
+};

--- a/packages/modules/services/src/app-state/endpoints/admin-app.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/admin-app.delete.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      // The API requires an explicit opt-in header before it will wipe every user's state for the app.
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Wipe': 'true' },
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/admin/apps/${args.appKey}?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as WipeAllAppUsersStateVersion,
+  type MethodArg as WipeAllAppUsersStateArg,
+  type ApiResponse as WipeAllAppUsersStateResponse,
+  type MethodResult as WipeAllAppUsersStateResult,
+  executeApiCall as wipeAllAppUsersState,
+};

--- a/packages/modules/services/src/app-state/endpoints/admin-app.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/admin-app.delete.ts
@@ -56,14 +56,15 @@ const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
   // Select the response schema that matches the requested API version.
   switch (version) {
     case ApiVersion.v1: {
-      // The API requires an explicit opt-in header before it will wipe every user's state for the app.
       const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
         method: 'DELETE',
-        headers: { 'X-Confirm-Wipe': 'true' },
         selector: schemaSelector(ApiResponseSchema[version]),
       };
-      // Merge caller overrides on top of the generated version-specific defaults.
-      return Object.assign({}, baseInit, init);
+      // Preserve caller headers, but force the API's required confirmation header last so it can't be stripped.
+      const headers = new Headers(init?.headers);
+      headers.set('X-Confirm-Wipe', 'true');
+      // Merge caller overrides on top of the generated defaults, with the confirmation header applied last.
+      return Object.assign({}, baseInit, init, { headers });
     }
   }
   throw Error(`Unknown API version: ${version}`);

--- a/packages/modules/services/src/app-state/endpoints/me-app.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/me-app.delete.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        method: 'DELETE',
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/persons/me/apps/${args.appKey}?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as WipeMyAppStateVersion,
+  type MethodArg as WipeMyAppStateArg,
+  type ApiResponse as WipeMyAppStateResponse,
+  type MethodResult as WipeMyAppStateResult,
+  executeApiCall as wipeMyAppState,
+};

--- a/packages/modules/services/src/app-state/endpoints/me-app.get.ts
+++ b/packages/modules/services/src/app-state/endpoints/me-app.get.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({
+    appKey: z.string(),
+  }),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the input arguments to this operation. */
+type MethodArg<TVersion extends AllowedVersions> = z.input<
+  (typeof ArgSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/persons/me/apps/${args.appKey}?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    input: MethodArg<MethodVersion>,
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse(input);
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as GetMyAppStateVersion,
+  type MethodArg as GetMyAppStateArg,
+  type ApiResponse as GetMyAppStateResponse,
+  type MethodResult as GetMyAppStateResult,
+  executeApiCall as getMyAppState,
+};

--- a/packages/modules/services/src/app-state/endpoints/me-apps.get.ts
+++ b/packages/modules/services/src/app-state/endpoints/me-apps.get.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({}),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/persons/me/apps?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse({});
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as ListMyAppsVersion,
+  type ApiResponse as ListMyAppsResponse,
+  type MethodResult as ListMyAppsResult,
+  executeApiCall as listMyApps,
+};

--- a/packages/modules/services/src/app-state/endpoints/me.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/me.delete.ts
@@ -49,14 +49,15 @@ const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
   // Select the response schema that matches the requested API version.
   switch (version) {
     case ApiVersion.v1: {
-      // The API requires an explicit opt-in header before it will perform a full GDPR erasure.
       const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
         method: 'DELETE',
-        headers: { 'X-Confirm-Wipe': 'true' },
         selector: schemaSelector(ApiResponseSchema[version]),
       };
-      // Merge caller overrides on top of the generated version-specific defaults.
-      return Object.assign({}, baseInit, init);
+      // Preserve caller headers, but force the API's required confirmation header last so it can't be stripped.
+      const headers = new Headers(init?.headers);
+      headers.set('X-Confirm-Wipe', 'true');
+      // Merge caller overrides on top of the generated defaults, with the confirmation header applied last.
+      return Object.assign({}, baseInit, init, { headers });
     }
   }
   throw Error(`Unknown API version: ${version}`);

--- a/packages/modules/services/src/app-state/endpoints/me.delete.ts
+++ b/packages/modules/services/src/app-state/endpoints/me.delete.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+import type {
+  ClientRequestInit,
+  FetchRequestInit,
+  IHttpClient,
+  JsonRequest,
+} from '@equinor/fusion-framework-module-http/client';
+
+import type { ClientMethod, ExtractApiVersion, FilterAllowedApiVersions } from '../types';
+
+import { extractVersion, schemaSelector } from '../../utils';
+import { ApiVersion } from '../static';
+
+/** API version which this operation uses. */
+type AvailableVersions = ApiVersion.v1;
+
+/** Defines the allowed versions for this operation. (key of enum as string or enum value) */
+type AllowedVersions = FilterAllowedApiVersions<AvailableVersions>;
+
+/** Schema for the input arguments to this operation. */
+const ArgSchema = {
+  [ApiVersion.v1]: z.object({}),
+} as const;
+
+/** Schema for the response from the API. The upstream spec does not publish a response schema. */
+const ApiResponseSchema = {
+  [ApiVersion.v1]: z.unknown(),
+};
+
+/** Defines the expected output from the api. */
+type ApiResponse<TVersion extends AllowedVersions> = z.infer<
+  (typeof ApiResponseSchema)[ExtractApiVersion<TVersion>]
+>;
+
+/** Defines the expected output of this operation. */
+type MethodResult<
+  TVersion extends AllowedVersions,
+  TMethod extends keyof ClientMethod<unknown> = keyof ClientMethod<unknown>,
+  TResult = ApiResponse<TVersion>,
+> = ClientMethod<TResult>[TMethod];
+
+/** utility function for generating http request initialization parameters  */
+const generateRequestParameters = <TResult, TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+  init?: ClientRequestInit<IHttpClient, TResult>,
+): ClientRequestInit<IHttpClient, TResult> => {
+  // Select the response schema that matches the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      // The API requires an explicit opt-in header before it will perform a full GDPR erasure.
+      const baseInit: FetchRequestInit<ApiResponse<ApiVersion.v1>, JsonRequest> = {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Wipe': 'true' },
+        selector: schemaSelector(ApiResponseSchema[version]),
+      };
+      // Merge caller overrides on top of the generated version-specific defaults.
+      return Object.assign({}, baseInit, init);
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** utility function for generating the api path */
+const generateApiPath = <TVersion extends AvailableVersions>(
+  version: TVersion,
+  _args: z.infer<(typeof ArgSchema)[TVersion]>,
+): string => {
+  // Build the endpoint path according to the requested API version.
+  switch (version) {
+    case ApiVersion.v1: {
+      const params = new URLSearchParams();
+      params.append('api-version', version);
+      return `/persons/me?${String(params)}`;
+    }
+  }
+  throw Error(`Unknown API version: ${version}`);
+};
+
+/** executes the api call */
+const executeApiCall = <TVersion extends AllowedVersions, TMethod extends keyof ClientMethod>(
+  version: TVersion,
+  client: IHttpClient,
+  method: TMethod = 'json' as TMethod,
+) => {
+  type MethodVersion = ExtractApiVersion<TVersion>;
+  const apiVersion = extractVersion(ApiVersion, version);
+  return <
+    TResponse = ApiResponse<MethodVersion>,
+    TResult = MethodResult<MethodVersion, TMethod, TResponse>,
+  >(
+    init?: ClientRequestInit<IHttpClient, TResponse>,
+  ): TResult => {
+    const args = ArgSchema[apiVersion].parse({});
+    return client[method](
+      generateApiPath(apiVersion, args),
+      generateRequestParameters(apiVersion, args, init),
+    ) as TResult;
+  };
+};
+
+// Aliased re-export: the generic type/function names (AllowedVersions, MethodArg, ...) are reused
+// across every endpoint file in this directory, so they cannot be exported inline under their
+// unique consumer-facing names.
+// fusion-lint-disable-next-line no-separate-export
+export {
+  type AllowedVersions as WipeAllMyStateVersion,
+  type ApiResponse as WipeAllMyStateResponse,
+  type MethodResult as WipeAllMyStateResult,
+  executeApiCall as wipeAllMyState,
+};

--- a/packages/modules/services/src/app-state/index.ts
+++ b/packages/modules/services/src/app-state/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @packageDocumentation
+ *
+ * App State API client and types.
+ *
+ * Provides {@link AppStateApiClient} for reading and wiping a user's stored
+ * application state, and for admins to manage per-user state on behalf of
+ * an app (`Fusion.AppState.AppAdmin` / `Fusion.AppState.Admin` roles).
+ *
+ * @example
+ * ```ts
+ * import { AppStateApiClient } from '@equinor/fusion-framework-module-services/app-state';
+ * ```
+ */
+
+export { AppStateApiClient, default } from './client';
+
+export { ApiVersion } from './static';
+
+export * from './types';

--- a/packages/modules/services/src/app-state/static.ts
+++ b/packages/modules/services/src/app-state/static.ts
@@ -1,0 +1,5 @@
+/** Supported API versions for the App State service. */
+export enum ApiVersion {
+  /** App State API version 1.0. */
+  v1 = '1.0',
+}

--- a/packages/modules/services/src/app-state/types.ts
+++ b/packages/modules/services/src/app-state/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Re-exported shared types scoped for the App State service.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  FilterAllowedApiVersions as FilterAllowApiVersionsBase,
+  ExtractApiVersion as ExtractApiVersionBase,
+} from '../types';
+
+import type { ApiVersion } from './static';
+
+export { ClientMethodType, ClientMethod, ApiClientArguments } from '../types';
+
+/**
+ * Union of allowed version keys and values for the App State API.
+ *
+ * @template TAllowed - Subset of `ApiVersion` keys to include.
+ */
+export type FilterAllowedApiVersions<TAllowed extends string = keyof typeof ApiVersion> =
+  FilterAllowApiVersionsBase<typeof ApiVersion, TAllowed>;
+
+/**
+ * Extracts the concrete version string from a key-or-value version identifier
+ * for the App State API.
+ *
+ * @template TVersion - The version string to resolve.
+ * @template TAllowed - Constraint on allowed versions.
+ */
+export type ExtractApiVersion<
+  TVersion extends string,
+  TAllowed extends string = FilterAllowedApiVersions,
+> = ExtractApiVersionBase<typeof ApiVersion, TVersion, TAllowed>;

--- a/packages/modules/services/src/provider.ts
+++ b/packages/modules/services/src/provider.ts
@@ -8,6 +8,7 @@ import { ContextApiClient } from './context';
 import BookmarksApiClient from './bookmarks/client';
 import { NotificationApiClient } from './notification';
 import { PeopleApiClient } from './people/client';
+import { AppStateApiClient } from './app-state/client';
 import { ApiProviderError } from './ApiProviderError';
 
 export { ApiProviderError } from './ApiProviderError';
@@ -59,6 +60,17 @@ export interface IApiProvider<TClient extends IHttpClient = IHttpClient> {
    * @returns A configured {@link PeopleApiClient} instance.
    */
   createPeopleClient(): Promise<PeopleApiClient<TClient>>;
+
+  /**
+   * Creates a typed client for the App State API.
+   *
+   * @template TMethod - The client execution method (`'json'` or `'json$'`).
+   * @param method - The execution method to use for requests.
+   * @returns A configured {@link AppStateApiClient} instance.
+   */
+  createAppStateClient<TMethod extends keyof ClientMethod>(
+    method: TMethod,
+  ): Promise<AppStateApiClient<TMethod, TClient>>;
 }
 
 /**
@@ -177,5 +189,20 @@ export class ApiProvider<TClient extends IHttpClient = IHttpClient>
     const httpClient = await this._createClientFn('people');
     httpClient.responseHandler.add('validate_api_request', validateResponse);
     return new PeopleApiClient(httpClient);
+  }
+
+  /**
+   * Creates a typed App State API client and attaches response validation.
+   *
+   * @template TMethod - The client execution method.
+   * @param method - The execution method to use for requests.
+   * @returns A configured App State API client.
+   */
+  public async createAppStateClient<TMethod extends keyof ClientMethod>(
+    method: TMethod,
+  ): Promise<AppStateApiClient<TMethod, TClient>> {
+    const httpClient = await this._createClientFn('app-state');
+    httpClient.responseHandler.add('validate_api_request', validateResponse);
+    return new AppStateApiClient(httpClient, method);
   }
 }

--- a/packages/modules/services/tests/app-state.test.ts
+++ b/packages/modules/services/tests/app-state.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+
+import { BASE_URL } from './setup';
+
+import { AppStateApiClient, ApiVersion } from '../src/app-state';
+
+import { HttpClient } from '@equinor/fusion-framework-module-http/client';
+
+describe('AppState', () => {
+  let httpClient: HttpClient;
+  let httpClientWatcher: MockInstance;
+  let appStateClient: AppStateApiClient;
+
+  beforeEach(() => {
+    httpClient = new HttpClient(BASE_URL, {
+      /* options */
+    });
+    httpClientWatcher = vi.spyOn(httpClient, 'json');
+    appStateClient = new AppStateApiClient(httpClient, 'json');
+  });
+
+  afterEach(() => {
+    httpClientWatcher.mockRestore();
+  });
+
+  describe('listMyApps', () => {
+    it('requests the current user apps endpoint', async () => {
+      const result = await appStateClient.listMyApps('v1');
+
+      expect(result).toMatchObject([{ appKey: 'my-app' }]);
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/persons/me/apps?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ selector: expect.any(Function) }),
+      );
+    });
+  });
+
+  describe('getMyAppState', () => {
+    it('requests the current user state for a single app', async () => {
+      const result = await appStateClient.getMyAppState('v1', { appKey: 'my-app' });
+
+      expect(result).toMatchObject({ appKey: 'my-app' });
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/persons/me/apps/my-app?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ selector: expect.any(Function) }),
+      );
+    });
+  });
+
+  describe('wipeMyAppState', () => {
+    it('sends a DELETE request for a single app', async () => {
+      await appStateClient.wipeMyAppState('v1', { appKey: 'my-app' });
+
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/persons/me/apps/my-app?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  describe('wipeAllMyState', () => {
+    it('sends the required X-Confirm-Wipe header', async () => {
+      const result = await appStateClient.wipeAllMyState('v1');
+
+      expect(result).toMatchObject({ wiped: true });
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/persons/me?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'X-Confirm-Wipe': 'true' },
+        }),
+      );
+    });
+  });
+
+  describe('listAppUsers', () => {
+    it('requests the users with state for an app', async () => {
+      const result = await appStateClient.listAppUsers('v1', { appKey: 'my-app' });
+
+      expect(result).toEqual(['user-oid-1', 'user-oid-2']);
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/admin/apps/my-app/users?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ selector: expect.any(Function) }),
+      );
+    });
+  });
+
+  describe('getUserAppState', () => {
+    it('requests a single user state for an app', async () => {
+      const result = await appStateClient.getUserAppState('v1', {
+        appKey: 'my-app',
+        userId: 'user-1',
+      });
+
+      expect(result).toMatchObject({ userId: 'user-1' });
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/admin/apps/my-app/users/user-1?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ selector: expect.any(Function) }),
+      );
+    });
+  });
+
+  describe('wipeUserAppState', () => {
+    it('sends a DELETE request for a single user', async () => {
+      await appStateClient.wipeUserAppState('v1', { appKey: 'my-app', userId: 'user-1' });
+
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/admin/apps/my-app/users/user-1?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  describe('wipeAllAppUsersState', () => {
+    it('sends the required X-Confirm-Wipe header', async () => {
+      const result = await appStateClient.wipeAllAppUsersState('v1', { appKey: 'my-app' });
+
+      expect(result).toMatchObject({ wiped: true });
+      expect(httpClientWatcher).toHaveBeenCalledWith(
+        `/admin/apps/my-app?api-version=${ApiVersion.v1}`,
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'X-Confirm-Wipe': 'true' },
+        }),
+      );
+    });
+
+    it('rejects when the API rejects a missing confirmation header', async () => {
+      // Simulate the upstream API rejecting the request when the confirmation header is stripped
+      await expect(
+        appStateClient.wipeAllAppUsersState(
+          'v1',
+          { appKey: 'my-app' },
+          { headers: {} as unknown as HeadersInit },
+        ),
+      ).rejects.toBeTruthy();
+    });
+  });
+});

--- a/packages/modules/services/tests/app-state.test.ts
+++ b/packages/modules/services/tests/app-state.test.ts
@@ -65,11 +65,22 @@ describe('AppState', () => {
       expect(result).toMatchObject({ wiped: true });
       expect(httpClientWatcher).toHaveBeenCalledWith(
         `/persons/me?api-version=${ApiVersion.v1}`,
-        expect.objectContaining({
-          method: 'DELETE',
-          headers: { 'X-Confirm-Wipe': 'true' },
-        }),
+        expect.objectContaining({ method: 'DELETE' }),
       );
+      const [, init] = httpClientWatcher.mock.calls.at(-1) ?? [];
+      expect(new Headers(init?.headers).get('X-Confirm-Wipe')).toBe('true');
+    });
+
+    it('preserves caller headers without stripping the confirmation header', async () => {
+      const result = await appStateClient.wipeAllMyState('v1', {
+        headers: { 'X-Custom': 'yes' },
+      });
+
+      expect(result).toMatchObject({ wiped: true });
+      const [, init] = httpClientWatcher.mock.calls.at(-1) ?? [];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-Custom')).toBe('yes');
+      expect(headers.get('X-Confirm-Wipe')).toBe('true');
     });
   });
 
@@ -118,22 +129,25 @@ describe('AppState', () => {
       expect(result).toMatchObject({ wiped: true });
       expect(httpClientWatcher).toHaveBeenCalledWith(
         `/admin/apps/my-app?api-version=${ApiVersion.v1}`,
-        expect.objectContaining({
-          method: 'DELETE',
-          headers: { 'X-Confirm-Wipe': 'true' },
-        }),
+        expect.objectContaining({ method: 'DELETE' }),
       );
+      const [, init] = httpClientWatcher.mock.calls.at(-1) ?? [];
+      expect(new Headers(init?.headers).get('X-Confirm-Wipe')).toBe('true');
     });
 
-    it('rejects when the API rejects a missing confirmation header', async () => {
-      // Simulate the upstream API rejecting the request when the confirmation header is stripped
-      await expect(
-        appStateClient.wipeAllAppUsersState(
-          'v1',
-          { appKey: 'my-app' },
-          { headers: {} as unknown as HeadersInit },
-        ),
-      ).rejects.toBeTruthy();
+    it('preserves caller headers without stripping the confirmation header', async () => {
+      // The caller's own headers must survive alongside the mandatory confirmation header, not replace it.
+      const result = await appStateClient.wipeAllAppUsersState(
+        'v1',
+        { appKey: 'my-app' },
+        { headers: { 'X-Custom': 'yes' } },
+      );
+
+      expect(result).toMatchObject({ wiped: true });
+      const [, init] = httpClientWatcher.mock.calls.at(-1) ?? [];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-Custom')).toBe('yes');
+      expect(headers.get('X-Confirm-Wipe')).toBe('true');
     });
   });
 });

--- a/packages/modules/services/tests/setup.ts
+++ b/packages/modules/services/tests/setup.ts
@@ -65,6 +65,96 @@ const handlers = [
         ),
     );
   }),
+
+  // Mock GET /persons/me/apps
+  http.get(new URL('persons/me/apps', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json([{ appKey: 'my-app', documentCount: 3, storageSize: 1024 }]);
+  }),
+
+  // Mock GET /persons/me/apps/:appKey
+  http.get(new URL('persons/me/apps/:appKey', BASE_URL).toString(), (req) => {
+    const { appKey } = req.params;
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json({ appKey, documentCount: 3, storageSize: 1024 });
+  }),
+
+  // Mock DELETE /persons/me/apps/:appKey
+  http.delete(new URL('persons/me/apps/:appKey', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json({ wiped: true });
+  }),
+
+  // Mock DELETE /persons/me
+  http.delete(new URL('persons/me', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    // The GDPR erasure endpoint requires an explicit opt-in header
+    if (req.request.headers.get('X-Confirm-Wipe') !== 'true') {
+      return new HttpResponse(null, { status: 400 });
+    }
+    return HttpResponse.json({ wiped: true });
+  }),
+
+  // Mock GET /admin/apps/:appKey/users
+  http.get(new URL('admin/apps/:appKey/users', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json(['user-oid-1', 'user-oid-2']);
+  }),
+
+  // Mock GET /admin/apps/:appKey/users/:userId
+  http.get(new URL('admin/apps/:appKey/users/:userId', BASE_URL).toString(), (req) => {
+    const { userId } = req.params;
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json({ userId, documentCount: 1, storageSize: 128 });
+  }),
+
+  // Mock DELETE /admin/apps/:appKey/users/:userId
+  http.delete(new URL('admin/apps/:appKey/users/:userId', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    return HttpResponse.json({ wiped: true });
+  }),
+
+  // Mock DELETE /admin/apps/:appKey
+  http.delete(new URL('admin/apps/:appKey', BASE_URL).toString(), (req) => {
+    const url = new URL(req.request.url);
+    // Reject requests that omit the API version required by the fixture
+    if (!url.searchParams.get('api-version')) {
+      return HttpResponse.error();
+    }
+    // Wiping every user's state for an app requires an explicit opt-in header
+    if (req.request.headers.get('X-Confirm-Wipe') !== 'true') {
+      return new HttpResponse(null, { status: 400 });
+    }
+    return HttpResponse.json({ wiped: true });
+  }),
 ];
 
 // Initialize the server


### PR DESCRIPTION
**Why is this change needed?**
The App State API (https://appstate.ci.api.fusion-dev.net/openapi/v1.json) has no typed client in `@equinor/fusion-framework-module-services`. Consumers need a domain client to read and manage per-user/per-app state, consistent with the other service domains already offered by this package.

**What is the current behavior?**
`@equinor/fusion-framework-module-services` exposes `BookmarksApiClient`, `ContextApiClient`, `NotificationApiClient`, and `PeopleApiClient`. There is no App State client and no `createAppStateClient` factory on `ApiProvider`.

**What is the new behavior?**
Adds `AppStateApiClient`, exposed via a new `./app-state` subpath export and `ApiProvider.createAppStateClient()`. It follows the same versioned-method pattern as `bookmarks`/`context`/`notification`: every method takes an API version (`'v1'`) as its first argument, builds the request with a Zod-validated response selector, and appends `?api-version=1.0` to the request path.

Operations covered:
- `listMyApps`, `getMyAppState`, `wipeMyAppState`, `wipeAllMyState` (current user's own state, incl. GDPR full erasure)
- `listAppUsers`, `getUserAppState`, `wipeUserAppState`, `wipeAllAppUsersState` (admin operations scoped to an app)

**What is the intended behavior or invariant?**
- Every method requires an explicit API version argument, even though the upstream API currently only supports one version — this keeps the client API consistent with sibling domains and future-proofs it if the API introduces `v2`.
- The upstream OpenAPI spec does not publish response body schemas, only status-code descriptions, so response types default to `unknown` unless the caller supplies a `TResponse` type argument.
- The two GDPR/bulk-wipe operations (`wipeAllMyState`, `wipeAllAppUsersState`) always send the `X-Confirm-Wipe: true` header the API requires; callers can still add further headers via `init`.

**Does this PR introduce a breaking change?**
No. This is a net-new subpath export and a new method on `ApiProvider`; no existing exports or signatures changed.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (see changeset)
- Consumer impact: New opt-in `./app-state` subpath and `createAppStateClient()` method; no action required for existing consumers
- Downstream impact: None outside `@equinor/fusion-framework-module-services`

**Review guidance:**
- Compare `app-state/*` against `context/*` or `bookmarks/*` to confirm the versioned pattern (enum, zod schemas, `api-version` query param, `no-separate-export` suppression) is followed consistently.
- `client.ts` is the main new consumer-facing surface — check method signatures and TSDoc.
- `tests/app-state.test.ts` and the added `tests/setup.ts` msw handlers cover all 8 operations, including the missing-confirmation-header rejection path.

**Additional context**
Validated locally: `tsc -b --force`, `biome check`, `fusion-lint lint`, and `vitest` all pass for `packages/modules/services`.

**Related issues**
Closes equinor/fusion-core-tasks#1671 (sub-issue of the App State epic, equinor/fusion-core-tasks#538).

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
