### PR TITLE
docs: fix framework package count in CODEMAP.md after state module merge

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -13,7 +13,7 @@ search to rediscover it.
 
 | Path | Contains | Published? |
 | --- | --- | --- |
-| `packages/*` | Framework libraries (59 packages) | Yes, via Changesets |
+| `packages/*` | Framework libraries (60 packages) | Yes, via Changesets |
 | `cookbooks/*` | Runnable example apps and portals | Yes (versioned, but examples) |
 | `eds-content/`, `eds/` | EDS design-system content and token tooling | No |
 | `vue-press/` | Documentation site | Partly |


### PR DESCRIPTION
Fixes the `verify:agent-context` CI failure on `main` after #3286 merged (https://github.com/equinor/fusion-framework/actions/runs/30998701272/job/92281949275?pr=3286).

`@equinor/fusion-framework-module-state` added a 60th `packages/*` library but `CODEMAP.md` still declared 59. Bumped the count; `pnpm verify:agent-context` now passes.