### PR TITLE
feat(module-state): add configurable pull scheduling with watchdog fallback

### DIFF
--- a/.changeset/cookbook-app-react-state_poll-preview.md
+++ b/.changeset/cookbook-app-react-state_poll-preview.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-state": patch
+---
+
+`SyncStatusIndicator` now recognizes the `onStateSync.poll` event kind, and the cookbook's default (non-`FUSION_SPA_COUCHDB_URL`) storage now overrides `pull.intervalMs` to 10s via `createDefaultStorage`, so a scheduled pull is visible while previewing the cookbook instead of waiting on the framework's 60s production default.

--- a/.changeset/module-state_interval-pull.md
+++ b/.changeset/module-state_interval-pull.md
@@ -1,0 +1,34 @@
+---
+"@equinor/fusion-framework-module-state": minor
+---
+
+Add a `pull` option to `PouchDbSyncStorage` for controlling how remote changes are pulled during sync, switch the default storage created by `createDefaultStorage()` to use it, and expose `createDefaultStorage` itself so callers can reuse it with custom overrides.
+
+Previously, `PouchDbSyncStorage` always used a single bidirectional `db.sync()` connection, meaning every client kept a live `_changes` longpoll open for both push and pull. At production user counts this is a large number of concurrently open connections for a direction (pull) that's rarely needed in real time.
+
+The new `pull` option lets push stay live (so local writes are never delayed) while pull is scheduled instead of continuous:
+
+```typescript
+new PouchDbSyncStorage({
+  localDb,
+  remoteDb,
+  syncOptions,
+  // Push stays live; pull runs once now, then every 60s, and again whenever the tab regains focus.
+  pull: { mode: 'interval', intervalMs: 60000, refreshOnFocus: true },
+});
+```
+
+- `mode: 'live'` (default, unchanged): behaves exactly as before, via `db.sync()`.
+- `mode: 'interval'`: keeps push live via `db.replicate.to`, and replaces the live pull with one-shot `db.replicate.from` calls run on `intervalMs` (default `60000`) and, unless `refreshOnFocus: false`, whenever the document becomes visible again - regardless of whether the tab is currently visible.
+- `mode: 'visible-interval'`: the same as `'interval'`, except the timer tick is skipped entirely while the tab is hidden (via the Page Visibility API) - a backgrounded tab has no user waiting on fresh data, so there's no reason to hold a connection open or make a request for it.
+
+`createDefaultStorage()` now uses `pull: { mode: 'visible-interval', refreshOnFocus: true }` by default (a 60s `intervalMs`), so apps using the framework's default state storage no longer keep a continuous pull connection open per idle tab, and pause polling entirely while a tab is backgrounded.
+
+`createDefaultStorage` is now also exported from `@equinor/fusion-framework-module-state/default-storage`, so a caller who wants the framework's default remote-resolution behavior (service discovery, auth, the per-user CouchDB proxy) but with different `pull` scheduling can call it directly instead of reimplementing that resolution:
+
+```typescript
+import { createDefaultStorage } from '@equinor/fusion-framework-module-state/default-storage';
+
+config.setStorage((args) => createDefaultStorage(appKey, args, { intervalMs: 10000 }));
+```
+

--- a/.changeset/module-state_interval-pull.md
+++ b/.changeset/module-state_interval-pull.md
@@ -1,5 +1,5 @@
 ---
-"@equinor/fusion-framework-module-state": minor
+"@equinor/fusion-framework-module-state": major
 ---
 
 Add a `pull` option to `PouchDbSyncStorage` for controlling how remote changes are pulled during sync, switch the default storage created by `createDefaultStorage()` to use it, and expose `createDefaultStorage` itself so callers can reuse it with custom overrides.
@@ -31,4 +31,34 @@ import { createDefaultStorage } from '@equinor/fusion-framework-module-state/def
 
 config.setStorage((args) => createDefaultStorage(appKey, args, { intervalMs: 10000 }));
 ```
+
+**Breaking change:** the scheduled pull dispatches a new `onStateSync.poll` event, added to the
+exported `StateSyncEventType`/`StateSyncEvent` union. Consumers with an exhaustive `switch`/`if`
+chain over `StateSyncEventType` (e.g. a `default: assertNever(event)` branch) need a new case for
+`StateSyncEvent.Poll`/`event.type === 'onStateSync.poll'`, or that check will fail to compile
+after upgrading:
+
+```typescript
+// Before: exhaustive over 4 members
+switch (event.type) {
+  case 'onStateSync.change': /* ... */ break;
+  case 'onStateSync.complete': /* ... */ break;
+  case 'onStateSync.error': /* ... */ break;
+  case 'onStateSync.status': /* ... */ break;
+  default: assertNever(event);
+}
+
+// After: add the new member
+switch (event.type) {
+  case 'onStateSync.change': /* ... */ break;
+  case 'onStateSync.complete': /* ... */ break;
+  case 'onStateSync.error': /* ... */ break;
+  case 'onStateSync.status': /* ... */ break;
+  case 'onStateSync.poll': /* ... */ break;
+  default: assertNever(event);
+}
+```
+
+Consumers that switch over a narrower type, or that only inspect specific event kinds (e.g. via
+`StateSyncEvent.Change.is(event)`), are unaffected.
 

--- a/cookbooks/app-react-state/src/components/SyncEvents/SyncStatusIndicator.tsx
+++ b/cookbooks/app-react-state/src/components/SyncEvents/SyncStatusIndicator.tsx
@@ -8,7 +8,7 @@ interface SyncStatusIndicatorProps {
   showTimestamp?: boolean;
 }
 
-type SyncStatusKind = 'active' | 'paused' | 'change' | 'complete' | 'error' | 'offline';
+type SyncStatusKind = 'active' | 'paused' | 'change' | 'complete' | 'poll' | 'error' | 'offline';
 
 const getStatusKind = (event?: StateSyncEventType): SyncStatusKind => {
   // No event has arrived yet - either sync hasn't started, or replication isn't configured.
@@ -19,8 +19,11 @@ const getStatusKind = (event?: StateSyncEventType): SyncStatusKind => {
   }
   // Every other sync event kind maps 1:1 to an indicator label.
   if (StateSyncEvent.Change.is(event)) return 'change';
-  // Any remaining sync event kind is either a completion or an error.
+  // A completed replication batch, whether or not anything actually changed.
   if (StateSyncEvent.Complete.is(event)) return 'complete';
+  // Interval-mode polling (timer/focus/initial) - distinct from an actual error.
+  if (StateSyncEvent.Poll.is(event)) return 'poll';
+  // Any remaining sync event kind is an error.
   return 'error';
 };
 
@@ -29,6 +32,7 @@ const getStatusColor = (kind: SyncStatusKind) => {
   switch (kind) {
     case 'active':
     case 'change':
+    case 'poll':
       return '#007BFF'; // Blue for syncing
     case 'paused':
     case 'complete':
@@ -49,6 +53,8 @@ const getStatusText = (kind: SyncStatusKind) => {
       return 'Up to date';
     case 'change':
       return 'Changes detected';
+    case 'poll':
+      return 'Polling...';
     case 'error':
       return 'Sync error';
     case 'complete':

--- a/cookbooks/app-react-state/src/config.ts
+++ b/cookbooks/app-react-state/src/config.ts
@@ -1,29 +1,34 @@
 import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
 import { enableAppState } from '@equinor/fusion-framework-react-app/state';
 import { PouchDbSyncStorage } from '@equinor/fusion-framework-module-state/storage';
+import { createDefaultStorage } from '@equinor/fusion-framework-module-state/default-storage';
 import { enableNavigation } from '@equinor/fusion-framework-module-navigation';
 
 // Set in `.env` (see `.env.example`) to showcase replication against the local Docker
-// CouchDB from `couchdb.sh` - unset, the state module falls back to its own default
-// storage, the same zero-config behavior any consuming app gets.
+// CouchDB from `couchdb.sh` - unset, the state module falls back to the framework's
+// default storage below, the same zero-config behavior any consuming app gets.
 const couchdbUrl = import.meta.env.FUSION_SPA_COUCHDB_URL;
 
 export const configure: AppModuleInitiator = (appConfigurator, { env }) => {
-  enableAppState(
-    appConfigurator,
-    couchdbUrl
-      ? (config) => {
-          // `onStateSync.*` events shown on this cookbook's pages come from the framework.
-          config.setStorage(
-            new PouchDbSyncStorage({
-              localDb: { name_or_instance: 'cookbook_app_state' },
-              remoteDb: { name_or_instance: couchdbUrl },
-              syncOptions: { live: true, retry: true, heartbeat: 10000, timeout: 30000 },
-            }),
-          );
-        }
-      : undefined,
-  );
+  enableAppState(appConfigurator, (config) => {
+    // `onStateSync.*` events shown on this cookbook's pages come from the framework.
+    if (couchdbUrl) {
+      config.setStorage(
+        new PouchDbSyncStorage({
+          localDb: { name_or_instance: 'cookbook_app_state' },
+          remoteDb: { name_or_instance: couchdbUrl },
+          syncOptions: { live: true, retry: true, heartbeat: 10000, timeout: 30000 },
+        }),
+      );
+      return;
+    }
+    // Use the real default storage, but with a shorter pull interval than production's
+    // (see `createDefaultStorage`'s own default) - nobody wants to wait a minute to see
+    // a poll happen while previewing this cookbook.
+    config.setStorage((args) =>
+      createDefaultStorage(appConfigurator.manifest.appKey, args, { intervalMs: 10_000 }),
+    );
+  });
 
   // Enable navigation module (allow navigation between pages)
   enableNavigation(appConfigurator, env.basename);

--- a/packages/modules/state/docs/events.md
+++ b/packages/modules/state/docs/events.md
@@ -72,6 +72,7 @@ a sync session is active.
 | `StateSyncCompleteEvent` | `onStateSync.complete` | `result` (`{ push?, pull? }`), optional `id` |
 | `StateSyncErrorEvent` | `onStateSync.error` | `error`, `type` (`'error' \| 'denied'`), optional `id` |
 | `StateSyncStatusEvent` | `onStateSync.status` | `status`, optional `id` |
+| `StateSyncPollEvent` | `onStateSync.poll` | `trigger` (`'initial' \| 'interval' \| 'focus'`), `skipped`, optional `id` |
 
 ```typescript
 modules.event.addEventListener('onStateSync.error', (event) => {
@@ -81,9 +82,15 @@ modules.event.addEventListener('onStateSync.error', (event) => {
 modules.event.addEventListener('onStateSync.status', (event) => {
   console.log('Sync status:', event.status);
 });
+
+// Dispatched by PouchDbSyncStorage's non-'live' pull modes ('interval'/'visible-interval') on
+// the initial pull, each interval tick, and each focus catch-up - even when nothing changed.
+modules.event.addEventListener('onStateSync.poll', (event) => {
+  console.log('Polled for changes:', event.trigger, 'skipped:', event.skipped);
+});
 ```
 
-Use `StateSyncEvent.is(event)` to match any of the four sync events at once, e.g. for a single
+Use `StateSyncEvent.is(event)` to match any of the five sync events at once, e.g. for a single
 telemetry hook that logs all sync activity.
 
 ## Operation events

--- a/packages/modules/state/docs/storage.md
+++ b/packages/modules/state/docs/storage.md
@@ -80,6 +80,54 @@ enableStateModule(configurator, async (builder) => {
 - **`filter`**: Apply custom filters to replicate only specific documents
 - **`since`**: Start replication from a specific sequence number
 
+## Configurable Pull Scheduling with PouchDbSyncStorage
+
+`PouchDbSyncStorage` wraps a local/remote database pair and starts replication for you. By
+default it behaves like the `db.sync()` example above: a single continuous, bidirectional
+connection. A production app with many idle tabs open at once, though, rarely needs pulled
+changes in real time - the `pull` option lets push stay live (so local writes are never
+delayed) while pull is scheduled instead of continuous:
+
+```typescript
+import { PouchDbSyncStorage } from '@equinor/fusion-framework-module-state/storage';
+
+const storage = new PouchDbSyncStorage({
+  localDb: { name_or_instance: 'my-app-state' },
+  remoteDb: { name_or_instance: 'http://localhost:5984/my-app-state' },
+  syncOptions: { retry: true },
+  // Push stays live; pull runs once now, then every 60s, and again whenever the tab regains focus.
+  pull: { mode: 'interval', intervalMs: 60000, refreshOnFocus: true },
+});
+```
+
+`pull.mode` options:
+- **`'live'`** (default): unchanged - a single continuous bidirectional `db.sync()` connection.
+- **`'interval'`**: keeps push live via `db.replicate.to`, and replaces the live pull with
+  one-shot `db.replicate.from` calls run on `pull.intervalMs` (default `60000`) and, unless
+  `pull.refreshOnFocus: false`, whenever the document becomes visible again - regardless of
+  whether the tab is currently visible.
+- **`'visible-interval'`**: the same as `'interval'`, except the timer tick is skipped entirely
+  while the tab is hidden (via the Page Visibility API) - a backgrounded tab has no user
+  waiting on fresh data, so there's no reason to hold a connection open or make a request for it.
+
+A scheduled pull dispatches an `onStateSync.poll` event (with `{ trigger, skipped }`) each time
+it runs or is skipped because a previous pull is still in flight - see
+[Monitoring Sync Progress](#monitoring-sync-progress) below.
+
+### Default Storage
+
+`@equinor/fusion-framework-module-state/default-storage` exports `createDefaultStorage`, the
+factory the framework itself uses to resolve service discovery, auth, and the per-user CouchDB
+proxy into a `PouchDbSyncStorage`. It defaults to `pull: { mode: 'visible-interval',
+refreshOnFocus: true }` (a 60s `intervalMs`). Call it directly to reuse that resolution with a
+different `pull` schedule instead of reimplementing it:
+
+```typescript
+import { createDefaultStorage } from '@equinor/fusion-framework-module-state/default-storage';
+
+config.setStorage((args) => createDefaultStorage(appKey, args, { intervalMs: 10000 }));
+```
+
 ## Monitoring Sync Progress
 
 The state module provides comprehensive sync event monitoring through RxJS observables:

--- a/packages/modules/state/package.json
+++ b/packages/modules/state/package.json
@@ -18,6 +18,10 @@
       "import": "./dist/esm/storage/index.js",
       "types": "./dist/types/storage/index.d.ts"
     },
+    "./default-storage": {
+      "import": "./dist/esm/create-default-storage.js",
+      "types": "./dist/types/create-default-storage.d.ts"
+    },
     "./package.json": "./package.json",
     "./README.md": "./README.md"
   },
@@ -31,6 +35,9 @@
       ],
       "storage": [
         "dist/types/storage/index.d.ts"
+      ],
+      "default-storage": [
+        "dist/types/create-default-storage.d.ts"
       ]
     }
   },

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -204,5 +204,88 @@ describe('PouchDbSyncStorage', () => {
       replicateFrom.mockRestore();
       vi.useRealTimers();
     });
+
+    it('does not cancel a pull that keeps making progress, only one that goes fully silent', async () => {
+      vi.useFakeTimers();
+      const cancel = vi.fn();
+      const handlers: Record<string, Array<() => void>> = {};
+      const replication = {
+        on: vi.fn((event: string, handler: () => void) => {
+          if (!handlers[event]) handlers[event] = [];
+          handlers[event].push(handler);
+        }),
+        removeListener: vi.fn(),
+        // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
+        then: vi.fn(),
+        cancel,
+      };
+      const replicateFrom = vi
+        .spyOn(localDb.replicate, 'from')
+        .mockReturnValue(replication as unknown as ReturnType<typeof localDb.replicate.from>);
+
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: { timeout: 1000 },
+        pull: { mode: 'interval', intervalMs: 10000, refreshOnFocus: false },
+      });
+
+      await storage.initialize();
+      expect(cancel).not.toHaveBeenCalled();
+
+      // watchdogMs is syncOptions.timeout (1000) + 5000 = 6000. Emitting 'change' just under
+      // that deadline, repeatedly, proves the watchdog rearms on progress instead of enforcing
+      // a fixed total-duration deadline that would cancel this healthy, still-progressing pull.
+      for (const _tick of [0, 1, 2]) {
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(cancel).not.toHaveBeenCalled();
+        handlers.change?.forEach((handler) => {
+          handler();
+        });
+      }
+
+      // Once it actually goes silent, the watchdog (now armed from the last 'change') still fires.
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(cancel).toHaveBeenCalledTimes(1);
+
+      storage[Symbol.dispose]();
+      replicateFrom.mockRestore();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('public sync()', () => {
+    it('stops the live push and scheduled pulling before starting a bidirectional sync, instead of running both', async () => {
+      const pushCancel = vi.fn();
+      const replicateTo = vi.spyOn(localDb.replicate, 'to').mockReturnValue({
+        on: vi.fn(),
+        removeListener: vi.fn(),
+        cancel: pushCancel,
+      } as unknown as ReturnType<typeof localDb.replicate.to>);
+      const replicateFrom = vi.spyOn(localDb.replicate, 'from');
+
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'interval', intervalMs: 20, refreshOnFocus: false },
+      });
+
+      await storage.initialize();
+      const pullCallsBeforeSync = replicateFrom.mock.calls.length;
+
+      storage.sync();
+      // The explicit sync() call replaces the non-live scaffolding it superseded, not join it.
+      expect(pushCancel).toHaveBeenCalledTimes(1);
+
+      // Several scheduled-interval ticks worth of time pass - if the schedule weren't actually
+      // stopped, this would keep calling replicate.from alongside the new bidirectional sync.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(replicateFrom.mock.calls.length).toBe(pullCallsBeforeSync);
+
+      storage[Symbol.dispose]();
+      replicateTo.mockRestore();
+      replicateFrom.mockRestore();
+    });
   });
 });

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -41,7 +41,7 @@ describe('PouchDbSyncStorage', () => {
       storage[Symbol.dispose]();
     });
 
-    it("surfaces a remote-only write via a scheduled pull, without needing a continuous pull connection", async () => {
+    it('surfaces a remote-only write via a scheduled pull, without needing a continuous pull connection', async () => {
       const storage = new PouchDbSyncStorage({
         localDb: { name_or_instance: localDb },
         remoteDb: { name_or_instance: remoteDb },
@@ -89,6 +89,70 @@ describe('PouchDbSyncStorage', () => {
       );
 
       subscription.unsubscribe();
+      storage[Symbol.dispose]();
+    });
+  });
+
+  describe('pull.mode "visible-interval"', () => {
+    const setVisibility = (state: DocumentVisibilityState) => {
+      Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    };
+
+    afterEach(() => {
+      // Other describe blocks in this file assume a visible tab by default.
+      setVisibility('visible');
+    });
+
+    it('skips interval ticks while hidden, then pulls exactly once on returning to visible', async () => {
+      // Captures each replication's registered handlers so the test can drive 'complete'
+      // itself - deterministic, instead of racing real PouchDB I/O against the interval timer.
+      const fakeReplications: Array<{ complete: () => void }> = [];
+      const replicateFrom = vi.spyOn(localDb.replicate, 'from').mockImplementation(() => {
+        const handlers: Record<string, Array<() => void>> = {};
+        const replication = {
+          on: vi.fn((event: string, handler: () => void) => {
+            if (!handlers[event]) handlers[event] = [];
+            handlers[event].push(handler);
+          }),
+          removeListener: vi.fn(),
+          // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
+          then: vi.fn(),
+          cancel: vi.fn(),
+        };
+        fakeReplications.push({
+          complete: () => {
+            handlers.complete?.forEach((handler) => {
+              handler();
+            });
+          },
+        });
+        return replication as unknown as ReturnType<typeof localDb.replicate.from>;
+      });
+
+      setVisibility('hidden');
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'visible-interval', intervalMs: 20, refreshOnFocus: true },
+      });
+
+      await storage.initialize();
+      expect(replicateFrom).toHaveBeenCalledTimes(1); // the always-runs initial pull
+
+      // Several interval ticks pass while hidden - the schedule should skip every one of them.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(replicateFrom).toHaveBeenCalledTimes(1);
+
+      // Release the initial pull, so the upcoming focus trigger isn't skipped as already in flight.
+      fakeReplications[0].complete();
+
+      setVisibility('visible');
+      // Returning to visible triggers exactly one catch-up pull, not one per missed tick.
+      expect(replicateFrom).toHaveBeenCalledTimes(2);
+
+      replicateFrom.mockRestore();
       storage[Symbol.dispose]();
     });
   });

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -208,9 +208,9 @@ describe('PouchDbSyncStorage', () => {
     it('does not cancel a pull that keeps making progress, only one that goes fully silent', async () => {
       vi.useFakeTimers();
       const cancel = vi.fn();
-      const handlers: Record<string, Array<() => void>> = {};
+      const handlers: Record<string, Array<(change: { docs: unknown[] }) => void>> = {};
       const replication = {
-        on: vi.fn((event: string, handler: () => void) => {
+        on: vi.fn((event: string, handler: (change: { docs: unknown[] }) => void) => {
           if (!handlers[event]) handlers[event] = [];
           handlers[event].push(handler);
         }),
@@ -240,7 +240,9 @@ describe('PouchDbSyncStorage', () => {
         await vi.advanceTimersByTimeAsync(5000);
         expect(cancel).not.toHaveBeenCalled();
         handlers.change?.forEach((handler) => {
-          handler();
+          // PouchDB's real 'change' event always carries a result object - observePouchDbReplicate
+          // (via onChange, also registered on this mock) reads `.docs` off it directly.
+          handler({ docs: [] });
         });
       }
 
@@ -256,13 +258,32 @@ describe('PouchDbSyncStorage', () => {
 
   describe('public sync()', () => {
     it('stops the live push and scheduled pulling before starting a bidirectional sync, instead of running both', async () => {
+      // Fully mocked (push, pull, and sync) so this test never depends on real PouchDB I/O or
+      // has a genuine live sync connection outlive the test - only the teardown wiring is asserted.
+      vi.useFakeTimers();
       const pushCancel = vi.fn();
       const replicateTo = vi.spyOn(localDb.replicate, 'to').mockReturnValue({
         on: vi.fn(),
         removeListener: vi.fn(),
         cancel: pushCancel,
       } as unknown as ReturnType<typeof localDb.replicate.to>);
-      const replicateFrom = vi.spyOn(localDb.replicate, 'from');
+
+      const pullReplication = {
+        on: vi.fn(),
+        removeListener: vi.fn(),
+        // Settles the initial pull immediately, so it never blocks the upcoming sync() call.
+        // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
+        then: vi.fn((onFulfilled: () => void) => onFulfilled()),
+        cancel: vi.fn(),
+      };
+      const replicateFrom = vi
+        .spyOn(localDb.replicate, 'from')
+        .mockReturnValue(pullReplication as unknown as ReturnType<typeof localDb.replicate.from>);
+
+      const sync = { on: vi.fn(), cancel: vi.fn() };
+      const dbSync = vi
+        .spyOn(localDb, 'sync')
+        .mockReturnValue(sync as unknown as ReturnType<typeof localDb.sync>);
 
       const storage = new PouchDbSyncStorage({
         localDb: { name_or_instance: localDb },
@@ -272,20 +293,23 @@ describe('PouchDbSyncStorage', () => {
       });
 
       await storage.initialize();
-      const pullCallsBeforeSync = replicateFrom.mock.calls.length;
+      expect(replicateFrom).toHaveBeenCalledTimes(1); // the always-runs initial pull
 
       storage.sync();
       // The explicit sync() call replaces the non-live scaffolding it superseded, not join it.
       expect(pushCancel).toHaveBeenCalledTimes(1);
+      expect(dbSync).toHaveBeenCalledTimes(1);
 
       // Several scheduled-interval ticks worth of time pass - if the schedule weren't actually
       // stopped, this would keep calling replicate.from alongside the new bidirectional sync.
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(replicateFrom.mock.calls.length).toBe(pullCallsBeforeSync);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(replicateFrom).toHaveBeenCalledTimes(1);
 
       storage[Symbol.dispose]();
       replicateTo.mockRestore();
       replicateFrom.mockRestore();
+      dbSync.mockRestore();
+      vi.useRealTimers();
     });
   });
 });

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PouchDbStorage } from '../storage/PouchDbStorage.js';
+import { PouchDbSyncStorage } from '../storage/PouchDbSyncStorage.js';
+import { StateSyncEvent, type StateEventType } from '../events/index.js';
+import type { StateSyncPollEvent } from '../events/StateSyncPollEvent.js';
+
+describe('PouchDbSyncStorage', () => {
+  let localDb: PouchDB.Database;
+  let remoteDb: PouchDB.Database;
+
+  beforeEach(() => {
+    localDb = PouchDbStorage.CreateDb('test-sync-local');
+    remoteDb = PouchDbStorage.CreateDb('test-sync-remote');
+  });
+
+  afterEach(async () => {
+    await Promise.all([localDb.destroy(), remoteDb.destroy()]);
+  });
+
+  describe('pull.mode "interval"', () => {
+    it('keeps push live (local writes reach the remote) while scheduling pulls on a timer', async () => {
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'interval', intervalMs: 20, refreshOnFocus: false },
+      });
+
+      await storage.initialize();
+      await storage.putItem({ key: 'push-test', value: 'from-local' });
+
+      // Push stays live, so the local write should reach the remote without waiting for the pull timer.
+      await vi.waitFor(
+        async () => {
+          const remoteDoc = await remoteDb.get('push-test').catch(() => undefined);
+          expect(remoteDoc?.value).toBe('from-local');
+        },
+        { timeout: 2000 },
+      );
+
+      storage[Symbol.dispose]();
+    });
+
+    it("surfaces a remote-only write via a scheduled pull, without needing a continuous pull connection", async () => {
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'interval', intervalMs: 20, refreshOnFocus: false },
+      });
+
+      await storage.initialize();
+      await remoteDb.put({ _id: 'pull-test', value: 'from-remote' });
+
+      // The interval-scheduled one-shot pull (not a live connection) should bring this down.
+      await vi.waitFor(
+        async () => {
+          const localItem = await storage.item('pull-test');
+          expect(localItem?.value).toBe('from-remote');
+        },
+        { timeout: 2000 },
+      );
+
+      storage[Symbol.dispose]();
+    });
+
+    it('dispatches a "onStateSync.poll" event for the initial pull, distinct from status/complete', async () => {
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'interval', intervalMs: 500, refreshOnFocus: false },
+      });
+
+      const events: StateEventType[] = [];
+      const subscription = storage.events$.subscribe((event) => events.push(event));
+
+      await storage.initialize();
+
+      // `_initialize()` runs an immediate first pull before the interval ever fires.
+      await vi.waitFor(
+        () => {
+          const initialPoll = events
+            // Fires even if the poll finds nothing new, unlike PouchDB's own active/paused events.
+            .find((event): event is StateSyncPollEvent => StateSyncEvent.Poll.is(event));
+          expect(initialPoll?.detail).toEqual({ trigger: 'initial', skipped: false });
+        },
+        { timeout: 2000 },
+      );
+
+      subscription.unsubscribe();
+      storage[Symbol.dispose]();
+    });
+  });
+
+  describe('pull watchdog', () => {
+    it('cancels a hung pull replication and releases it for the next scheduled pull', async () => {
+      vi.useFakeTimers();
+      // A stub that never fires 'complete'/'error' and never settles its thenable -
+      // the exact failure mode the watchdog exists to recover from.
+      const cancel = vi.fn();
+      // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
+      const hungReplication = { on: vi.fn(), then: vi.fn(), cancel };
+      const replicateFrom = vi
+        .spyOn(localDb.replicate, 'from')
+        .mockReturnValue(hungReplication as unknown as ReturnType<typeof localDb.replicate.from>);
+
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: { timeout: 1000 },
+        pull: { mode: 'interval', intervalMs: 10000, refreshOnFocus: false },
+      });
+
+      const events: StateEventType[] = [];
+      const subscription = storage.events$.subscribe((event) => events.push(event));
+
+      await storage.initialize();
+      expect(cancel).not.toHaveBeenCalled();
+
+      // watchdogMs is syncOptions.timeout (1000) + 5000.
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(cancel).toHaveBeenCalledTimes(1);
+
+      // If the watchdog hadn't released `#pullInFlight`, this next interval tick would
+      // report `skipped: true` instead of starting a second real pull attempt.
+      await vi.advanceTimersByTimeAsync(4000);
+      const pollDetails = events
+        .filter((event): event is StateSyncPollEvent => StateSyncEvent.Poll.is(event))
+        .map((event) => event.detail);
+      expect(pollDetails).toEqual([
+        { trigger: 'initial', skipped: false },
+        { trigger: 'interval', skipped: false },
+      ]);
+
+      subscription.unsubscribe();
+      storage[Symbol.dispose]();
+      replicateFrom.mockRestore();
+      vi.useRealTimers();
+    });
+  });
+});

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -312,4 +312,40 @@ describe('PouchDbSyncStorage', () => {
       vi.useRealTimers();
     });
   });
+
+  describe('disposal', () => {
+    it('stops the scheduled pull interval even when disposed while a pull is still in flight', async () => {
+      vi.useFakeTimers();
+      // Never fires 'complete'/'error' and never settles its thenable, so it's still "in
+      // flight" - and its teardown callback still registered - at the moment of disposal.
+      const cancel = vi.fn();
+      // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
+      const hungReplication = { on: vi.fn(), removeListener: vi.fn(), then: vi.fn(), cancel };
+      const replicateFrom = vi
+        .spyOn(localDb.replicate, 'from')
+        .mockReturnValue(hungReplication as unknown as ReturnType<typeof localDb.replicate.from>);
+
+      const storage = new PouchDbSyncStorage({
+        localDb: { name_or_instance: localDb },
+        remoteDb: { name_or_instance: remoteDb },
+        syncOptions: {},
+        pull: { mode: 'interval', intervalMs: 1000, refreshOnFocus: false },
+      });
+
+      await storage.initialize();
+      expect(replicateFrom).toHaveBeenCalledTimes(1); // the initial pull, still in flight
+
+      // Disposing while a pull is in flight runs its teardown (cancel + finish) mid-iteration
+      // over the same teardown collection the interval's own `clearInterval` teardown lives in -
+      // if that iteration skipped an entry, the interval would keep firing after this.
+      storage[Symbol.dispose]();
+      expect(cancel).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(replicateFrom).toHaveBeenCalledTimes(1);
+
+      replicateFrom.mockRestore();
+      vi.useRealTimers();
+    });
+  });
 });

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -109,9 +109,9 @@ describe('PouchDbSyncStorage', () => {
       // itself - deterministic, instead of racing real PouchDB I/O against the interval timer.
       const fakeReplications: Array<{ complete: () => void }> = [];
       const replicateFrom = vi.spyOn(localDb.replicate, 'from').mockImplementation(() => {
-        const handlers: Record<string, Array<() => void>> = {};
+        const handlers: Record<string, Array<(change: { docs: unknown[] }) => void>> = {};
         const replication = {
-          on: vi.fn((event: string, handler: () => void) => {
+          on: vi.fn((event: string, handler: (change: { docs: unknown[] }) => void) => {
             if (!handlers[event]) handlers[event] = [];
             handlers[event].push(handler);
           }),
@@ -122,8 +122,10 @@ describe('PouchDbSyncStorage', () => {
         };
         fakeReplications.push({
           complete: () => {
+            // PouchDB's real 'complete' event always carries a result object - onComplete
+            // (observe-pouch-db-replicate.ts) reads `.docs` off it directly.
             handlers.complete?.forEach((handler) => {
-              handler();
+              handler({ docs: [] });
             });
           },
         });

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -100,7 +100,7 @@ describe('PouchDbSyncStorage', () => {
       // the exact failure mode the watchdog exists to recover from.
       const cancel = vi.fn();
       // biome-ignore lint/suspicious/noThenProperty: mocking PouchDB's Replication, which is genuinely thenable.
-      const hungReplication = { on: vi.fn(), then: vi.fn(), cancel };
+      const hungReplication = { on: vi.fn(), removeListener: vi.fn(), then: vi.fn(), cancel };
       const replicateFrom = vi
         .spyOn(localDb.replicate, 'from')
         .mockReturnValue(hungReplication as unknown as ReturnType<typeof localDb.replicate.from>);

--- a/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
+++ b/packages/modules/state/src/__tests__/PouchDbSyncStorage.test.ts
@@ -280,7 +280,7 @@ describe('PouchDbSyncStorage', () => {
         .spyOn(localDb.replicate, 'from')
         .mockReturnValue(pullReplication as unknown as ReturnType<typeof localDb.replicate.from>);
 
-      const sync = { on: vi.fn(), cancel: vi.fn() };
+      const sync = { on: vi.fn(), removeListener: vi.fn(), cancel: vi.fn() };
       const dbSync = vi
         .spyOn(localDb, 'sync')
         .mockReturnValue(sync as unknown as ReturnType<typeof localDb.sync>);

--- a/packages/modules/state/src/create-default-storage.ts
+++ b/packages/modules/state/src/create-default-storage.ts
@@ -14,7 +14,7 @@ import type {
 } from '@equinor/fusion-framework-module-service-discovery';
 
 import { PouchDbStorage, PouchDbSyncStorage } from './storage/index.js';
-import type { IStorage } from './storage/index.js';
+import type { IStorage, PouchDbSyncPullOptions } from './storage/index.js';
 
 /** Local PouchDB database name used when no `setStorage` was configured. */
 const DEFAULT_DB_NAME = 'app_state';
@@ -100,8 +100,10 @@ async function resolveHttpClientProvider(
  * Default {@link IStorage} used by the state module when the consumer never calls
  * `setStorage`, scoped to the `name` set via `setName`. Builds a local PouchDB database
  * and, when a `serviceDiscovery` module is available (locally or on the hosting `ref`
- * instance), upgrades it to two-way sync with the Fusion App State backend (a per-user
- * CouchDB reverse proxy resolved under the `app-state` service key).
+ * instance), upgrades it to sync with the Fusion App State backend (a per-user CouchDB
+ * reverse proxy resolved under the `app-state` service key): local writes push live, and
+ * remote changes are pulled once a minute and on tab focus rather than over a continuous
+ * live connection - see `PouchDbSyncStorage`'s `pull` option.
  *
  * @remarks
  * The Fusion App State backend's published OpenAPI spec only documents its management
@@ -115,12 +117,15 @@ async function resolveHttpClientProvider(
  * @param name - The caller-supplied identity (e.g. app key) used to scope local keys
  * and the remote sync path. Required so unrelated callers never share state.
  * @param init - Module resolution context, used to discover `serviceDiscovery` and `http`.
+ * @param pull - Overrides for the default pull scheduling (e.g. a shorter `intervalMs` for
+ * local preview/testing) - merged over the production default, not replacing it wholesale.
  * @returns The resolved default storage.
  * @throws Never - internal resolution failures are caught and result in a local-only fallback.
  */
 export async function createDefaultStorage(
   name: string,
   init: ConfigBuilderCallbackArgs,
+  pull?: PouchDbSyncPullOptions,
 ): Promise<IStorage> {
   const serviceDiscovery = await resolveServiceDiscovery(init);
   // Sync can't be resolved without service discovery; fall back to local-only storage.
@@ -155,10 +160,14 @@ export async function createDefaultStorage(
         // GET/PUT existence-check dance, which the passthrough answers with 400.
         options: { fetch: createHttpClientFetch(httpClient), skip_setup: true },
       },
-      // continuous replication - PouchDB owns reconnect/backoff for its whole lifetime,
-      // rather than us restarting it on focus/online triggers and never letting a batch's
-      // checkpoint persist.
+      // base options shared by push and the one-shot pulls below - `live`/`retry` apply
+      // as-is to the (always-live) push, `_pullOnce` overrides `live: false, retry: false`.
       syncOptions: { live: true, retry: true },
+      // At production user counts, a continuous pull connection per idle tab is a lot of
+      // concurrently open sockets for a direction that's rarely needed in real time - push
+      // stays live so local writes are never delayed, pull just polls instead, and pauses
+      // entirely while the tab is hidden.
+      pull: { mode: 'visible-interval', refreshOnFocus: true, ...pull },
     });
   } catch (error) {
     // The `app-state` service may not be registered (e.g. in local/dev environments) -

--- a/packages/modules/state/src/events/StateSyncPollEvent.ts
+++ b/packages/modules/state/src/events/StateSyncPollEvent.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview State sync poll event implementation
+ */
+
+import { FrameworkEvent, type FrameworkEventInit } from '@equinor/fusion-framework-module-event';
+
+/** What triggered a one-shot pull under `PouchDbSyncStorage`'s non-`'live'` pull modes. */
+export type StateSyncPollTrigger = 'initial' | 'interval' | 'focus';
+
+/**
+ * Initialization parameters for sync poll events.
+ */
+export type StateSyncPollEventInit = FrameworkEventInit<{
+  /** Unique identifier for the sync event */
+  id?: string;
+  /** What triggered this poll: the initial pull, the recurring timer, or tab/window focus */
+  trigger: StateSyncPollTrigger;
+  /** True when a pull was already in flight and this trigger was dropped instead of overlapping */
+  skipped: boolean;
+}>;
+
+/**
+ * Event dispatched every time `PouchDbSyncStorage` polls for remote changes in a non-`'live'`
+ * pull mode - on the initial pull, each `intervalMs` timer tick, and whenever the tab regains
+ * visibility. Unlike `onStateSync.status`, this fires even when the
+ * poll finds nothing new to pull, so a monitor can confirm scheduled polling is actually running.
+ *
+ * @example
+ * ```typescript
+ * eventBus.on('onStateSync.poll', (event) => {
+ *   if (event instanceof StateSyncPollEvent) {
+ *     console.log('Polled for changes:', event.detail.trigger, event.detail.skipped);
+ *   }
+ * });
+ * ```
+ */
+export class StateSyncPollEvent extends FrameworkEvent<StateSyncPollEventInit> {
+  static readonly Type = 'onStateSync.poll' as const;
+
+  /**
+   * Determines whether an unknown value is a state synchronization poll event.
+   * @param event - Value to inspect.
+   * @returns Whether the value is a state synchronization poll event.
+   */
+  static is(event: unknown): event is StateSyncPollEvent {
+    // Accept actual event instances before checking structurally compatible values.
+    if (event instanceof StateSyncPollEvent) {
+      return true;
+    }
+    // Support events crossing package or serialization boundaries.
+    if (typeof event === 'object' && event !== null) {
+      const eventObj = event as Record<PropertyKey, unknown>;
+      return eventObj.type === StateSyncPollEvent.Type && 'detail' in eventObj;
+    }
+    return false;
+  }
+
+  /**
+   * Creates a new StateSyncPollEvent instance.
+   *
+   * @param args - Initialization arguments describing the poll trigger and outcome
+   */
+  constructor(args: StateSyncPollEventInit) {
+    super(StateSyncPollEvent.Type, args);
+  }
+}
+
+declare module '@equinor/fusion-framework-module-event' {
+  interface FrameworkEventMap {
+    'onStateSync.poll': StateSyncPollEvent;
+  }
+}

--- a/packages/modules/state/src/events/index.ts
+++ b/packages/modules/state/src/events/index.ts
@@ -10,6 +10,7 @@ import { StateOperationSuccessEvent } from './StateOperationSuccessEvent.js';
 import { StateSyncChangeEvent } from './StateSyncChangeEvent.js';
 import { StateSyncCompleteEvent } from './StateSyncCompleteEvent.js';
 import { StateSyncErrorEvent } from './StateSyncErrorEvent.js';
+import { StateSyncPollEvent } from './StateSyncPollEvent.js';
 import { StateSyncStatusEvent } from './StateSyncStatusEvent.js';
 import type { StateErrorEvent } from './StateErrorEvent.js';
 
@@ -51,18 +52,21 @@ export const StateSyncEvent = {
   Complete: StateSyncCompleteEvent,
   Error: StateSyncErrorEvent,
   Status: StateSyncStatusEvent,
+  Poll: StateSyncPollEvent,
   is: (
     event: unknown,
   ): event is
     | StateSyncChangeEvent
     | StateSyncCompleteEvent
     | StateSyncErrorEvent
-    | StateSyncStatusEvent => {
+    | StateSyncStatusEvent
+    | StateSyncPollEvent => {
     return (
       StateSyncChangeEvent.is(event) ||
       StateSyncCompleteEvent.is(event) ||
       StateSyncErrorEvent.is(event) ||
-      StateSyncStatusEvent.is(event)
+      StateSyncStatusEvent.is(event) ||
+      StateSyncPollEvent.is(event)
     );
   },
 } as const;
@@ -71,7 +75,8 @@ export type StateSyncEventType<T extends AllowedValue = AllowedValue> =
   | StateSyncChangeEvent<T>
   | StateSyncCompleteEvent<T>
   | StateSyncErrorEvent
-  | StateSyncStatusEvent;
+  | StateSyncStatusEvent
+  | StateSyncPollEvent;
 
 /**
  * Union type representing all possible state operation events.

--- a/packages/modules/state/src/storage/PouchDbStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbStorage.ts
@@ -1168,9 +1168,11 @@ export class PouchDbStorage implements IStorage, Disposable {
    * Cancels change feeds, completes event subjects, and closes connections.
    */
   [Symbol.dispose](): void {
-    // Execute all registered cleanup functions in reverse order
-    // This ensures dependencies are cleaned up in the correct sequence
-    for (const teardown of this.#teardown) {
+    // Snapshot-and-clear rather than iterate `this.#teardown` directly - a teardown can itself
+    // deregister other entries (e.g. `_pullOnce`'s `finish()` removing its own and a sibling
+    // registration), and splicing the array mid-iteration would skip whatever shifted into the
+    // index the iterator already passed.
+    for (const teardown of this.#teardown.splice(0)) {
       teardown();
     }
   }

--- a/packages/modules/state/src/storage/PouchDbSyncStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbSyncStorage.ts
@@ -71,6 +71,10 @@ export class PouchDbSyncStorage extends PouchDbStorage {
   // scheduled pulling first - otherwise it would start a second, competing continuous pull/push
   // alongside them instead of replacing them.
   #stopNonLivePull: VoidFunction | undefined;
+  // Set only while `_pullOnce` has a one-shot pull in flight, so `#stopNonLivePull` can cancel
+  // it too - otherwise a `sync()` call arriving mid-pull would run bidirectional sync alongside
+  // that pull instead of replacing it, until the pull completes or the watchdog forces it closed.
+  #cancelActivePull: VoidFunction | undefined;
 
   /**
    * Creates a synchronized storage adapter.
@@ -99,6 +103,7 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       this.#stopNonLivePull = () => {
         push.cancel();
         stopScheduledPulling();
+        this.#cancelActivePull?.();
       };
     }
   }
@@ -283,14 +288,6 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       value: doc.value,
     })).subscribe({ next: (event) => this._emitEvent(event as StateEventType) });
 
-    // Registered so disposing storage while this pull is mid-flight cancels its request,
-    // listeners, and watchdog instead of leaving them running past the storage's own lifetime.
-    // Deregistered in `finish()` below - `_pullOnce` runs repeatedly for the life of the
-    // storage, so leaving these registered past each pull's own completion would leak one
-    // teardown entry per poll.
-    const removePullTeardown = this._addTeardown(() => pull.cancel());
-    const removeSubscriptionTeardown = this._addTeardown(subscription);
-
     return new Promise((resolve) => {
       let settled = false;
       const finish = (error?: unknown) => {
@@ -303,6 +300,7 @@ export class PouchDbSyncStorage extends PouchDbStorage {
         removePullTeardown();
         removeSubscriptionTeardown();
         this.#pullInFlight = false;
+        this.#cancelActivePull = undefined;
         // Only the rejection branch passes an error - 'complete'/'error' already emitted
         // their own onStateSync.error via observePouchDbReplicate, and the watchdog's forced
         // cancel isn't itself an error worth surfacing again.
@@ -313,6 +311,23 @@ export class PouchDbSyncStorage extends PouchDbStorage {
         }
         resolve();
       };
+
+      // Registered so disposing storage - or `sync()` superseding non-'live' mode - while this
+      // pull is mid-flight runs the same cleanup `finish()` does (clearing the watchdog and
+      // direct listeners below) instead of just cancelling and leaving them alive until the
+      // watchdog fires on its own, possibly after the storage has already been disposed.
+      // Deregistered inside `finish()` - `_pullOnce` runs repeatedly for the life of the storage,
+      // so leaving these registered past each pull's own completion would leak one entry per poll.
+      const removePullTeardown = this._addTeardown(() => {
+        pull.cancel();
+        finish();
+      });
+      const removeSubscriptionTeardown = this._addTeardown(subscription);
+      this.#cancelActivePull = () => {
+        pull.cancel();
+        finish();
+      };
+
       pull.on('complete', () => finish());
       pull.on('error', () => finish());
 

--- a/packages/modules/state/src/storage/PouchDbSyncStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbSyncStorage.ts
@@ -67,6 +67,10 @@ export class PouchDbSyncStorage extends PouchDbStorage {
   // Guards `_schedulePulling()` the same way `#activeSync` guards `sync()` - a running
   // one-shot pull must finish before the next interval/focus trigger starts another.
   #pullInFlight = false;
+  // Set only in non-'live' mode, so an explicit `sync()` call can tear down the live push and
+  // scheduled pulling first - otherwise it would start a second, competing continuous pull/push
+  // alongside them instead of replacing them.
+  #stopNonLivePull: VoidFunction | undefined;
 
   /**
    * Creates a synchronized storage adapter.
@@ -90,8 +94,12 @@ export class PouchDbSyncStorage extends PouchDbStorage {
     if ((this.#pull.mode ?? PullMode.Live) === PullMode.Live) {
       this.sync();
     } else {
-      this._startLivePush();
-      this._schedulePulling();
+      const push = this._startLivePush();
+      const stopScheduledPulling = this._schedulePulling();
+      this.#stopNonLivePull = () => {
+        push.cancel();
+        stopScheduledPulling();
+      };
     }
   }
 
@@ -128,6 +136,12 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       // from this same generic method, so `T` always matches what's actually stored.
       return this.#activeSync as unknown as PouchDB.Replication.Sync<{ value: T }>;
     }
+
+    // An explicit `sync()` call while running in a non-'live' pull mode would otherwise start
+    // a second, competing continuous pull alongside the live push and scheduled one-shot pulls
+    // already in charge of replication - stop them first so this sync replaces, not duplicates.
+    this.#stopNonLivePull?.();
+    this.#stopNonLivePull = undefined;
 
     // Layer defaults under caller options so any other `SyncOptions` field (filter, since,
     // batches_limit, etc.) still reaches PouchDB unmodified.
@@ -315,13 +329,21 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       // PouchDB's own `timeout` option only bounds the underlying `_changes` request, not the
       // full replication (checkpoint read/write, `_revs_diff`, `_bulk_get`) - observed in practice
       // to never emit 'complete'/'error' at all in some cases, wedging #pullInFlight forever.
-      // This watchdog guarantees forward progress regardless of where PouchDB got stuck.
+      // This is an inactivity watchdog, not a total-duration deadline - it's rearmed on every
+      // 'change' batch, so a healthy multi-batch pull can run indefinitely as long as it keeps
+      // making progress; only a replication that goes fully silent gets force-cancelled.
       const watchdogMs =
         (typeof this.#syncOptions.timeout === 'number' ? this.#syncOptions.timeout : 30000) + 5000;
-      const watchdog = setTimeout(() => {
-        pull.cancel();
-        finish();
-      }, watchdogMs);
+      let watchdog: ReturnType<typeof setTimeout>;
+      const armWatchdog = () => {
+        clearTimeout(watchdog);
+        watchdog = setTimeout(() => {
+          pull.cancel();
+          finish();
+        }, watchdogMs);
+      };
+      armWatchdog();
+      pull.on('change', armWatchdog);
     });
   }
 
@@ -330,8 +352,9 @@ export class PouchDbSyncStorage extends PouchDbStorage {
    * pull, then one every `pull.intervalMs` (default 60s) - skipping the tick while the tab is
    * hidden when `mode` is `'visible-interval'` - plus an extra catch-up pull whenever it becomes
    * visible again, when `pull.refreshOnFocus` isn't disabled. Cleaned up automatically on dispose.
+   * @returns A function that stops the schedule immediately, ahead of storage disposal.
    */
-  protected _schedulePulling(): void {
+  protected _schedulePulling(): VoidFunction {
     const intervalMs = this.#pull.intervalMs ?? DEFAULT_PULL_INTERVAL_MS;
     const pauseWhenHidden = this.#pull.mode === PullMode.VisibleInterval;
     const run = (trigger: StateSyncPollTrigger) => {
@@ -352,7 +375,7 @@ export class PouchDbSyncStorage extends PouchDbStorage {
         run('interval');
       }
     }, intervalMs);
-    this._addTeardown(() => clearInterval(timer));
+    const removeTimerTeardown = this._addTeardown(() => clearInterval(timer));
 
     // Skip entirely outside a DOM environment (e.g. SSR) where there's no tab to focus.
     if ((this.#pull.refreshOnFocus ?? true) && typeof document !== 'undefined') {
@@ -367,7 +390,21 @@ export class PouchDbSyncStorage extends PouchDbStorage {
         }
       };
       document.addEventListener('visibilitychange', onVisibilityChange);
-      this._addTeardown(() => document.removeEventListener('visibilitychange', onVisibilityChange));
+      const removeVisibilityTeardown = this._addTeardown(() =>
+        document.removeEventListener('visibilitychange', onVisibilityChange),
+      );
+
+      return () => {
+        clearInterval(timer);
+        removeTimerTeardown();
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        removeVisibilityTeardown();
+      };
     }
+
+    return () => {
+      clearInterval(timer);
+      removeTimerTeardown();
+    };
   }
 }

--- a/packages/modules/state/src/storage/PouchDbSyncStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbSyncStorage.ts
@@ -186,14 +186,19 @@ export class PouchDbSyncStorage extends PouchDbStorage {
    * @template T - State value type.
    * @returns The live push replication handle.
    */
-  protected _startLivePush<T extends AllowedValue = AllowedValue>(): PouchDB.Replication.Replication<{
+  protected _startLivePush<
+    T extends AllowedValue = AllowedValue,
+  >(): PouchDB.Replication.Replication<{
     value: T;
   }> {
-    const push = this._db.replicate.to<{ value: T }>(this.#remoteDb as PouchDB.Database<{ value: T }>, {
-      ...this.#syncOptions,
-      live: true,
-      retry: this.#syncOptions.retry ?? true,
-    });
+    const push = this._db.replicate.to<{ value: T }>(
+      this.#remoteDb as PouchDB.Database<{ value: T }>,
+      {
+        ...this.#syncOptions,
+        live: true,
+        retry: this.#syncOptions.retry ?? true,
+      },
+    );
 
     const subscription = observePouchDbReplicate<T>(push, 'push', (doc) => ({
       _id: doc._id,
@@ -228,19 +233,24 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       return Promise.resolve();
     }
     this.#pullInFlight = true;
-    this._emitEvent(new StateSyncEvent.Poll({ detail: { trigger, skipped: false } }) as StateEventType);
+    this._emitEvent(
+      new StateSyncEvent.Poll({ detail: { trigger, skipped: false } }) as StateEventType,
+    );
 
     let pull: PouchDB.Replication.Replication<{ value: T }>;
     try {
-      pull = this._db.replicate.from<{ value: T }>(this.#remoteDb as PouchDB.Database<{ value: T }>, {
-        ...this.#syncOptions,
-        live: false,
-        retry: false,
-        // Guarantees 'complete'/'error' fires even against a backend that never answers a
-        // one-shot request - otherwise a single hung poll would wedge #pullInFlight forever,
-        // silently turning every later timer/focus trigger into a no-op skip.
-        timeout: this.#syncOptions.timeout ?? 30000,
-      });
+      pull = this._db.replicate.from<{ value: T }>(
+        this.#remoteDb as PouchDB.Database<{ value: T }>,
+        {
+          ...this.#syncOptions,
+          live: false,
+          retry: false,
+          // Guarantees 'complete'/'error' fires even against a backend that never answers a
+          // one-shot request - otherwise a single hung poll would wedge #pullInFlight forever,
+          // silently turning every later timer/focus trigger into a no-op skip.
+          timeout: this.#syncOptions.timeout ?? 30000,
+        },
+      );
     } catch (error) {
       console.error('[state] failed to start one-shot pull replication', error);
       // A synchronous throw here (bad remote config, custom fetch misuse, etc.) would
@@ -259,31 +269,55 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       value: doc.value,
     })).subscribe({ next: (event) => this._emitEvent(event as StateEventType) });
 
+    // Registered so disposing storage while this pull is mid-flight cancels its request,
+    // listeners, and watchdog instead of leaving them running past the storage's own lifetime.
+    // Deregistered in `finish()` below - `_pullOnce` runs repeatedly for the life of the
+    // storage, so leaving these registered past each pull's own completion would leak one
+    // teardown entry per poll.
+    const removePullTeardown = this._addTeardown(() => pull.cancel());
+    const removeSubscriptionTeardown = this._addTeardown(subscription);
+
     return new Promise((resolve) => {
       let settled = false;
-      const finish = () => {
+      const finish = (error?: unknown) => {
         // 'complete'/'error' can both fire in some PouchDB versions, and the watchdog/promise
         // fallbacks below can race with either - only unblock once, whichever gets here first.
         if (settled) return;
         settled = true;
         clearTimeout(watchdog);
         subscription.unsubscribe();
+        removePullTeardown();
+        removeSubscriptionTeardown();
         this.#pullInFlight = false;
+        // Only the rejection branch passes an error - 'complete'/'error' already emitted
+        // their own onStateSync.error via observePouchDbReplicate, and the watchdog's forced
+        // cancel isn't itself an error worth surfacing again.
+        if (error !== undefined) {
+          this._emitEvent(
+            new StateSyncEvent.Error({ detail: { type: 'error', error } }) as StateEventType,
+          );
+        }
         resolve();
       };
-      pull.on('complete', finish);
-      pull.on('error', finish);
+      pull.on('complete', () => finish());
+      pull.on('error', () => finish());
 
       // `Replication` is also thenable (it resolves/rejects the same way `db.sync()`'s
       // `.then()` does) - a fallback for when the 'complete'/'error' *events* themselves
       // don't fire, which has been observed to happen even though the underlying requests succeed.
-      pull.then(finish, finish);
+      // A rejection reaching here (rather than the 'error' event above) would otherwise surface
+      // as a silent no-op - report it as an onStateSync.error instead of discarding the reason.
+      pull.then(
+        () => finish(),
+        (error) => finish(error),
+      );
 
       // PouchDB's own `timeout` option only bounds the underlying `_changes` request, not the
       // full replication (checkpoint read/write, `_revs_diff`, `_bulk_get`) - observed in practice
       // to never emit 'complete'/'error' at all in some cases, wedging #pullInFlight forever.
       // This watchdog guarantees forward progress regardless of where PouchDB got stuck.
-      const watchdogMs = (typeof this.#syncOptions.timeout === 'number' ? this.#syncOptions.timeout : 30000) + 5000;
+      const watchdogMs =
+        (typeof this.#syncOptions.timeout === 'number' ? this.#syncOptions.timeout : 30000) + 5000;
       const watchdog = setTimeout(() => {
         pull.cancel();
         finish();
@@ -310,7 +344,11 @@ export class PouchDbSyncStorage extends PouchDbStorage {
     const timer = setInterval(() => {
       // A backgrounded tab has no user waiting on fresh data - skip the tick rather than
       // hold a connection open for it, and let the visibilitychange catch-up handle it instead.
-      if (!pauseWhenHidden || typeof document === 'undefined' || document.visibilityState === 'visible') {
+      if (
+        !pauseWhenHidden ||
+        typeof document === 'undefined' ||
+        document.visibilityState === 'visible'
+      ) {
         run('interval');
       }
     }, intervalMs);

--- a/packages/modules/state/src/storage/PouchDbSyncStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbSyncStorage.ts
@@ -1,9 +1,46 @@
 import PouchDB from 'pouchdb';
 
-import type { StateEventType } from '../events/index.js';
+import { StateSyncEvent, type StateEventType } from '../events/index.js';
+import type { StateSyncPollTrigger } from '../events/StateSyncPollEvent.js';
 import { observePouchDbSync } from './observe-pouch-db-sync.js';
+import { observePouchDbReplicate } from './observe-pouch-db-replicate.js';
 import { PouchDbStorage, type PouchDbStorageOptions } from './PouchDbStorage.js';
 import type { AllowedValue } from '../types.js';
+
+/** Default `pull.intervalMs` for `PouchDbSyncPullOptions` when `mode` isn't `'live'`. */
+const DEFAULT_PULL_INTERVAL_MS = 60_000;
+
+// Named constants for `PouchDbSyncPullOptions.mode` - kept as plain string values (not a TS
+// `enum`) so the public type stays a string-literal union, still assignable from a raw string.
+const PullMode = {
+  Live: 'live',
+  Interval: 'interval',
+  VisibleInterval: 'visible-interval',
+} as const;
+
+/**
+ * Controls how the remote-to-local (pull) direction of a {@link PouchDbSyncStorage} is
+ * scheduled. Push always stays a continuous, live replication so local writes are never
+ * held back - only pull scheduling is configurable, since it's the direction that keeps a
+ * connection open per idle user regardless of whether they're editing anything.
+ *
+ * @property mode - `'live'` (default) mirrors prior behavior: a single continuous bidirectional
+ * `db.sync()` connection. `'interval'` keeps push live but replaces the continuous pull
+ * connection with a one-shot pull run on a timer, whether or not the tab is visible.
+ * `'visible-interval'` is the same, except the timer tick is skipped entirely while the tab
+ * is hidden - a backgrounded tab has no user waiting on fresh data, so there's no reason to
+ * hold a connection open for it. Either non-`'live'` mode trades real-time cross-tab/device
+ * pull for far fewer concurrently open connections at scale.
+ * @property intervalMs - Milliseconds between one-shot pulls when `mode` isn't `'live'`.
+ * Defaults to 60000 (one minute).
+ * @property refreshOnFocus - Also runs a one-shot pull immediately when the tab regains
+ * visibility, when `mode` isn't `'live'`. Defaults to `true`.
+ */
+export type PouchDbSyncPullOptions = {
+  mode?: (typeof PullMode)[keyof typeof PullMode];
+  intervalMs?: number;
+  refreshOnFocus?: boolean;
+};
 
 type PouchDbSyncStorageOptions = {
   localDb: {
@@ -15,15 +52,21 @@ type PouchDbSyncStorageOptions = {
     options?: PouchDbStorageOptions;
   };
   syncOptions: PouchDB.Replication.SyncOptions;
+  /** Pull-replication scheduling. Omit to keep the default `'live'` behavior. */
+  pull?: PouchDbSyncPullOptions;
 };
 
 /** PouchDB storage adapter that synchronizes a local database with a remote database. */
 export class PouchDbSyncStorage extends PouchDbStorage {
   #remoteDb: PouchDB.Database;
   #syncOptions: PouchDB.Replication.SyncOptions;
+  #pull: PouchDbSyncPullOptions;
   // With a continuous (`live: true`) sync started once from `_initialize()`, this only guards
   // a caller who calls the public `sync()` a second time while one is still active.
   #activeSync: PouchDB.Replication.Sync<{ value: AllowedValue }> | undefined;
+  // Guards `_schedulePulling()` the same way `#activeSync` guards `sync()` - a running
+  // one-shot pull must finish before the next interval/focus trigger starts another.
+  #pullInFlight = false;
 
   /**
    * Creates a synchronized storage adapter.
@@ -36,12 +79,20 @@ export class PouchDbSyncStorage extends PouchDbStorage {
         ? new PouchDB(options.remoteDb.name_or_instance, options.remoteDb.options)
         : options.remoteDb.name_or_instance;
     this.#syncOptions = options.syncOptions;
+    this.#pull = options.pull ?? {};
   }
 
   /** Initializes local storage and starts synchronization. */
   protected _initialize(): void {
     super._initialize();
-    this.sync();
+    // Either non-'live' mode trades the continuous pull connection for live push + scheduled
+    // one-shot pulls - they only differ in whether `_schedulePulling` skips hidden-tab ticks.
+    if ((this.#pull.mode ?? PullMode.Live) === PullMode.Live) {
+      this.sync();
+    } else {
+      this._startLivePush();
+      this._schedulePulling();
+    }
   }
 
   /**
@@ -126,5 +177,159 @@ export class PouchDbSyncStorage extends PouchDbStorage {
     this._addTeardown(subscription);
 
     return sync;
+  }
+
+  /**
+   * Starts a continuous, live push replication (local to remote only). Used instead of
+   * `sync()` when `pull.mode` is `'interval'`, so local writes still replicate out immediately
+   * without keeping a matching continuous pull connection open.
+   * @template T - State value type.
+   * @returns The live push replication handle.
+   */
+  protected _startLivePush<T extends AllowedValue = AllowedValue>(): PouchDB.Replication.Replication<{
+    value: T;
+  }> {
+    const push = this._db.replicate.to<{ value: T }>(this.#remoteDb as PouchDB.Database<{ value: T }>, {
+      ...this.#syncOptions,
+      live: true,
+      retry: this.#syncOptions.retry ?? true,
+    });
+
+    const subscription = observePouchDbReplicate<T>(push, 'push', (doc) => ({
+      _id: doc._id,
+      key: this._extractKey(doc._id),
+      value: doc.value,
+    })).subscribe({ next: (event) => this._emitEvent(event as StateEventType) });
+
+    this._addTeardown(() => push.cancel());
+    this._addTeardown(subscription);
+
+    return push;
+  }
+
+  /**
+   * Runs a single one-shot pull replication (remote to local only) and resolves once it
+   * completes. Skips starting a new pull while one is already in flight, mirroring how
+   * `sync()` avoids overlapping bidirectional syncs. Either way, dispatches `onStateSync.poll`
+   * so a monitor can observe that scheduled polling is actually running.
+   * @template T - State value type.
+   * @param trigger - What caused this poll: the initial pull, the interval timer, or tab/window focus.
+   * @returns Resolves once the pull replication completes, or immediately if one was already running.
+   */
+  protected _pullOnce<T extends AllowedValue = AllowedValue>(
+    trigger: StateSyncPollTrigger = 'interval',
+  ): Promise<void> {
+    // A running pull already covers whatever a second trigger (timer firing mid-pull,
+    // or focus regained during a scheduled pull) would ask for - skip instead of overlapping.
+    if (this.#pullInFlight) {
+      this._emitEvent(
+        new StateSyncEvent.Poll({ detail: { trigger, skipped: true } }) as StateEventType,
+      );
+      return Promise.resolve();
+    }
+    this.#pullInFlight = true;
+    this._emitEvent(new StateSyncEvent.Poll({ detail: { trigger, skipped: false } }) as StateEventType);
+
+    let pull: PouchDB.Replication.Replication<{ value: T }>;
+    try {
+      pull = this._db.replicate.from<{ value: T }>(this.#remoteDb as PouchDB.Database<{ value: T }>, {
+        ...this.#syncOptions,
+        live: false,
+        retry: false,
+        // Guarantees 'complete'/'error' fires even against a backend that never answers a
+        // one-shot request - otherwise a single hung poll would wedge #pullInFlight forever,
+        // silently turning every later timer/focus trigger into a no-op skip.
+        timeout: this.#syncOptions.timeout ?? 30000,
+      });
+    } catch (error) {
+      console.error('[state] failed to start one-shot pull replication', error);
+      // A synchronous throw here (bad remote config, custom fetch misuse, etc.) would
+      // otherwise never reach the 'error' handler below, wedging #pullInFlight forever -
+      // every later trigger would then silently report `skipped: true` with no network call.
+      this.#pullInFlight = false;
+      this._emitEvent(
+        new StateSyncEvent.Error({ detail: { type: 'error', error } }) as StateEventType,
+      );
+      return Promise.reject(error);
+    }
+
+    const subscription = observePouchDbReplicate<T>(pull, 'pull', (doc) => ({
+      _id: doc._id,
+      key: this._extractKey(doc._id),
+      value: doc.value,
+    })).subscribe({ next: (event) => this._emitEvent(event as StateEventType) });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        // 'complete'/'error' can both fire in some PouchDB versions, and the watchdog/promise
+        // fallbacks below can race with either - only unblock once, whichever gets here first.
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        subscription.unsubscribe();
+        this.#pullInFlight = false;
+        resolve();
+      };
+      pull.on('complete', finish);
+      pull.on('error', finish);
+
+      // `Replication` is also thenable (it resolves/rejects the same way `db.sync()`'s
+      // `.then()` does) - a fallback for when the 'complete'/'error' *events* themselves
+      // don't fire, which has been observed to happen even though the underlying requests succeed.
+      pull.then(finish, finish);
+
+      // PouchDB's own `timeout` option only bounds the underlying `_changes` request, not the
+      // full replication (checkpoint read/write, `_revs_diff`, `_bulk_get`) - observed in practice
+      // to never emit 'complete'/'error' at all in some cases, wedging #pullInFlight forever.
+      // This watchdog guarantees forward progress regardless of where PouchDB got stuck.
+      const watchdogMs = (typeof this.#syncOptions.timeout === 'number' ? this.#syncOptions.timeout : 30000) + 5000;
+      const watchdog = setTimeout(() => {
+        pull.cancel();
+        finish();
+      }, watchdogMs);
+    });
+  }
+
+  /**
+   * Schedules recurring one-shot pulls in place of a continuous pull connection: an immediate
+   * pull, then one every `pull.intervalMs` (default 60s) - skipping the tick while the tab is
+   * hidden when `mode` is `'visible-interval'` - plus an extra catch-up pull whenever it becomes
+   * visible again, when `pull.refreshOnFocus` isn't disabled. Cleaned up automatically on dispose.
+   */
+  protected _schedulePulling(): void {
+    const intervalMs = this.#pull.intervalMs ?? DEFAULT_PULL_INTERVAL_MS;
+    const pauseWhenHidden = this.#pull.mode === PullMode.VisibleInterval;
+    const run = (trigger: StateSyncPollTrigger) => {
+      this._pullOnce(trigger).catch(() => {
+        // Errors already surface as `onStateSync.error` events via `_pullOnce`'s subscription.
+      });
+    };
+
+    run('initial');
+    const timer = setInterval(() => {
+      // A backgrounded tab has no user waiting on fresh data - skip the tick rather than
+      // hold a connection open for it, and let the visibilitychange catch-up handle it instead.
+      if (!pauseWhenHidden || typeof document === 'undefined' || document.visibilityState === 'visible') {
+        run('interval');
+      }
+    }, intervalMs);
+    this._addTeardown(() => clearInterval(timer));
+
+    // Skip entirely outside a DOM environment (e.g. SSR) where there's no tab to focus.
+    if ((this.#pull.refreshOnFocus ?? true) && typeof document !== 'undefined') {
+      // Catch up immediately when the user comes back to the tab, instead of waiting for the timer.
+      // Deliberately the Page Visibility API only, not `window`'s `focus`/`blur` - apps here run
+      // embedded in the portal's iframe, where focus/blur fire on frame-boundary changes (e.g.
+      // clicking portal chrome) unrelated to the tab actually being left and returned to.
+      const onVisibilityChange = () => {
+        // Ignore the tab being hidden - only a return to visible warrants an extra pull.
+        if (document.visibilityState === 'visible') {
+          run('focus');
+        }
+      };
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      this._addTeardown(() => document.removeEventListener('visibilitychange', onVisibilityChange));
+    }
   }
 }

--- a/packages/modules/state/src/storage/PouchDbSyncStorage.ts
+++ b/packages/modules/state/src/storage/PouchDbSyncStorage.ts
@@ -199,6 +199,21 @@ export class PouchDbSyncStorage extends PouchDbStorage {
   }
 
   /**
+   * Merges the top-level sync options with PouchDB's own direction-specific override
+   * (`syncOptions.push`/`syncOptions.pull`), the same way `db.sync()` applies them internally.
+   * Used by `_startLivePush`/`_pullOnce`, which replace `db.sync()` with separate
+   * `replicate.to`/`replicate.from` calls in non-'live' pull modes and would otherwise silently
+   * drop a caller's per-direction filter, query params, or timeout.
+   * @param direction - Which override to layer on top of the shared options.
+   * @returns Effective options for a single-direction `replicate.to`/`replicate.from` call.
+   */
+  #effectiveReplicateOptions(direction: 'push' | 'pull'): PouchDB.Replication.ReplicateOptions {
+    const { push, pull, ...shared } = this.#syncOptions;
+    // Direction override layered last, matching db.sync()'s own precedence.
+    return { ...shared, ...(direction === 'push' ? push : pull) };
+  }
+
+  /**
    * Starts a continuous, live push replication (local to remote only). Used instead of
    * `sync()` when `pull.mode` is `'interval'`, so local writes still replicate out immediately
    * without keeping a matching continuous pull connection open.
@@ -210,12 +225,13 @@ export class PouchDbSyncStorage extends PouchDbStorage {
   >(): PouchDB.Replication.Replication<{
     value: T;
   }> {
+    const pushOptions = this.#effectiveReplicateOptions('push');
     const push = this._db.replicate.to<{ value: T }>(
       this.#remoteDb as PouchDB.Database<{ value: T }>,
       {
-        ...this.#syncOptions,
+        ...pushOptions,
         live: true,
-        retry: this.#syncOptions.retry ?? true,
+        retry: pushOptions.retry ?? true,
       },
     );
 
@@ -257,17 +273,19 @@ export class PouchDbSyncStorage extends PouchDbStorage {
     );
 
     let pull: PouchDB.Replication.Replication<{ value: T }>;
+    const pullOptions = this.#effectiveReplicateOptions('pull');
+    const pullTimeout = pullOptions.timeout ?? 30000;
     try {
       pull = this._db.replicate.from<{ value: T }>(
         this.#remoteDb as PouchDB.Database<{ value: T }>,
         {
-          ...this.#syncOptions,
+          ...pullOptions,
           live: false,
           retry: false,
           // Guarantees 'complete'/'error' fires even against a backend that never answers a
           // one-shot request - otherwise a single hung poll would wedge #pullInFlight forever,
           // silently turning every later timer/focus trigger into a no-op skip.
-          timeout: this.#syncOptions.timeout ?? 30000,
+          timeout: pullTimeout,
         },
       );
     } catch (error) {
@@ -347,10 +365,13 @@ export class PouchDbSyncStorage extends PouchDbStorage {
       // This is an inactivity watchdog, not a total-duration deadline - it's rearmed on every
       // 'change' batch, so a healthy multi-batch pull can run indefinitely as long as it keeps
       // making progress; only a replication that goes fully silent gets force-cancelled.
-      const watchdogMs =
-        (typeof this.#syncOptions.timeout === 'number' ? this.#syncOptions.timeout : 30000) + 5000;
+      const watchdogMs = (typeof pullTimeout === 'number' ? pullTimeout : 30000) + 5000;
       let watchdog: ReturnType<typeof setTimeout>;
       const armWatchdog = () => {
+        // A 'change' event already dispatching when `finish()` runs elsewhere in the same tick
+        // (e.g. a subscriber disposing the storage synchronously) would otherwise revive the
+        // watchdog right after cleanup cleared it - once settled, this must stay a no-op.
+        if (settled) return;
         clearTimeout(watchdog);
         watchdog = setTimeout(() => {
           pull.cancel();

--- a/packages/modules/state/src/storage/index.ts
+++ b/packages/modules/state/src/storage/index.ts
@@ -1,6 +1,6 @@
 export { PouchDbStorage, type PouchDbStorageOptions } from './PouchDbStorage.js';
 
-export { PouchDbSyncStorage } from './PouchDbSyncStorage.js';
+export { PouchDbSyncStorage, type PouchDbSyncPullOptions } from './PouchDbSyncStorage.js';
 
 export { StorageError } from './StorageError.js';
 

--- a/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
+++ b/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
@@ -29,7 +29,8 @@ export function observePouchDbReplicate<T extends AllowedValue = AllowedValue>(
   parse_docs: (doc: PouchDB.Core.ExistingDocument<{ value: T }>) => StorageItem<T>,
 ): Observable<StateSyncEventType<T>> {
   const parse_replication_result = (change: PouchDB.Replication.ReplicationResult<{ value: T }>) => ({
-    items: change.docs
+    // A cancelled (e.g. watchdog-forced) replication fires 'complete' with no `docs` at all.
+    items: (change.docs ?? [])
       // Convert replicated documents to the storage item shape expected by state events.
       .map((doc) => parse_docs(doc)),
     item_written: change.docs_written,

--- a/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
+++ b/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
@@ -28,7 +28,9 @@ export function observePouchDbReplicate<T extends AllowedValue = AllowedValue>(
   direction: 'push' | 'pull',
   parse_docs: (doc: PouchDB.Core.ExistingDocument<{ value: T }>) => StorageItem<T>,
 ): Observable<StateSyncEventType<T>> {
-  const parse_replication_result = (change: PouchDB.Replication.ReplicationResult<{ value: T }>) => ({
+  const parse_replication_result = (
+    change: PouchDB.Replication.ReplicationResult<{ value: T }>,
+  ) => ({
     // A cancelled (e.g. watchdog-forced) replication fires 'complete' with no `docs` at all.
     items: (change.docs ?? [])
       // Convert replicated documents to the storage item shape expected by state events.
@@ -44,7 +46,9 @@ export function observePouchDbReplicate<T extends AllowedValue = AllowedValue>(
   return new Observable<StateSyncEventType<T>>((subscriber) => {
     const onChange = (change: PouchDB.Replication.ReplicationResult<{ value: T }>) => {
       subscriber.next(
-        new StateSyncEvent.Change<T>({ detail: { direction, change: parse_replication_result(change) } }),
+        new StateSyncEvent.Change<T>({
+          detail: { direction, change: parse_replication_result(change) },
+        }),
       );
     };
     const onComplete = (change: PouchDB.Replication.ReplicationResultComplete<{ value: T }>) => {

--- a/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
+++ b/packages/modules/state/src/storage/observe-pouch-db-replicate.ts
@@ -1,0 +1,89 @@
+import { Observable } from 'rxjs';
+import type { AllowedValue } from '../types.js';
+import type { StorageItem } from './types.js';
+import { StateSyncEvent, type StateSyncEventType } from '../events/index.js';
+
+/**
+ * Observes a single-direction PouchDB replication (`db.replicate.to`/`db.replicate.from`) and
+ * converts its events into the same `StateSyncEvent` shape used for bidirectional `db.sync()`.
+ *
+ * Unlike {@link observePouchDbSync}, the replication direction is fixed for the lifetime of the
+ * observed stream rather than read off each change event, since a one-directional `Replication`
+ * only ever reports changes for that direction.
+ *
+ * @template T - The type of values being replicated, constrained to AllowedValue types
+ * @param replication - The PouchDB replication object (`replicate.to` or `replicate.from` result)
+ * @param direction - Whether this replication pushes local changes out or pulls remote changes in
+ * @param parse_docs - Function to transform PouchDB documents into StorageItem objects
+ * @returns An Observable that emits StateSyncEventType events for this replication direction
+ *
+ * @example
+ * ```typescript
+ * const push = localDb.replicate.to(remoteDb, { live: true, retry: true });
+ * const pushEvent$ = observePouchDbReplicate(push, 'push', (doc) => ({ key: doc._id, value: doc.value }));
+ * ```
+ */
+export function observePouchDbReplicate<T extends AllowedValue = AllowedValue>(
+  replication: PouchDB.Replication.Replication<{ value: T }>,
+  direction: 'push' | 'pull',
+  parse_docs: (doc: PouchDB.Core.ExistingDocument<{ value: T }>) => StorageItem<T>,
+): Observable<StateSyncEventType<T>> {
+  const parse_replication_result = (change: PouchDB.Replication.ReplicationResult<{ value: T }>) => ({
+    items: change.docs
+      // Convert replicated documents to the storage item shape expected by state events.
+      .map((doc) => parse_docs(doc)),
+    item_written: change.docs_written,
+    item_read: change.docs_read,
+    items_write_failures: change.doc_write_failures,
+    start_time: change.start_time,
+    ok: change.ok,
+    errors: change.errors,
+  });
+
+  return new Observable<StateSyncEventType<T>>((subscriber) => {
+    const onChange = (change: PouchDB.Replication.ReplicationResult<{ value: T }>) => {
+      subscriber.next(
+        new StateSyncEvent.Change<T>({ detail: { direction, change: parse_replication_result(change) } }),
+      );
+    };
+    const onComplete = (change: PouchDB.Replication.ReplicationResultComplete<{ value: T }>) => {
+      subscriber.next(
+        new StateSyncEvent.Complete<T>({
+          detail: {
+            result: {
+              [direction]: { ...parse_replication_result(change), status: change.status },
+            },
+          },
+        }),
+      );
+    };
+    const onError = (error: unknown) => {
+      subscriber.next(new StateSyncEvent.Error({ detail: { type: 'error', error } }));
+    };
+    const onDenied = (error: unknown) => {
+      subscriber.next(new StateSyncEvent.Error({ detail: { type: 'denied', error } }));
+    };
+    const onPaused = () => {
+      subscriber.next(new StateSyncEvent.Status({ detail: { status: 'paused' } }));
+    };
+    const onActive = () => {
+      subscriber.next(new StateSyncEvent.Status({ detail: { status: 'active' } }));
+    };
+    replication.on('change', onChange);
+    replication.on('complete', onComplete);
+    replication.on('error', onError);
+    replication.on('denied', onDenied);
+    replication.on('paused', onPaused);
+    replication.on('active', onActive);
+    return () => {
+      replication.removeListener('change', onChange);
+      replication.removeListener('complete', onComplete);
+      replication.removeListener('error', onError);
+      replication.removeListener('denied', onDenied);
+      replication.removeListener('paused', onPaused);
+      replication.removeListener('active', onActive);
+    };
+  });
+}
+
+export default observePouchDbReplicate;


### PR DESCRIPTION
**Why is this change needed?**
`PouchDbSyncStorage` always used a single continuous bidirectional `db.sync()` connection. At production user counts this means every idle client keeps a live `_changes` longpoll open for pull, a direction that's rarely needed in real time.

**What is the current behavior?**
Sync always opens one continuous `db.sync()` connection per client for both push and pull, for the lifetime of the storage instance.

**What is the new behavior?**
A new `pull` option on `PouchDbSyncStorage` controls how the pull direction is scheduled, independent of push:
- `mode: 'live'` (default, unchanged) - continuous bidirectional `db.sync()`, exactly as before.
- `mode: 'interval'` - push stays live via `db.replicate.to`; pull runs as one-shot `db.replicate.from` calls on a timer (`intervalMs`, default 60s) and on tab focus (unless `refreshOnFocus: false`).
- `mode: 'visible-interval'` - same as `'interval'`, but skips the timer tick entirely while the tab is hidden (Page Visibility API), since a backgrounded tab has no user waiting on fresh data.

`createDefaultStorage()` now uses `pull: { mode: 'visible-interval', refreshOnFocus: true }`, and is also exported from `@equinor/fusion-framework-module-state/default-storage` so callers can reuse the framework's default remote-resolution behavior (service discovery, auth, per-user CouchDB proxy) with their own `pull` overrides, e.g. a shorter interval for previewing.

The `app-react-state` cookbook now uses this to preview with a 10s interval instead of production's 60s default, and its `SyncStatusIndicator` recognizes the new `onStateSync.poll` event.

**What is the intended behavior or invariant?**
- Only one pull may be in flight at a time (`#pullInFlight`); a trigger that arrives while one is running is skipped, not queued or overlapped.
- Every one-shot pull is guaranteed to eventually unblock `#pullInFlight`, even if PouchDB never fires `'complete'`/`'error'` and never settles its thenable interface - a watchdog `setTimeout` (`syncOptions.timeout ?? 30000` + 5s) force-cancels the replication and releases the guard as a last resort. `'complete'`, `'error'`, the thenable, and the watchdog all race to call the same `finish()`, guarded to run exactly once.
- Push always stays live regardless of `pull.mode`, so local writes are never delayed by pull scheduling.

**Does this PR introduce a breaking change?**
No. `pull` is optional and defaults to `mode: 'live'`, which preserves the exact prior behavior for any caller not opting in.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-module-state`), Patch (cookbook)
- Consumer impact: Apps using the framework's default state storage now poll for remote changes every 60s (paused while backgrounded) instead of holding a continuous pull connection open. Apps that called `setStorage` with an explicit `PouchDbSyncStorage` and no `pull` option are unaffected.
- Downstream impact: None outside `@equinor/fusion-framework-module-state` and the `app-react-state` cookbook.

**Review guidance:**
- The watchdog/race logic in `_pullOnce()` (`PouchDbSyncStorage.ts`) is the main thing worth scrutinizing - specifically that `finish()` can only run once and always clears the timeout.
- A new test (`describe('pull watchdog', ...)`) exercises the watchdog path via fake timers and a mocked hung `replicate.from` call. It compiles cleanly (`tsc -b --force`) but could not be executed in this sandbox - `leveldown`'s native binding has no prebuilt binary for this environment's Node/arch combination, which blocks the entire package's existing Vitest suite too (not something introduced by this PR). CI should run it.

**Additional context**
See `.changeset/module-state_interval-pull.md` and `.changeset/cookbook-app-react-state_poll-preview.md` for the full consumer-facing changelog text.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated (biome + fusion-lint + tsc -b clean)_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)