### PR TITLE
feat(module-bookmark): add BookmarkMockClient and enableBookmarkMock

### DIFF
--- a/.changeset/module-bookmark_mock-entry-point.md
+++ b/.changeset/module-bookmark_mock-entry-point.md
@@ -10,7 +10,16 @@ Add a purpose-built mock, exported from a new `/mock` subpath (`@equinor/fusion-
 import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mock';
 
 enableBookmarkMock(configurator, (builder) => {
-  builder.setBookmarks([{ id: 'bookmark-1', name: 'My Bookmark', appKey: 'my-app', payload: {} }]);
+  builder.setBookmarks([
+    {
+      id: 'bookmark-1',
+      name: 'My Bookmark',
+      appKey: 'my-app',
+      payload: {},
+      created: new Date(),
+      createdBy: { id: 'mock-user', name: 'Mock User' },
+    },
+  ]);
   builder.setCurrentBookmark('bookmark-1');
   builder.setFavorite('bookmark-1', true);
 });

--- a/.changeset/module-bookmark_mock-entry-point.md
+++ b/.changeset/module-bookmark_mock-entry-point.md
@@ -1,0 +1,21 @@
+---
+"@equinor/fusion-framework-module-bookmark": minor
+---
+
+Add a purpose-built mock, exported from a new `/mock` subpath (`@equinor/fusion-framework-module-bookmark/mock`).
+
+`enableBookmarkMock` swaps in an in-memory `IBookmarkClient` behind the real `BookmarkModuleConfigurator`, `BookmarkProvider`, and store flows — create, update, delete, and favourite calls all reach the mock client through the real flow logic, not a stand-in. `BookmarkMockConfigurator` adds a bookmark-domain vocabulary for seeding state:
+
+```typescript
+import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mock';
+
+enableBookmarkMock(configurator, (builder) => {
+  builder.setBookmarks([{ id: 'bookmark-1', name: 'My Bookmark', appKey: 'my-app', payload: {} }]);
+  builder.setCurrentBookmark('bookmark-1');
+  builder.setFavorite('bookmark-1', true);
+});
+```
+
+The whole real builder API stays available, including `setClient`, so an explicit call to it still replaces the mock client outright. When no real `app`/`context` module is registered alongside the mock, `resolve.application`/`resolve.context` fall back to trivial resolvers automatically, since the module's config schema requires both.
+
+Related: equinor/fusion-core-tasks#1667.

--- a/packages/modules/bookmark/README.md
+++ b/packages/modules/bookmark/README.md
@@ -241,7 +241,14 @@ import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mo
 
 enableBookmarkMock(configurator, (builder) => {
   builder.setBookmarks([
-    { id: 'bookmark-1', name: 'My Bookmark', appKey: 'my-app', payload: {} },
+    {
+      id: 'bookmark-1',
+      name: 'My Bookmark',
+      appKey: 'my-app',
+      payload: {},
+      created: new Date(),
+      createdBy: { id: 'mock-user', name: 'Mock User' },
+    },
   ]);
   builder.setCurrentBookmark('bookmark-1');
   builder.setFavorite('bookmark-1', true);

--- a/packages/modules/bookmark/README.md
+++ b/packages/modules/bookmark/README.md
@@ -232,6 +232,34 @@ enableBookmark(configurator, (builder) => {
 });
 ```
 
+## Testing
+
+Import from `@equinor/fusion-framework-module-bookmark/mock` to seed bookmarks in-process instead of calling a real API. The real `BookmarkModuleConfigurator`, `BookmarkProvider`, and store flows still run — only `IBookmarkClient` is substituted with an in-memory implementation.
+
+```ts
+import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mock';
+
+enableBookmarkMock(configurator, (builder) => {
+  builder.setBookmarks([
+    { id: 'bookmark-1', name: 'My Bookmark', appKey: 'my-app', payload: {} },
+  ]);
+  builder.setCurrentBookmark('bookmark-1');
+  builder.setFavorite('bookmark-1', true);
+});
+```
+
+`setBookmarks` seeds the bookmarks `getAllBookmarks`/`getBookmarkById`/`getBookmarkData` resolve. `setCurrentBookmark` declares which seeded bookmark `currentBookmark`/`currentBookmark$` report as active on initialization. `setFavorite` seeds `isBookmarkInFavorites`. Create, update, delete, and favourite calls all reach the in-memory client through the real flows — nothing is stubbed out.
+
+The whole real builder API stays available, including `setClient`, so an explicit call to it still replaces the mock client outright:
+
+```ts
+enableBookmarkMock(configurator, (builder) => {
+  builder.setClient(myOwnBookmarkClient);
+});
+```
+
+If no real `app` or `context` module is registered alongside the mock, `resolve.application`/`resolve.context` fall back to trivial resolvers automatically, since the module's config schema requires both. Registering a real `app`/`context` module still wins.
+
 ## Error Handling
 
 The module exposes two error classes:

--- a/packages/modules/bookmark/package.json
+++ b/packages/modules/bookmark/package.json
@@ -13,6 +13,10 @@
     "./utils": {
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/types/utils/index.d.ts"
+    },
+    "./mock": {
+      "import": "./dist/esm/mock/index.js",
+      "types": "./dist/types/mock/index.d.ts"
     }
   },
   "typesVersions": {
@@ -22,11 +26,15 @@
       ],
       "utils": [
         "dist/types/utils/index.d.ts"
+      ],
+      "mock": [
+        "dist/types/mock/index.d.ts"
       ]
     }
   },
   "scripts": {
     "build": "tsc -b",
+    "test": "vitest run",
     "prepack": "pnpm build"
   },
   "keywords": [],
@@ -57,6 +65,7 @@
     "@equinor/fusion-framework-module-http": "workspace:^",
     "@equinor/fusion-framework-module-services": "workspace:^",
     "typescript": "^7.0.2",
+    "vitest": "^4.1.0",
     "zod": "^4.4.3"
   }
 }

--- a/packages/modules/bookmark/src/__tests__/mock/bookmark-mock.test.ts
+++ b/packages/modules/bookmark/src/__tests__/mock/bookmark-mock.test.ts
@@ -165,6 +165,12 @@ describe('enableBookmarkMock', () => {
     expect(updated.name).toBe('Renamed');
   });
 
+  it('surfaces a missing bookmark as an observable error through the real fetch flow', async () => {
+    const provider = await initializeMockWith();
+
+    await expect(firstValue(provider.getBookmark('missing-bookmark'))).rejects.toThrow();
+  });
+
   it('deletes a bookmark through the real delete flow', async () => {
     const seeded = createBookmark();
     const provider = await initializeMockWith((builder) => {

--- a/packages/modules/bookmark/src/__tests__/mock/bookmark-mock.test.ts
+++ b/packages/modules/bookmark/src/__tests__/mock/bookmark-mock.test.ts
@@ -1,0 +1,193 @@
+import { firstValueFrom, from, type ObservableInput } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+
+import { BookmarkModuleConfigurator } from '../../BookmarkModuleConfigurator';
+import { BookmarkProvider } from '../../BookmarkProvider';
+import type { IBookmarkProvider } from '../../BookmarkProvider.interface';
+import { module as realModule } from '../../bookmark-module';
+import type { Bookmark } from '../../types';
+
+import {
+  BookmarkMockClient,
+  BookmarkMockConfigurator,
+  bookmarkMockModule,
+  enableBookmarkMock,
+} from '../../mock';
+
+/** A fully-formed seeded bookmark, so tests only override what they care about. */
+const createBookmark = (overrides: Partial<Bookmark> = {}): Bookmark => ({
+  id: 'bookmark-1',
+  name: 'My Bookmark',
+  appKey: 'test-app',
+  created: new Date('2024-01-01T00:00:00.000Z'),
+  createdBy: { id: 'seed-user', name: 'Seed User' },
+  ...overrides,
+});
+
+/**
+ * Initializes the mock module through the real module system.
+ *
+ * @remarks
+ * Deliberately avoids hand-building initialization arguments — faking the
+ * module system is the very cost this mock removes.
+ *
+ * @param configure - Optional callback to seed bookmarks, current bookmark, or favorites.
+ * @returns The `IBookmarkProvider` the module produced.
+ */
+const initializeMockWith = async (
+  configure?: (builder: BookmarkMockConfigurator) => void,
+): Promise<IBookmarkProvider> => {
+  const configurator = new ModulesConfigurator([]);
+  enableBookmarkMock(configurator, configure);
+  const instances = await configurator.initialize();
+  return (instances as unknown as { bookmark: IBookmarkProvider }).bookmark;
+};
+
+/**
+ * Resolves the first value of an `IBookmarkProvider` call.
+ *
+ * @remarks
+ * `IBookmarkProvider`'s methods are typed as `ObservableInput`, not `Observable`,
+ * so this wraps with `from()` before handing off to `firstValueFrom`.
+ *
+ * @template T - The value the observable input emits.
+ * @param input - The observable input to resolve.
+ * @returns A promise resolving to the first emitted value.
+ */
+const firstValue = <T>(input: ObservableInput<T>): Promise<T> => firstValueFrom(from(input));
+
+describe('bookmarkMockModule', () => {
+  it('changes nothing but the configurator', () => {
+    expect(bookmarkMockModule.name).toBe(realModule.name);
+    expect(bookmarkMockModule.version).toBe(realModule.version);
+    // The production initializer, untouched — the mock has no lifecycle of its own
+    expect(bookmarkMockModule.initialize).toBe(realModule.initialize);
+  });
+
+  it('builds a real BookmarkModuleConfigurator, so the whole builder stays available', () => {
+    const configurator = bookmarkMockModule.configure?.();
+
+    expect(configurator).toBeInstanceOf(BookmarkModuleConfigurator);
+    expect(configurator).toBeInstanceOf(BookmarkMockConfigurator);
+  });
+});
+
+describe('enableBookmarkMock', () => {
+  it('produces the real BookmarkProvider, not a stand-in', async () => {
+    const provider = await initializeMockWith();
+
+    expect(provider).toBeInstanceOf(BookmarkProvider);
+  });
+
+  it('replaces a bookmark module that is already registered', async () => {
+    // A FrameworkConfigurator pre-registers the real bookmark module, so the
+    // mock is only useful if registering it afterwards wins
+    const configurator = new ModulesConfigurator([realModule]);
+    enableBookmarkMock(configurator, (builder) => {
+      builder.setBookmarks([createBookmark()]);
+    });
+
+    const instances = await configurator.initialize();
+    const provider = (instances as unknown as { bookmark: IBookmarkProvider }).bookmark;
+
+    const bookmarks = await firstValue(provider.getAllBookmarks());
+    expect(bookmarks).toHaveLength(1);
+  });
+
+  it('reflects seeded bookmarks with no real HTTP', async () => {
+    const seeded = createBookmark();
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([seeded]);
+    });
+
+    const bookmarks = await firstValue(provider.getAllBookmarks());
+    expect(bookmarks.map((b) => b.id)).toEqual([seeded.id]);
+  });
+
+  it('reflects the seeded current bookmark', async () => {
+    const seeded = createBookmark();
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([seeded]);
+      builder.setCurrentBookmark(seeded.id);
+    });
+
+    expect(provider.currentBookmark?.id).toBe(seeded.id);
+  });
+
+  it('leaves the current bookmark unset when none is seeded', async () => {
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([createBookmark()]);
+    });
+
+    expect(provider.currentBookmark).toBeNull();
+  });
+
+  it('reflects a seeded favorite', async () => {
+    const seeded = createBookmark();
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([seeded]);
+      builder.setFavorite(seeded.id, true);
+    });
+
+    await expect(firstValue(provider.isBookmarkInFavorites(seeded.id))).resolves.toBe(true);
+  });
+
+  it('creates a bookmark through the real create flow', async () => {
+    const provider = await initializeMockWith();
+    // without a payload generator, generatePayload() never emits and the create
+    // flow would hang forever waiting on it
+    provider.addPayloadGenerator(() => {});
+
+    const created = await firstValue(
+      provider.createBookmark({ name: 'New Bookmark', appKey: 'test-app' }),
+    );
+
+    expect(created.name).toBe('New Bookmark');
+    const bookmarks = await firstValue(provider.getAllBookmarks());
+    expect(bookmarks.map((b) => b.id)).toContain(created.id);
+  });
+
+  it('updates a bookmark through the real update flow', async () => {
+    const seeded = createBookmark();
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([seeded]);
+    });
+    // the update reducer only applies to bookmarks already tracked in the store,
+    // so fetch once first to seed it
+    await firstValue(provider.getAllBookmarks());
+
+    const updated = await firstValue(
+      provider.updateBookmark(seeded.id, { name: 'Renamed' }, { excludePayloadGeneration: true }),
+    );
+
+    expect(updated.name).toBe('Renamed');
+  });
+
+  it('deletes a bookmark through the real delete flow', async () => {
+    const seeded = createBookmark();
+    const provider = await initializeMockWith((builder) => {
+      builder.setBookmarks([seeded]);
+    });
+
+    await firstValue(provider.deleteBookmark(seeded.id));
+
+    const bookmarks = await firstValue(provider.getAllBookmarks());
+    expect(bookmarks.map((b) => b.id)).not.toContain(seeded.id);
+  });
+
+  it('lets setClient() replace the mock client outright', async () => {
+    const ownClient = new BookmarkMockClient();
+    ownClient.setBookmarks([createBookmark({ id: 'own-bookmark' })]);
+
+    const provider = await initializeMockWith((builder) => {
+      // the escape hatch is inherited unchanged from BookmarkModuleConfigurator
+      builder.setBookmarks([createBookmark({ id: 'ignored-bookmark' })]);
+      builder.setClient(ownClient);
+    });
+
+    const bookmarks = await firstValue(provider.getAllBookmarks());
+    expect(bookmarks.map((b) => b.id)).toEqual(['own-bookmark']);
+  });
+});

--- a/packages/modules/bookmark/src/mock/BookmarkMockClient.ts
+++ b/packages/modules/bookmark/src/mock/BookmarkMockClient.ts
@@ -28,8 +28,9 @@ const stripPayload = (bookmark: Bookmark): BookmarkWithoutData => {
  * Checks whether a seeded bookmark matches the given {@link BookmarksFilter}.
  *
  * @remarks
- * Only `appKey` and `contextId` are checked, mirroring the two fields the real
- * `BookmarkProvider` actually resolves and passes through as a filter.
+ * `appKey`, `contextId`, and `sourceSystem` are checked, mirroring what the real
+ * `BookmarkProvider` resolves and passes through as a filter (`BookmarkProvider.getAllBookmarks`
+ * always includes `sourceSystem`, so it must be matched even though it's rarely set explicitly).
  *
  * @param bookmark - The seeded bookmark to test.
  * @param filter - The filter to match against, if any.
@@ -42,6 +43,16 @@ const matchesFilter = (bookmark: Bookmark, filter?: BookmarksFilter): boolean =>
   if (filter.appKey && bookmark.appKey !== filter.appKey) return false;
   // a contextId constraint excludes bookmarks attributed to a different context
   if (filter.contextId && bookmark.context?.id !== filter.contextId) return false;
+  // a sourceSystem constraint excludes bookmarks attributed to a different source system
+  if (filter.sourceSystem) {
+    const { identifier, name, subSystem } = filter.sourceSystem;
+    // an identifier constraint excludes bookmarks attributed to a different source system identifier
+    if (identifier && bookmark.sourceSystem?.identifier !== identifier) return false;
+    // a name constraint excludes bookmarks attributed to a different source system name
+    if (name !== undefined && bookmark.sourceSystem?.name !== name) return false;
+    // a subSystem constraint excludes bookmarks attributed to a different source sub-system
+    if (subSystem !== undefined && bookmark.sourceSystem?.subSystem !== subSystem) return false;
+  }
   return true;
 };
 
@@ -127,15 +138,23 @@ export class BookmarkMockClient implements IBookmarkClient {
   }
 
   /**
-   * Returns every seeded bookmark that matches `filter`.
+   * Returns every seeded bookmark that matches `filter`, without its payload.
+   *
+   * @remarks
+   * The real client strips payloads from list results (see `BookmarkClient.getAllBookmarks`),
+   * so the mock does the same here even though the interface's declared return type is `Bookmark[]`.
    *
    * @param filter - Optional constraints to narrow the returned bookmarks.
-   * @returns The matching bookmarks.
+   * @returns The matching bookmarks, without their payloads.
    */
   public getAllBookmarks(filter?: BookmarksFilter): ObservableInput<Array<Bookmark>> {
-    return resultOf(() =>
-      // only appKey/contextId are checked, mirroring what BookmarkProvider resolves
-      Array.from(this.#bookmarks.values()).filter((bookmark) => matchesFilter(bookmark, filter)),
+    return resultOf(
+      () =>
+        Array.from(this.#bookmarks.values())
+          // only bookmarks matching every constraint in `filter` are returned
+          .filter((bookmark) => matchesFilter(bookmark, filter))
+          // list results never include payloads, mirroring the real client
+          .map(stripPayload) as Array<Bookmark>,
     );
   }
 
@@ -265,6 +284,8 @@ export class BookmarkMockClient implements IBookmarkClient {
       const updated: Bookmark<T> = {
         ...existing,
         ...updates,
+        // `payload: null` clears data on a BookmarkUpdate, so normalize it to `undefined` like setBookmarkData does
+        payload: updates.payload === null ? undefined : (updates.payload ?? existing.payload),
         updated: new Date(),
         updatedBy: mockUser,
       } as Bookmark<T>;

--- a/packages/modules/bookmark/src/mock/BookmarkMockClient.ts
+++ b/packages/modules/bookmark/src/mock/BookmarkMockClient.ts
@@ -1,0 +1,289 @@
+import { of, throwError, type ObservableInput } from 'rxjs';
+import { v4 as generateGUID } from 'uuid';
+
+import type {
+  BookmarkNew,
+  BookmarksFilter,
+  BookmarkUpdate,
+  IBookmarkClient,
+} from '../BookmarkClient.interface';
+import type { Bookmark, BookmarkData, BookmarkUser, BookmarkWithoutData } from '../types';
+
+/** Attributed to every bookmark the mock client creates or updates. */
+const mockUser: BookmarkUser = { id: 'mock-user', name: 'Mock User' };
+
+/**
+ * Strips the `payload` field from a bookmark, mirroring what the real
+ * `BookmarkClient` does before returning a {@link BookmarkWithoutData}.
+ *
+ * @param bookmark - The bookmark to strip.
+ * @returns The bookmark without its payload.
+ */
+const stripPayload = (bookmark: Bookmark): BookmarkWithoutData => {
+  const { payload: _payload, ...rest } = bookmark;
+  return rest;
+};
+
+/**
+ * Checks whether a seeded bookmark matches the given {@link BookmarksFilter}.
+ *
+ * @remarks
+ * Only `appKey` and `contextId` are checked, mirroring the two fields the real
+ * `BookmarkProvider` actually resolves and passes through as a filter.
+ *
+ * @param bookmark - The seeded bookmark to test.
+ * @param filter - The filter to match against, if any.
+ * @returns `true` when the bookmark satisfies every constraint in `filter`.
+ */
+const matchesFilter = (bookmark: Bookmark, filter?: BookmarksFilter): boolean => {
+  // no filter means every seeded bookmark matches
+  if (!filter) return true;
+  // an appKey constraint excludes bookmarks attributed to a different app
+  if (filter.appKey && bookmark.appKey !== filter.appKey) return false;
+  // a contextId constraint excludes bookmarks attributed to a different context
+  if (filter.contextId && bookmark.context?.id !== filter.contextId) return false;
+  return true;
+};
+
+/**
+ * Runs `fn` synchronously and reports the outcome as an {@link ObservableInput},
+ * so a mock method can `throw` for a "not found" case exactly like the async
+ * real client would reject.
+ *
+ * @template T - The value `fn` produces.
+ * @param fn - The synchronous operation to run.
+ * @returns An observable emitting `fn`'s result, or erroring with what it threw.
+ */
+const resultOf = <T>(fn: () => T): ObservableInput<T> => {
+  try {
+    return of(fn());
+  } catch (error) {
+    return throwError(() => error);
+  }
+};
+
+/**
+ * In-memory {@link IBookmarkClient} backed by a `Map` of seeded bookmarks and a
+ * `Set` of favorite ids.
+ *
+ * @remarks
+ * Used by {@link BookmarkMockConfigurator} to swap out the real API client
+ * while leaving `BookmarkProvider` and the `bookmark-flows/` epics running
+ * unmodified — every create, update, delete, and favorite call still goes
+ * through the real flow logic, only the underlying data source is in-memory.
+ */
+export class BookmarkMockClient implements IBookmarkClient {
+  #bookmarks = new Map<string, Bookmark>();
+  #favorites = new Set<string>();
+
+  /**
+   * Replaces the seeded bookmarks with the given collection, keyed by `id`.
+   *
+   * @param items - The bookmarks to seed. Replaces any previously seeded bookmarks.
+   */
+  public setBookmarks(items: Iterable<Bookmark>): void {
+    this.#bookmarks = new Map(Array.from(items, (item) => [item.id, item]));
+  }
+
+  /**
+   * Marks a seeded bookmark as a favorite, or clears it.
+   *
+   * @param bookmarkId - The id of the bookmark to update.
+   * @param isFavorite - `true` to favorite the bookmark, `false` to clear it.
+   */
+  public setFavorite(bookmarkId: string, isFavorite: boolean): void {
+    // track favorites as a set membership rather than a boolean field on the bookmark
+    if (isFavorite) {
+      this.#favorites.add(bookmarkId);
+    } else {
+      this.#favorites.delete(bookmarkId);
+    }
+  }
+
+  /**
+   * Looks up a seeded bookmark by id without going through the `ObservableInput` API.
+   *
+   * @param bookmarkId - The id of the bookmark to look up.
+   * @returns The seeded bookmark, or `undefined` when no bookmark was seeded for that id.
+   */
+  public getBookmark(bookmarkId: string): Bookmark | undefined {
+    return this.#bookmarks.get(bookmarkId);
+  }
+
+  /**
+   * Looks up a seeded bookmark by id, throwing when none was seeded.
+   *
+   * @param bookmarkId - The id of the bookmark to look up.
+   * @returns The seeded bookmark.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  #requireBookmark(bookmarkId: string): Bookmark {
+    const bookmark = this.#bookmarks.get(bookmarkId);
+    // fail loudly so a missing seed reads as a test setup bug, not a silent no-op
+    if (!bookmark) {
+      throw new Error(`BookmarkMockClient: no bookmark seeded for id '${bookmarkId}'`);
+    }
+    return bookmark;
+  }
+
+  /**
+   * Returns every seeded bookmark that matches `filter`.
+   *
+   * @param filter - Optional constraints to narrow the returned bookmarks.
+   * @returns The matching bookmarks.
+   */
+  public getAllBookmarks(filter?: BookmarksFilter): ObservableInput<Array<Bookmark>> {
+    return resultOf(() =>
+      // only appKey/contextId are checked, mirroring what BookmarkProvider resolves
+      Array.from(this.#bookmarks.values()).filter((bookmark) => matchesFilter(bookmark, filter)),
+    );
+  }
+
+  /**
+   * Returns a seeded bookmark by id, without its payload.
+   *
+   * @param bookmarkId - The id of the bookmark to look up.
+   * @returns The bookmark without its payload.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  public getBookmarkById(bookmarkId: string): ObservableInput<BookmarkWithoutData> {
+    return resultOf(() => stripPayload(this.#requireBookmark(bookmarkId)));
+  }
+
+  /**
+   * Returns the payload data of a seeded bookmark.
+   *
+   * @template T - The shape of the bookmark's payload.
+   * @param bookmarkId - The id of the bookmark to look up.
+   * @returns The bookmark's payload.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  public getBookmarkData<T extends BookmarkData>(bookmarkId: string): ObservableInput<T> {
+    return resultOf(() => this.#requireBookmark(bookmarkId).payload as T);
+  }
+
+  /**
+   * Replaces the payload data of a seeded bookmark.
+   *
+   * @template T - The shape of the bookmark's payload.
+   * @param bookmarkId - The id of the bookmark to update.
+   * @param data - The new payload data.
+   * @returns The payload that was set.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  public setBookmarkData<T extends BookmarkData | null>(
+    bookmarkId: string,
+    data: T,
+  ): ObservableInput<T> {
+    return resultOf(() => {
+      const existing = this.#requireBookmark(bookmarkId);
+      this.#bookmarks.set(bookmarkId, { ...existing, payload: data ?? undefined });
+      return data;
+    });
+  }
+
+  /**
+   * Marks a seeded bookmark as a favorite.
+   *
+   * @param bookmarkId - The id of the bookmark to favorite.
+   * @returns `true` once the bookmark is marked as a favorite.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  public addBookmarkToFavorites(bookmarkId: string): ObservableInput<boolean> {
+    return resultOf(() => {
+      this.#requireBookmark(bookmarkId);
+      this.#favorites.add(bookmarkId);
+      return true;
+    });
+  }
+
+  /**
+   * Clears a seeded bookmark's favorite status.
+   *
+   * @param bookmarkId - The id of the bookmark to unfavorite.
+   * @returns `true` once the bookmark is no longer a favorite.
+   */
+  public removeBookmarkFromFavorites(bookmarkId: string): ObservableInput<boolean> {
+    return resultOf(() => {
+      this.#favorites.delete(bookmarkId);
+      return true;
+    });
+  }
+
+  /**
+   * Checks whether a seeded bookmark is currently a favorite.
+   *
+   * @param bookmarkId - The id of the bookmark to check.
+   * @returns `true` when the bookmark is a favorite.
+   */
+  public isBookmarkFavorite(bookmarkId: string): ObservableInput<boolean> {
+    return of(this.#favorites.has(bookmarkId));
+  }
+
+  /**
+   * Seeds a new bookmark from create input, generating its id and audit fields.
+   *
+   * @template T - The shape of the bookmark's payload.
+   * @param bookmark - The data to create the bookmark from.
+   * @returns The created bookmark.
+   */
+  public createBookmark<T extends BookmarkData>(
+    bookmark: BookmarkNew<T>,
+  ): ObservableInput<Bookmark<T>> {
+    return resultOf(() => {
+      // `contextId` is a plain id on the client input, but a `{ id }` object on the bookmark itself
+      const { contextId, ...rest } = bookmark;
+      // merge the create input with generated audit fields and a normalized context
+      const created: Bookmark<T> = {
+        ...rest,
+        id: generateGUID(),
+        created: new Date(),
+        createdBy: mockUser,
+        ...(contextId ? { context: { id: contextId } } : {}),
+      };
+      this.#bookmarks.set(created.id, created);
+      return created;
+    });
+  }
+
+  /**
+   * Applies updates to a seeded bookmark, stamping new audit fields.
+   *
+   * @template T - The shape of the bookmark's payload.
+   * @param bookmarkId - The id of the bookmark to update.
+   * @param updates - The fields to update.
+   * @returns The updated bookmark.
+   * @throws {Error} When no bookmark was seeded for `bookmarkId`.
+   */
+  public updateBookmark<T extends BookmarkData>(
+    bookmarkId: string,
+    updates: BookmarkUpdate<T>,
+  ): ObservableInput<Bookmark<T>> {
+    return resultOf(() => {
+      const existing = this.#requireBookmark(bookmarkId);
+      // merge the updates onto the existing bookmark, then stamp new audit fields
+      const updated: Bookmark<T> = {
+        ...existing,
+        ...updates,
+        updated: new Date(),
+        updatedBy: mockUser,
+      } as Bookmark<T>;
+      this.#bookmarks.set(bookmarkId, updated);
+      return updated;
+    });
+  }
+
+  /**
+   * Removes a seeded bookmark and clears its favorite status.
+   *
+   * @param bookmarkId - The id of the bookmark to delete.
+   * @returns `true` when a bookmark was seeded for `bookmarkId` and was removed.
+   */
+  public deleteBookmark(bookmarkId: string): ObservableInput<boolean> {
+    return resultOf(() => {
+      const existed = this.#bookmarks.delete(bookmarkId);
+      this.#favorites.delete(bookmarkId);
+      return existed;
+    });
+  }
+}

--- a/packages/modules/bookmark/src/mock/BookmarkMockConfigurator.ts
+++ b/packages/modules/bookmark/src/mock/BookmarkMockConfigurator.ts
@@ -1,0 +1,154 @@
+import { of } from 'rxjs';
+
+import type { ConfigBuilderCallbackArgs } from '@equinor/fusion-framework-module';
+
+import { BookmarkModuleConfigurator } from '../BookmarkModuleConfigurator';
+import type { IBookmarkProvider } from '../BookmarkProvider.interface';
+import type { Bookmark, BookmarkModuleConfig } from '../types';
+
+import { BookmarkMockClient } from './BookmarkMockClient';
+
+/**
+ * Fallback application resolver used when the mock is configured standalone,
+ * without a real `app` module registered.
+ */
+const mockApplicationResolver: BookmarkModuleConfig['resolve']['application'] = async () => ({
+  appKey: 'mock-app',
+});
+
+/**
+ * Fallback context resolver used when the mock is configured standalone,
+ * without a real `context` module registered.
+ */
+const mockContextResolver: BookmarkModuleConfig['resolve']['context'] = async () => undefined;
+
+/**
+ * The real bookmark configurator, backed by an in-memory {@link BookmarkMockClient}.
+ *
+ * @remarks
+ * Extends {@link BookmarkModuleConfigurator} directly, so the whole builder API
+ * (source system, filters, resolvers, `setParent`) stays available. Only a
+ * default client is added — through the same
+ * {@link BookmarkModuleConfigurator.setClient | setClient} seam a caller would
+ * use to plug in their own client — so an explicit `setClient()` call still
+ * replaces it outright, exactly as it would on the real configurator.
+ *
+ * Seeded bookmarks and favorites flow through the real `BookmarkProvider` and
+ * `bookmark-flows/` epics unmodified: create, update, delete, and favorite
+ * calls all reach {@link BookmarkMockClient}, not a stand-in.
+ *
+ * @example Seed bookmarks and a current bookmark
+ * ```typescript
+ * enableBookmarkMock(configurator, (builder) => {
+ *   builder.setBookmarks([myBookmark]);
+ *   builder.setCurrentBookmark(myBookmark.id);
+ *   builder.setFavorite(myBookmark.id, true);
+ * });
+ * ```
+ *
+ * @example Take full control of the client
+ * ```typescript
+ * enableBookmarkMock(configurator, (builder) => {
+ *   builder.setClient(myOwnBookmarkClient);
+ * });
+ * ```
+ */
+export class BookmarkMockConfigurator extends BookmarkModuleConfigurator {
+  #client = new BookmarkMockClient();
+  #currentId?: string;
+
+  /**
+   * Seeds the bookmarks the mock client resolves through `getAllBookmarks`,
+   * `getBookmarkById`, and `getBookmarkData`.
+   *
+   * @param items - The bookmarks to seed. Replaces any previously seeded bookmarks.
+   * @returns `this`, for chaining.
+   */
+  public setBookmarks(items: Iterable<Bookmark>): this {
+    this.#client.setBookmarks(items);
+    return this;
+  }
+
+  /**
+   * Declares which seeded bookmark `IBookmarkProvider.currentBookmark` reports
+   * as active once the module initializes.
+   *
+   * @remarks
+   * `BookmarkProvider` only reads its initial current bookmark from a parent
+   * provider (see {@link BookmarkModuleConfigurator.setParent}), so this
+   * registers a synthetic parent exposing the seeded bookmark — the same seam
+   * a real nested-portal provider would use, just standing in for one.
+   *
+   * @param bookmarkId - The id of a bookmark previously passed to {@link setBookmarks},
+   *   or `undefined` to leave the current bookmark unset.
+   * @returns `this`, for chaining.
+   */
+  public setCurrentBookmark(bookmarkId: string | undefined): this {
+    this.#currentId = bookmarkId;
+    return this;
+  }
+
+  /**
+   * Marks a seeded bookmark as a favorite, or clears it, reflected through
+   * `IBookmarkClient.isBookmarkFavorite`.
+   *
+   * @param bookmarkId - The id of the bookmark to update.
+   * @param isFavorite - `true` to favorite the bookmark, `false` to clear it. Defaults to `true`.
+   * @returns `this`, for chaining.
+   */
+  public setFavorite(bookmarkId: string, isFavorite = true): this {
+    this.#client.setFavorite(bookmarkId, isFavorite);
+    return this;
+  }
+
+  /**
+   * Installs the mock client and a synthetic current-bookmark parent before
+   * building the configuration, unless the caller already declared their own.
+   *
+   * @remarks
+   * Also falls back to trivial application/context resolvers when neither an
+   * `app` nor a `context` module is registered alongside this mock — both are
+   * required by {@link BookmarkModuleConfig}'s schema, but a standalone test
+   * has no reason to pull in either module just to satisfy it. Registering a
+   * real `app`/`context` module still wins, exactly as it does on the real
+   * configurator.
+   *
+   * @param init - The config builder callback arguments.
+   * @param initial - An optional initial config to merge into the returned config.
+   * @returns The observable configuration, produced by the real configurator.
+   */
+  protected override _createConfig(
+    init: ConfigBuilderCallbackArgs,
+    initial?: Partial<BookmarkModuleConfig>,
+  ) {
+    // only stand in a mock client when the caller hasn't set their own
+    if (!this._has('client')) {
+      this.setClient(this.#client);
+    }
+
+    // only stand in a synthetic parent when a current bookmark was seeded and
+    // the caller hasn't declared their own parent provider
+    if (this.#currentId && !this._has('parent')) {
+      const current = this.#client.getBookmark(this.#currentId) ?? null;
+      const parent: Pick<IBookmarkProvider, 'currentBookmark' | 'currentBookmark$'> = {
+        currentBookmark: current,
+        currentBookmark$: of(current),
+      };
+      this.setParent(parent as IBookmarkProvider);
+    }
+
+    // no app module means the real default resolver would resolve to `undefined`,
+    // which fails the required `resolve.application` schema field
+    if (!this._has('resolve.application') && !init.hasModule('app')) {
+      this.setApplicationResolver(async () => mockApplicationResolver);
+    }
+
+    // no context module means the real default resolver would resolve to `undefined`,
+    // which fails the required `resolve.context` schema field
+    if (!this._has('resolve.context') && !init.hasModule('context')) {
+      this.setContextResolver(async () => mockContextResolver);
+    }
+
+    return super._createConfig(init, initial);
+  }
+}

--- a/packages/modules/bookmark/src/mock/BookmarkMockConfigurator.ts
+++ b/packages/modules/bookmark/src/mock/BookmarkMockConfigurator.ts
@@ -137,15 +137,20 @@ export class BookmarkMockConfigurator extends BookmarkModuleConfigurator {
       this.setParent(parent as IBookmarkProvider);
     }
 
-    // no app module means the real default resolver would resolve to `undefined`,
-    // which fails the required `resolve.application` schema field
-    if (!this._has('resolve.application') && !init.hasModule('app')) {
+    // no app module means the real default resolver would resolve to `undefined`, which fails
+    // the required `resolve.application` schema field — but `initial.resolve.application` may
+    // already carry a resolver inherited from a parent config, which must not be overwritten
+    if (
+      !this._has('resolve.application') &&
+      !initial?.resolve?.application &&
+      !init.hasModule('app')
+    ) {
       this.setApplicationResolver(async () => mockApplicationResolver);
     }
 
-    // no context module means the real default resolver would resolve to `undefined`,
-    // which fails the required `resolve.context` schema field
-    if (!this._has('resolve.context') && !init.hasModule('context')) {
+    // no context module means the real default resolver would resolve to `undefined`, which
+    // fails the required `resolve.context` schema field — same inherited-config caveat as above
+    if (!this._has('resolve.context') && !initial?.resolve?.context && !init.hasModule('context')) {
       this.setContextResolver(async () => mockContextResolver);
     }
 

--- a/packages/modules/bookmark/src/mock/index.ts
+++ b/packages/modules/bookmark/src/mock/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Mock bookmark module for tests: real provider, real configurator, in-memory client.
+ *
+ * @remarks
+ * Substituting `IBookmarkClient` is the smallest change that removes the
+ * Fusion Core Services backend from a test. Everything above it — the
+ * `BookmarkProvider` store, `bookmark-flows/` epics, payload generators, and
+ * events — is the production code path.
+ *
+ * @example
+ * ```typescript
+ * import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mock';
+ *
+ * enableBookmarkMock(configurator, (builder) => {
+ *   builder.setBookmarks([myBookmark]);
+ *   builder.setCurrentBookmark(myBookmark.id);
+ *   builder.setFavorite(myBookmark.id, true);
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+export { BookmarkMockClient } from './BookmarkMockClient';
+export { BookmarkMockConfigurator } from './BookmarkMockConfigurator';
+export { enableBookmarkMock, bookmarkMockModule, type BookmarkMockConfigFn } from './module';

--- a/packages/modules/bookmark/src/mock/module.ts
+++ b/packages/modules/bookmark/src/mock/module.ts
@@ -1,0 +1,64 @@
+import type { AnyModule, IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+import { module, type BookmarkModule } from '../bookmark-module';
+
+import { BookmarkMockConfigurator } from './BookmarkMockConfigurator';
+
+/**
+ * The bookmark module with a mock, in-memory client instead of a live
+ * `@equinor/fusion-framework-module-services` connection.
+ *
+ * @remarks
+ * Only `configure` differs from the real module. `initialize` is the
+ * production one, untouched, so the real `BookmarkProvider` and
+ * `bookmark-flows/` epics run exactly as they do in production — a test
+ * observes the real create/update/delete/favorite flow, not a rehearsal of it.
+ */
+export const bookmarkMockModule: BookmarkModule = {
+  ...module,
+  configure: () => new BookmarkMockConfigurator(),
+};
+
+/**
+ * Configuration callback for {@link enableBookmarkMock}.
+ *
+ * @template TRef - Reference type forwarded to the callback, inferred from the configurator.
+ */
+export type BookmarkMockConfigFn<TRef = unknown> = (
+  configurator: BookmarkMockConfigurator,
+  ref?: TRef,
+) => void | Promise<void>;
+
+/**
+ * Enables the bookmark module against an in-memory mock client, so a test
+ * needs no network and no real Fusion Core Services backend.
+ *
+ * @remarks
+ * Registered last, this replaces whichever bookmark module the configurator
+ * already carries, so it works on a `FrameworkConfigurator` that pre-registers
+ * the real one.
+ *
+ * @param configurator - The modules configurator to register on.
+ * @param configure - Optional callback to seed bookmarks, the current bookmark, or favorites.
+ * @template TModules - The array of module descriptors managed by `configurator`.
+ * @template TRef - Reference type forwarded to `configure`, inferred from `configurator`.
+ *
+ * @example
+ * ```typescript
+ * enableBookmarkMock(configurator, (builder) => {
+ *   builder.setBookmarks([myBookmark]);
+ *   builder.setCurrentBookmark(myBookmark.id);
+ * });
+ * ```
+ */
+export const enableBookmarkMock = <
+  TModules extends Array<AnyModule> = Array<AnyModule>,
+  TRef = unknown,
+>(
+  configurator: IModulesConfigurator<TModules, TRef>,
+  configure?: BookmarkMockConfigFn<TRef>,
+): void => {
+  configurator.addConfig({ module: bookmarkMockModule, configure } as {
+    module: BookmarkModule;
+  });
+};

--- a/packages/modules/bookmark/vitest.config.ts
+++ b/packages/modules/bookmark/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject } from 'vitest/config';
+
+import { name, version } from './package.json';
+
+export default defineProject({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    name: `${name}@${version}`,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1808,6 +1808,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
**Why is this change needed?**
The bookmark module's `IBookmarkClient` requires a real backend, so exercising `BookmarkProvider`, its store flows, and event lifecycle in a test currently means standing up (or hand-mocking) an HTTP client. `equinor/fusion-core-tasks#1667` asks for a purpose-built mock with a bookmark-domain vocabulary, following the same client-boundary-swap pattern already shipped for `msal` (`enableMsalMock`/`MsalMockConfigurator`).

**What is the current behavior?**
There is no `/mock` subpath for `@equinor/fusion-framework-module-bookmark`. Testing anything that depends on `IBookmarkProvider` requires implementing `IBookmarkClient` by hand.

**What is the new behavior?**
Adds `@equinor/fusion-framework-module-bookmark/mock`, exporting:
- `BookmarkMockClient` — an in-memory `IBookmarkClient` backed by a `Map` of seeded bookmarks and a `Set` of favorite ids.
- `BookmarkMockConfigurator` — extends the real `BookmarkModuleConfigurator` with `setBookmarks`, `setCurrentBookmark`, and `setFavorite`. The whole real builder API (`setSourceSystem`, `setFilter`, `setContextResolver`, `setApplicationResolver`, `setParent`, `setClient`) stays available.
- `enableBookmarkMock` / `bookmarkMockModule` — a module descriptor identical to the real one except for `configure`, mirroring `enableMsalMock`'s shape.

Create, update, delete, and favorite calls all flow through the real `BookmarkProvider` and `bookmark-flows/` epics unmodified — only the underlying `IBookmarkClient` is swapped.

**What is the intended behavior or invariant?**
- `BookmarkModuleConfig['resolve'].{application,context}` are schema-required functions with no safe default outside a real `app`/`context` module. When neither is registered alongside the mock, `BookmarkMockConfigurator` installs trivial fallback resolvers (gated on `init.hasModule(...)`) so the mock works standalone; a real `app`/`context` module registered alongside it still wins.
- `BookmarkProvider` only seeds its initial `currentBookmark` from a `parent` provider reference. `setCurrentBookmark(id)` synthesizes a minimal `Pick<IBookmarkProvider, 'currentBookmark' | 'currentBookmark$'>` object and installs it via `setParent(...)`, unless the caller already declared their own parent.
- An explicit `setClient(...)` call still replaces the mock client outright, exactly as on the real configurator.

**Does this PR introduce a breaking change?**
No. Purely additive — a new `/mock` subpath export.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-module-bookmark`)
- Consumer impact: New opt-in `/mock` subpath; no changes to existing exports or behavior.
- Downstream impact: None.

**Review guidance:**
Two bookmark-specific gotchas worth double-checking:
1. `generatePayload()` never emits when zero payload generators are registered (`from([])` through `mergeScan` completes without emitting), which silently hangs `createBookmark`/non-excluded `updateBookmark` — this is existing `BookmarkProvider` behavior, not something this PR changes, but it's easy to trip over in a test (see the test suite's `addPayloadGenerator(() => {})` call).
2. `updateBookmark`'s success reducer only applies to bookmarks already tracked in the store (`bookmarkId in state.bookmarks`), which is only populated by a prior `getAllBookmarks`/`getBookmark` fetch — seeding the mock client alone isn't enough for the update flow's returned value to reflect the change.

**Additional context**
Followed the `msal` module's real, shipped `enableMsalMock`/`MsalMockConfigurator` as the concrete template (the issue's cited precedent, a `ContextMockConfigurator` for `#1658`, does not exist yet in the codebase).

**Related issues**
ref: equinor/fusion-core-tasks#1667

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated (biome, fusion-lint, `tsc -b`, vitest all pass)
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
