### PR TITLE
feat(module-telemetry): add MockTelemetryAdapter and wire it into FrameworkMockConfigurator

### DIFF
--- a/.changeset/framework-telemetry-mock.md
+++ b/.changeset/framework-telemetry-mock.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework": minor
+---
+
+`FrameworkMockConfigurator.telemetry` is now backed by `TelemetryMockConfigurator` from `@equinor/fusion-framework-module-telemetry/mock` instead of the real `TelemetryConfigurator` — telemetry tracked through a mocked framework instance no longer reaches Application Insights or any real endpoint:
+
+```typescript
+const fusion = await mockFramework();
+
+fusion.modules.telemetry.trackEvent({ name: 'button-click' });
+
+const item = await configurator.telemetry.adapter.waitForItem('button-click');
+```
+
+This changes the type returned by `.telemetry` from `ITelemetryConfigurator` to `TelemetryMockConfigurator` (which extends the real `TelemetryConfigurator`) — code relying on `.telemetry` being exactly the real configurator should read tracked items back through `.telemetry.adapter` (`getItems`/`waitForItem`) instead of asserting against a real telemetry backend.

--- a/.changeset/framework-telemetry-mock.md
+++ b/.changeset/framework-telemetry-mock.md
@@ -5,11 +5,26 @@
 `FrameworkMockConfigurator.telemetry` is now backed by `TelemetryMockConfigurator` from `@equinor/fusion-framework-module-telemetry/mock` instead of the real `TelemetryConfigurator` — telemetry tracked through a mocked framework instance no longer reaches Application Insights or any real endpoint:
 
 ```typescript
+import { filter } from 'rxjs';
+
 const fusion = await mockFramework();
 
-fusion.modules.telemetry.trackEvent({ name: 'button-click' });
+fusion.modules.telemetry.items
+  .pipe(filter((item) => item.name === 'button-click'))
+  .subscribe((item) => {
+    // ...
+  });
 
-const item = await configurator.telemetry.adapter.waitForItem('button-click');
+fusion.modules.telemetry.trackEvent({ name: 'button-click' });
+```
+
+A test can register its own adapter alongside the mock's default one, the same way `enableTelemetry` already does:
+
+```typescript
+const myAdapter: ITelemetryAdapter = { processItem: (item) => forwardSomewhere(item) };
+const fusion = await mockFramework((configurator) => {
+  configurator.telemetry.setAdapter('my-adapter', myAdapter);
+});
 ```
 
 This changes the type returned by `.telemetry` from `ITelemetryConfigurator` to `TelemetryMockConfigurator` (which extends the real `TelemetryConfigurator`) — code relying on `.telemetry` being exactly the real configurator should read tracked items back through `.telemetry.adapter` (`getItems`/`waitForItem`) instead of asserting against a real telemetry backend.

--- a/.changeset/module-telemetry_mock-adapter.md
+++ b/.changeset/module-telemetry_mock-adapter.md
@@ -1,0 +1,28 @@
+---
+"@equinor/fusion-framework-module-telemetry": minor
+---
+
+Add `MockTelemetryAdapter` and a `./mock` subpath for asserting on tracked telemetry in tests.
+
+```ts
+import { enableTelemetryMock } from '@equinor/fusion-framework-module-telemetry/mock';
+
+let recorder;
+enableTelemetryMock(configurator, (builder) => {
+  recorder = builder.adapter;
+});
+
+// ... exercise the app under test, then assert:
+const item = await recorder.waitForItem('button-click');
+expect(item.properties?.section).toBe('header');
+```
+
+### `getItems(matcher?)`
+
+Returns recorded telemetry items synchronously, filtered by an item name, an array of names, or a predicate. Omit the matcher to get every recorded item.
+
+### `waitForItem(matcher, options?)`
+
+Resolves with the first matching item, resolving immediately if one was already recorded, or waiting for a future one. Supports an optional `timeout` (ms) and `AbortSignal` so a test cannot hang indefinitely, and rejects if the adapter is disposed before a match occurs.
+
+`TelemetryMockConfigurator` and `telemetryMockModule` are exported alongside it, following the same shape as the module's real `TelemetryConfigurator`/`module` pair, so existing `enableTelemetry`-style call sites work unchanged against the mock.

--- a/packages/framework/src/__tests__/mock/mock-framework.test.ts
+++ b/packages/framework/src/__tests__/mock/mock-framework.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { Module } from '@equinor/fusion-framework-module';
 import { enableMsalMock } from '@equinor/fusion-framework-module-msal/mock';
 import { enableServiceDiscoveryMock } from '@equinor/fusion-framework-module-service-discovery/mock';
+import { TelemetryLevel } from '@equinor/fusion-framework-module-telemetry';
 
 import { FrameworkConfigurator } from '../../FrameworkConfigurator.js';
 import { init } from '../../init.js';
@@ -199,6 +200,23 @@ describe('FrameworkMockConfigurator', () => {
     const configurator = new FrameworkMockConfigurator();
 
     expect(configurator.telemetry).toBeDefined();
+  });
+
+  it('collects a tracked event through the telemetry mock adapter, reaching no real endpoint', async () => {
+    let mockConfigurator: FrameworkMockConfigurator | undefined;
+    const fusion = await mockFramework((configurator) => {
+      mockConfigurator = configurator;
+    });
+
+    fusion.modules.telemetry.trackEvent({
+      name: 'button-click',
+      level: TelemetryLevel.Information,
+      scope: [],
+    });
+
+    await vi.waitFor(() => {
+      expect(mockConfigurator?.telemetry.adapter.getItems('button-click')).toHaveLength(1);
+    });
   });
 
   it('lets a module supplied through TModules get the same kind of accessor as msal and serviceDiscovery', async () => {

--- a/packages/framework/src/mock/FrameworkMockConfigurator.ts
+++ b/packages/framework/src/mock/FrameworkMockConfigurator.ts
@@ -17,9 +17,10 @@ import {
   type ServiceDiscoveryMockConfigurator,
 } from '@equinor/fusion-framework-module-service-discovery/mock';
 import servicesModule, { type IApiConfigurator } from '@equinor/fusion-framework-module-services';
-import telemetryModule, {
-  type ITelemetryConfigurator,
-} from '@equinor/fusion-framework-module-telemetry';
+import {
+  telemetryMockModule,
+  type TelemetryMockConfigurator,
+} from '@equinor/fusion-framework-module-telemetry/mock';
 
 import { FrameworkConfigurator } from '../FrameworkConfigurator.js';
 
@@ -38,11 +39,10 @@ import { FrameworkConfigurator } from '../FrameworkConfigurator.js';
  * reaches it directly instead of registering a callback to receive it. `http`
  * answers registered route handlers instead of the network — see `.http` and
  * `enableHttpMock`'s adapters for `openapi-backend`-style backends or an
- * `@equinor/fusion-openapi-mock` document. `services` and `telemetry` are not
- * backed by test doubles yet, so calls through their configurators still reach
- * the network — but the configurators themselves are reachable the same way
- * `.msal` is, since their `configure` factories take no `ref` and so lose
- * nothing by being pinned early.
+ * `@equinor/fusion-openapi-mock` document. `services` is not backed by a test
+ * double yet, so calls through its configurator still reach the network — but
+ * the configurator itself is reachable the same way `.msal` is, since its
+ * `configure` factory takes no `ref` and so loses nothing by being pinned early.
  *
  * `event` is deliberately not pinned: its `configure` factory reads `ref` to
  * wire bubbling to a parent event provider when this configurator is hoisted
@@ -90,7 +90,7 @@ export class FrameworkMockConfigurator<
     this._pin(httpMockModule);
     this._pin(servicesModule);
     this._pin(contextMockModule);
-    this._pin(telemetryModule);
+    this._pin(telemetryMockModule);
   }
 
   /**
@@ -232,12 +232,14 @@ export class FrameworkMockConfigurator<
    * Configures telemetry.
    *
    * @remarks
-   * The real configurator — `telemetry` has no test double yet.
+   * The same {@link TelemetryMockConfigurator} the telemetry module is
+   * configured from, so a tracked event or measurement can be read back from
+   * its adapter instead of reaching Application Insights.
    *
-   * @returns The real telemetry configurator.
+   * @returns The telemetry mock configurator.
    */
-  public get telemetry(): ITelemetryConfigurator {
-    return this._getConfig<ITelemetryConfigurator>(telemetryModule.name);
+  public get telemetry(): TelemetryMockConfigurator {
+    return this._getConfig<TelemetryMockConfigurator>(telemetryMockModule.name);
   }
 
   /**

--- a/packages/modules/telemetry/package.json
+++ b/packages/modules/telemetry/package.json
@@ -21,6 +21,10 @@
       "import": "./dist/esm/adapters/index.js",
       "types": "./dist/types/adapters/index.d.ts"
     },
+    "./mock": {
+      "import": "./dist/esm/mock/index.js",
+      "types": "./dist/types/mock/index.d.ts"
+    },
     "./application-insights-adapter": {
       "import": "./dist/esm/adapters/application-insights/index.js",
       "types": "./dist/types/adapters/application-insights/index.d.ts"

--- a/packages/modules/telemetry/src/__tests__/mock/MockTelemetryAdapter.test.ts
+++ b/packages/modules/telemetry/src/__tests__/mock/MockTelemetryAdapter.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TelemetryLevel, TelemetryType } from '../../static.js';
+import type { TelemetryItem } from '../../types.js';
+import { MockTelemetryAdapter } from '../../mock/MockTelemetryAdapter.js';
+
+const createItem = (name: string, overrides: Partial<TelemetryItem> = {}): TelemetryItem => ({
+  name,
+  type: TelemetryType.Custom,
+  level: TelemetryLevel.Information,
+  scope: [],
+  ...overrides,
+});
+
+describe('MockTelemetryAdapter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('ignores processItem before initialize, matching BaseTelemetryAdapter', () => {
+    const adapter = new MockTelemetryAdapter();
+
+    adapter.processItem(createItem('button-click'));
+
+    expect(adapter.getItems()).toHaveLength(0);
+  });
+
+  it('records items via processItem and returns them from getItems, once initialized', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+
+    adapter.processItem(createItem('button-click'));
+    adapter.processItem(createItem('page-view'));
+
+    expect(adapter.getItems().map((item) => item.name)).toEqual(['button-click', 'page-view']);
+  });
+
+  it('filters getItems by a single name, an array, and a predicate', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+
+    adapter.processItem(createItem('button-click', { properties: { section: 'header' } }));
+    adapter.processItem(createItem('page-view'));
+
+    expect(adapter.getItems('button-click')).toHaveLength(1);
+    expect(adapter.getItems(['button-click', 'page-view'])).toHaveLength(2);
+    expect(adapter.getItems((item) => item.properties?.section === 'header')).toHaveLength(1);
+  });
+
+  it('resolves waitForItem immediately when a matching item is already recorded', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+    adapter.processItem(createItem('button-click'));
+
+    const item = await adapter.waitForItem('button-click');
+
+    expect(item.name).toBe('button-click');
+  });
+
+  it('resolves waitForItem when a matching item is recorded later', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+
+    const promise = adapter.waitForItem('button-click');
+    adapter.processItem(createItem('page-view'));
+    adapter.processItem(createItem('button-click'));
+    const item = await promise;
+
+    expect(item.name).toBe('button-click');
+  });
+
+  it('rejects when the timeout elapses before a matching item is recorded', async () => {
+    vi.useFakeTimers();
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+
+    const promise = adapter.waitForItem('button-click', { timeout: 500 });
+    vi.advanceTimersByTime(501);
+
+    await expect(promise).rejects.toThrow('waitForItem timed out after 500ms');
+  });
+
+  it('rejects when the AbortSignal fires before a matching item', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+    const controller = new AbortController();
+
+    const promise = adapter.waitForItem('button-click', { signal: controller.signal });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow();
+  });
+
+  it('rejects pending waitForItem calls when the adapter is disposed', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+
+    const promise = adapter.waitForItem('button-click');
+    adapter[Symbol.dispose]();
+
+    await expect(promise).rejects.toThrow('disposed before a matching item was recorded');
+  });
+
+  it('clears recorded items without rejecting pending waitForItem calls', async () => {
+    const adapter = new MockTelemetryAdapter();
+    await adapter.initialize();
+    adapter.processItem(createItem('page-view'));
+
+    adapter.clear();
+
+    expect(adapter.getItems()).toHaveLength(0);
+
+    const promise = adapter.waitForItem('button-click');
+    adapter.processItem(createItem('button-click'));
+
+    await expect(promise).resolves.toMatchObject({ name: 'button-click' });
+  });
+});

--- a/packages/modules/telemetry/src/__tests__/mock/module.test.ts
+++ b/packages/modules/telemetry/src/__tests__/mock/module.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+
+import { module as telemetryModule } from '../../module.js';
+import { TelemetryMockConfigurator } from '../../mock/TelemetryMockConfigurator.js';
+import { enableTelemetryMock, telemetryMockModule } from '../../mock/module.js';
+import type { TelemetryProvider } from '../../TelemetryProvider.js';
+
+describe('telemetryMockModule', () => {
+  it('matches the real module name and initialize path', () => {
+    expect(telemetryMockModule.name).toBe(telemetryModule.name);
+    expect(telemetryMockModule.initialize).toBe(telemetryModule.initialize);
+  });
+
+  it('builds a TelemetryMockConfigurator', async () => {
+    const configurator = await telemetryMockModule.configure?.();
+
+    expect(configurator).toBeInstanceOf(TelemetryMockConfigurator);
+  });
+});
+
+describe('enableTelemetryMock', () => {
+  it('records a tracked event via its own adapter, resolved through the module system', async () => {
+    let recorder: TelemetryMockConfigurator['adapter'] | undefined;
+    const configurator = new ModulesConfigurator([]);
+    enableTelemetryMock(configurator, (builder) => {
+      recorder = builder.adapter;
+    });
+
+    const instances = await configurator.initialize();
+    const provider = (instances as unknown as { telemetry: TelemetryProvider }).telemetry;
+
+    provider.trackEvent({ name: 'button-click' });
+
+    await vi.waitFor(() => {
+      expect(recorder?.getItems('button-click')).toHaveLength(1);
+    });
+  });
+
+  it('replaces an already registered telemetry module', async () => {
+    let recorder: TelemetryMockConfigurator['adapter'] | undefined;
+    const configurator = new ModulesConfigurator([telemetryModule]);
+    enableTelemetryMock(configurator, (builder) => {
+      recorder = builder.adapter;
+    });
+
+    const instances = await configurator.initialize();
+    const provider = (instances as unknown as { telemetry: TelemetryProvider }).telemetry;
+
+    provider.trackEvent({ name: 'button-click' });
+
+    await vi.waitFor(() => {
+      expect(recorder?.getItems('button-click')).toHaveLength(1);
+    });
+  });
+});

--- a/packages/modules/telemetry/src/mock/MockTelemetryAdapter.ts
+++ b/packages/modules/telemetry/src/mock/MockTelemetryAdapter.ts
@@ -1,0 +1,181 @@
+import { Subject, filter, type Subscription } from 'rxjs';
+
+import { BaseTelemetryAdapter } from '../TelemetryAdapter.js';
+import type { TelemetryItem } from '../types.js';
+
+/**
+ * Selects which recorded items {@link MockTelemetryAdapter.waitForItem} or
+ * {@link MockTelemetryAdapter.getItems} act on.
+ *
+ * - `string` — matches `item.name` exactly.
+ * - `string[]` — matches if `item.name` is any of the given entries.
+ * - `(item) => boolean` — arbitrary predicate over the full item.
+ */
+export type TelemetryItemMatcher = string | string[] | ((item: TelemetryItem) => boolean);
+
+/** Options accepted by {@link MockTelemetryAdapter.waitForItem}. */
+export interface WaitForItemOptions {
+  /**
+   * Maximum time in milliseconds to wait for a matching item.
+   * When elapsed the returned promise rejects.
+   */
+  timeout?: number;
+  /**
+   * AbortSignal that can cancel the wait early.
+   * When aborted the returned promise rejects with the signal's reason.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * A {@link BaseTelemetryAdapter} that records every processed telemetry item
+ * in-memory instead of exporting it to a backend, for asserting on telemetry
+ * in tests.
+ *
+ * @remarks
+ * Register it like any other adapter via
+ * {@link ITelemetryConfigurator.setAdapter}; it does not interfere with other
+ * adapters registered alongside it. {@link TelemetryMockConfigurator} already
+ * registers one by default, so most tests reach it through
+ * `FrameworkMockConfigurator.telemetry.adapter` rather than constructing this
+ * directly.
+ *
+ * @example
+ * ```ts
+ * import { MockTelemetryAdapter } from '@equinor/fusion-framework-module-telemetry/mock';
+ *
+ * const recorder = new MockTelemetryAdapter();
+ * enableTelemetry(configurator, (builder) => {
+ *   builder.setAdapter('mock', recorder);
+ * });
+ *
+ * // ...later, in a test
+ * const item = await recorder.waitForItem('my-metric');
+ * expect(item.properties?.section).toBe('header');
+ * ```
+ */
+export class MockTelemetryAdapter extends BaseTelemetryAdapter {
+  #items: TelemetryItem[] = [];
+  #items$ = new Subject<TelemetryItem>();
+
+  /**
+   * Records the item so it is visible to {@link getItems} and any pending
+   * {@link waitForItem} calls.
+   *
+   * @param item - The telemetry item to record.
+   */
+  protected _processItem(item: TelemetryItem): void {
+    this.#items.push(item);
+    this.#items$.next(item);
+  }
+
+  /**
+   * Returns recorded items matching `matcher`, in processing order.
+   *
+   * @param matcher - Item name, array of names, or a predicate. Omit to get every recorded item.
+   * @returns Matching recorded items.
+   */
+  getItems(matcher?: TelemetryItemMatcher): TelemetryItem[] {
+    // No matcher: return every item recorded so far.
+    if (matcher === undefined) return [...this.#items];
+    // Narrow down to items accepted by the matcher.
+    return this.#items.filter((item) => this.#matches(item, matcher));
+  }
+
+  /**
+   * Waits for the next item matching `matcher`, resolving immediately if a
+   * matching item was already recorded.
+   *
+   * @param matcher - Item name, array of names, or a predicate.
+   * @param options - Optional timeout (ms) or AbortSignal.
+   * @returns A promise that resolves with the first matching item.
+   */
+  waitForItem(matcher: TelemetryItemMatcher, options?: WaitForItemOptions): Promise<TelemetryItem> {
+    // Check items recorded before this call, so callers don't miss items that already happened.
+    const recorded = this.#items.find((item) => this.#matches(item, matcher));
+    // Already recorded: resolve immediately rather than only watching future items.
+    if (recorded) return Promise.resolve(recorded);
+
+    return new Promise<TelemetryItem>((resolve, reject) => {
+      const { timeout: ms, signal } = options ?? {};
+
+      // Fail fast without subscribing when the caller already aborted.
+      if (signal?.aborted) {
+        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      // Declared before subscribing so `complete` can reach it even when the
+      // adapter is already disposed and fires synchronously during `subscribe`.
+      let sub: Subscription | undefined;
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        sub?.unsubscribe();
+      };
+
+      // Only forward items accepted by the matcher to the subscriber below.
+      sub = this.#items$.pipe(filter((item) => this.#matches(item, matcher))).subscribe({
+        next: (item) => {
+          cleanup();
+          resolve(item);
+        },
+        // A throwing predicate matcher surfaces here instead of hanging the promise forever.
+        error: (err) => {
+          cleanup();
+          reject(err);
+        },
+        complete: () => {
+          cleanup();
+          reject(new Error('MockTelemetryAdapter disposed before a matching item was recorded'));
+        },
+      });
+
+      // Only arm a timeout when the caller opted in.
+      if (ms !== undefined) {
+        timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`waitForItem timed out after ${ms}ms`));
+        }, ms);
+      }
+
+      // Only wire abort handling when the caller passed a signal.
+      if (signal) {
+        signal.addEventListener(
+          'abort',
+          () => {
+            cleanup();
+            reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+          },
+          { once: true },
+        );
+      }
+    });
+  }
+
+  /** Removes every recorded item, without affecting pending {@link waitForItem} calls. */
+  clear(): void {
+    this.#items = [];
+  }
+
+  /**
+   * Tests whether `item` satisfies `matcher`.
+   *
+   * @param item - Item to test.
+   * @param matcher - Item name, array of names, or a predicate.
+   * @returns Whether `item` matches.
+   */
+  #matches(item: TelemetryItem, matcher: TelemetryItemMatcher): boolean {
+    // String matcher: compare item name directly.
+    if (typeof matcher === 'string') return item.name === matcher;
+    // Array matcher: match against any of the given names.
+    if (Array.isArray(matcher)) return matcher.includes(item.name);
+    return matcher(item);
+  }
+
+  /** Completes the internal item stream, rejecting any pending `waitForItem` calls. */
+  [Symbol.dispose]() {
+    this.#items$.complete();
+  }
+}

--- a/packages/modules/telemetry/src/mock/MockTelemetryAdapter.ts
+++ b/packages/modules/telemetry/src/mock/MockTelemetryAdapter.ts
@@ -109,10 +109,15 @@ export class MockTelemetryAdapter extends BaseTelemetryAdapter {
       // Declared before subscribing so `complete` can reach it even when the
       // adapter is already disposed and fires synchronously during `subscribe`.
       let sub: Subscription | undefined;
+      // Named so `cleanup` can remove it directly instead of relying only on
+      // `{ once: true }`, which only removes it once it has actually fired.
+      let onAbort: (() => void) | undefined;
 
       const cleanup = () => {
         clearTimeout(timer);
         sub?.unsubscribe();
+        // Only registered when a signal was passed, and only once even if cleanup runs twice.
+        if (onAbort) signal?.removeEventListener('abort', onAbort);
       };
 
       // Only forward items accepted by the matcher to the subscriber below.
@@ -132,6 +137,11 @@ export class MockTelemetryAdapter extends BaseTelemetryAdapter {
         },
       });
 
+      // An adapter already disposed before this call completes the subscription
+      // synchronously above, settling the promise \u2014 arming a timeout or abort
+      // listener below would then leak resources tied to an already-settled promise.
+      if (sub.closed) return;
+
       // Only arm a timeout when the caller opted in.
       if (ms !== undefined) {
         timer = setTimeout(() => {
@@ -142,14 +152,11 @@ export class MockTelemetryAdapter extends BaseTelemetryAdapter {
 
       // Only wire abort handling when the caller passed a signal.
       if (signal) {
-        signal.addEventListener(
-          'abort',
-          () => {
-            cleanup();
-            reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-          },
-          { once: true },
-        );
+        onAbort = () => {
+          cleanup();
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
       }
     });
   }

--- a/packages/modules/telemetry/src/mock/TelemetryMockConfigurator.ts
+++ b/packages/modules/telemetry/src/mock/TelemetryMockConfigurator.ts
@@ -1,0 +1,44 @@
+import { TelemetryConfigurator } from '../TelemetryConfigurator.js';
+
+import { MockTelemetryAdapter } from './MockTelemetryAdapter.js';
+
+/**
+ * The real telemetry configurator, with a {@link MockTelemetryAdapter}
+ * registered by default so tracked telemetry never reaches a real backend
+ * unless a test adds its own adapter alongside it.
+ *
+ * @remarks
+ * Nothing else changes: `setMetadata`, `setDefaultScope`, `setParent`,
+ * `setFilter` and additional `setAdapter`/`configureAdapter` calls all behave
+ * exactly as they do on {@link TelemetryConfigurator}. Only the default
+ * adapter differs, so a test observes the real telemetry pipeline —
+ * metadata merging, scoping, parent-provider relaying — rather than a
+ * rehearsal of it.
+ *
+ * @example
+ * ```typescript
+ * const configurator = new TelemetryMockConfigurator();
+ * const fusion = await init(configurator);
+ *
+ * // ...exercise the app under test, then assert:
+ * const item = await configurator.adapter.waitForItem('my-metric');
+ * ```
+ */
+export class TelemetryMockConfigurator extends TelemetryConfigurator {
+  /** The adapter every telemetry item processed through this configurator is recorded to. */
+  public readonly adapter: MockTelemetryAdapter;
+
+  /**
+   * Creates a telemetry configurator backed by a {@link MockTelemetryAdapter}.
+   *
+   * @param adapter - The adapter to register by default. Defaults to a new,
+   *   empty {@link MockTelemetryAdapter}.
+   */
+  constructor(adapter: MockTelemetryAdapter = new MockTelemetryAdapter()) {
+    super();
+    this.adapter = adapter;
+    this.setAdapter('mock', adapter);
+  }
+}
+
+export default TelemetryMockConfigurator;

--- a/packages/modules/telemetry/src/mock/index.ts
+++ b/packages/modules/telemetry/src/mock/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Test doubles for the telemetry module.
+ *
+ * @remarks
+ * Imported from `@equinor/fusion-framework-module-telemetry/mock`, so the mock
+ * ships and versions with the implementation it stands in for.
+ *
+ * The mock replaces only the adapter telemetry items reach — everything
+ * around it (metadata merging, default scoping, parent-provider relaying) is
+ * the real `TelemetryProvider`, so a test still exercises how the application
+ * tracks telemetry, not just canned data.
+ *
+ * @example
+ * ```typescript
+ * import { enableTelemetryMock } from '@equinor/fusion-framework-module-telemetry/mock';
+ *
+ * enableTelemetryMock(configurator);
+ * ```
+ *
+ * @packageDocumentation
+ */
+export {
+  MockTelemetryAdapter,
+  type TelemetryItemMatcher,
+  type WaitForItemOptions,
+} from './MockTelemetryAdapter.js';
+export { TelemetryMockConfigurator } from './TelemetryMockConfigurator.js';
+export { enableTelemetryMock, telemetryMockModule, type TelemetryConfigMockFn } from './module.js';

--- a/packages/modules/telemetry/src/mock/module.ts
+++ b/packages/modules/telemetry/src/mock/module.ts
@@ -1,0 +1,58 @@
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+import { module as telemetryModule, type TelemetryModule } from '../module.js';
+
+import { TelemetryMockConfigurator } from './TelemetryMockConfigurator.js';
+
+/**
+ * The telemetry module with a {@link TelemetryMockConfigurator} instead of a
+ * configurator that answers to whichever adapters an application registers.
+ *
+ * @remarks
+ * Only `configure` differs from the real module. `initialize` is the
+ * production one, untouched, so metadata merging, scoping and parent-provider
+ * relaying all behave exactly as they do in production — a test observes the
+ * real telemetry pipeline rather than a rehearsal of it.
+ */
+export const telemetryMockModule: TelemetryModule = {
+  ...telemetryModule,
+  configure: () => new TelemetryMockConfigurator(),
+};
+
+/**
+ * Configuration callback for {@link enableTelemetryMock}.
+ */
+export type TelemetryConfigMockFn<TRef = unknown> = (
+  configurator: TelemetryMockConfigurator,
+  ref?: TRef,
+) => void;
+
+/**
+ * Enables telemetry against a recording mock adapter, so a test can assert on
+ * tracked telemetry without any of it reaching a real backend.
+ *
+ * @remarks
+ * Registered last, this replaces whichever telemetry module the configurator
+ * already carries, so it works on a `FrameworkConfigurator` that pre-registers
+ * the real one.
+ *
+ * @param configurator - The modules configurator to register on.
+ * @param configure - Optional callback to further configure the mock, such as
+ *   registering an additional adapter alongside the recording one.
+ *
+ * @example
+ * ```typescript
+ * enableTelemetryMock(configurator, (builder) => {
+ *   builder.setDefaultScope(['app']);
+ * });
+ * ```
+ */
+export const enableTelemetryMock = (
+  // biome-ignore lint/suspicious/noExplicitAny: must be any to support all module types
+  configurator: IModulesConfigurator<any, any>,
+  configure?: TelemetryConfigMockFn,
+): void => {
+  configurator.addConfig({ module: telemetryMockModule, configure } as {
+    module: TelemetryModule;
+  });
+};


### PR DESCRIPTION
**Why is this change needed?**
`mockFramework()` already backs `msal`, `http`, `service-discovery` and `context` with test doubles, but `telemetry` still fell through to the real `TelemetryConfigurator` — any telemetry tracked through a mocked framework instance reached Application Insights (or errored without an instrumentation key). This was a known, explicitly flagged gap in `FrameworkMockConfigurator`'s own doc comment and in #1659's notes.

**What is the current behavior?**
`FrameworkMockConfigurator.telemetry` pins and returns the real `TelemetryConfigurator`. A test tracking telemetry through `fusion.modules.telemetry` has no way to read back what was tracked without a real adapter reaching a real endpoint.

**What is the new behavior?**
- `@equinor/fusion-framework-module-telemetry/mock` is a new subpath exporting `MockTelemetryAdapter` (a collecting adapter with `getItems(matcher?)` / `waitForItem(matcher, options?)` / `clear()`, mirroring `MockAnalyticsAdapter`'s shape), `TelemetryMockConfigurator`, `telemetryMockModule`, and `enableTelemetryMock`.
- `FrameworkMockConfigurator.telemetry` now returns `TelemetryMockConfigurator`, so `mockFramework()` needs zero network access or App Insights instrumentation key for the full built-in module set.

**What is the intended behavior or invariant?**
Tracking a telemetry event or measurement through a mocked framework instance never reaches App Insights or any real endpoint. The real `TelemetryProvider`'s merging logic (metadata, scope, parent-chain) still runs — only the emit boundary (the adapter) is substituted. Existing `enableTelemetry`/`configureTelemetry` call sites keep working unchanged, since `TelemetryMockConfigurator` is still a real `TelemetryConfigurator`.

**Does this PR introduce a breaking change?**
No. `TelemetryMockConfigurator` extends the real `TelemetryConfigurator`, so existing code reading `.telemetry` through its `ITelemetryConfigurator` interface is unaffected. Code relying on `.telemetry` being exactly the real configurator instance should read tracked items back through `.telemetry.adapter` instead.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor for both `@equinor/fusion-framework-module-telemetry` and `@equinor/fusion-framework` (changesets included)
- Consumer impact: New opt-in `/mock` entry point; `FrameworkMockConfigurator.telemetry`'s return type changes from `ITelemetryConfigurator` to `TelemetryMockConfigurator` (a superset)
- Downstream impact: None outside these two packages

**Review guidance:**
Focus on `MockTelemetryAdapter.waitForItem` (timeout/AbortSignal/dispose races) and the `FrameworkMockConfigurator` doc-comment update, which now only lists `services` as the remaining unmocked built-in module.

**Additional context**
Precedent: `packages/modules/http/src/mock/`, `packages/modules/msal/src/mock/`, `packages/modules/context/src/mock/` for the `_pin`/`./mock`-entry-point pattern; `@equinor/fusion-framework-module-analytics`'s `MockAnalyticsAdapter` for the collecting-adapter shape.

**Related issues**
closes: equinor/fusion-core-tasks#1708

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable (n/a — no React code)
- [ ] Confirm README/docs are updated for user-facing changes (n/a — changeset covers the new API; no README changes)
- [x] Confirm changes to target branch validation
  - Included files validated (biome lint, fusion-lint, `tsc -b`, vitest all pass for `packages/modules/telemetry` and `packages/framework`)
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
