### PR TITLE
docs(react-app): add app testing guide

### DIFF
--- a/.changeset/app_enable-app-manifest-mock-asset-uri.md
+++ b/.changeset/app_enable-app-manifest-mock-asset-uri.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-app": minor
+---
+
+`enableAppManifestMock` accepts an optional third `assetUri` argument, overriding the base URI a loaded app's script is imported from — useful for tests that dynamically import a real fixture script. `env.config` is now optional; when omitted, a trivial `AppConfig` is used so `App.initialize()` can still resolve.

--- a/.changeset/react-app_fix-docs-accuracy.md
+++ b/.changeset/react-app_fix-docs-accuracy.md
@@ -1,0 +1,10 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Fix documentation accuracy issues found while adding hook test coverage:
+
+- The README and a deprecated `createComponent` example showed `configurator.http.configureClient(...)` for registering an app's HTTP client. That property only exists on the test/mock configurator (`AppMockConfigurator`) — real app configuration must use `configurator.configureHttpClient(...)` from `IAppConfigurator`. Both examples now use the correct API.
+- `docs/context.md` and `docs/framework.md` documented `setCurrentContext`/`useFrameworkCurrentContext`'s setter as returning `void`. It actually returns `void | Promise<ContextItem | null>` — `void` when clearing the context, a `Promise` when setting by id or by item — and can be awaited to know when the switch completes.
+- `docs/msal.md` documented `AuthenticationResult.account`/`expiresOn` as non-nullable; both are actually nullable (`AccountInfo | null`, `Date | null`), and the `useToken` example has been updated to guard against a `null` `expiresOn`.
+- `docs/bookmark.md` now documents `useCurrentBookmark`'s deprecated fallback to the framework-scoped bookmark provider (and the `@deprecation` console warning it logs) when an app hasn't called `enableBookmark`.

--- a/.changeset/react-app_render-app-component-testing.md
+++ b/.changeset/react-app_render-app-component-testing.md
@@ -1,0 +1,16 @@
+---
+"@equinor/fusion-framework-react-app": minor
+---
+
+Add `renderAppComponent` to the `/testing` entry-point, a component-level counterpart to `renderAppHook` for testing components (not just hooks) against a real, mock-backed application module scope.
+
+```tsx
+import { renderAppComponent } from '@equinor/fusion-framework-react-app/testing';
+import { waitFor } from '@testing-library/react';
+import { Apploader } from '../apploader/Apploader';
+
+const { container } = await renderAppComponent(<Apploader appKey="child-app" />);
+await waitFor(() => expect(container.textContent).toContain('mounted'));
+```
+
+`renderAppComponent` wraps `@testing-library/react`'s `render` with the same `FrameworkProvider` + `ModuleProvider` nesting `renderAppHook` uses, backed by `mockFramework` and `mockAppModules` (`@equinor/fusion-framework-app/mock`), so tests can render a real component tree without hand-wiring those mocks.

--- a/.changeset/react-app_render-app-hook-testing.md
+++ b/.changeset/react-app_render-app-hook-testing.md
@@ -1,0 +1,17 @@
+---
+"@equinor/fusion-framework-react-app": minor
+---
+
+Add a `/testing` entry-point with `renderAppHook`, a pre-wrapped `renderHook` for testing app-scoped hooks (`useAppModule`, `useAccessToken`, etc.) against a real, mock-backed module and framework instance.
+
+```tsx
+import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
+import { waitFor } from '@testing-library/react';
+
+const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+await waitFor(() => expect(result.current.pending).toBe(false));
+```
+
+`renderAppHook` wraps the hook with the same `FrameworkProvider` + `ModuleProvider` nesting `renderApp` uses in production, backed by `mockFramework` and `mockAppModules` (`@equinor/fusion-framework-app/mock`), so app teams no longer need to hand-wire those mocks in every test.
+
+Requires `@testing-library/react` (added as an optional peer dependency).

--- a/.changeset/react-app_testing-docs.md
+++ b/.changeset/react-app_testing-docs.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-react-app": patch
+---
+
+Document the supported `renderAppHook` and `renderAppComponent` testing helpers so app teams can verify app-scoped hooks and components against a real, mock-backed application module scope.
+
+Closes #1716.

--- a/.changeset/react-app_testing-docs.md
+++ b/.changeset/react-app_testing-docs.md
@@ -4,4 +4,4 @@
 
 Document the supported `renderAppHook` and `renderAppComponent` testing helpers so app teams can verify app-scoped hooks and components against a real, mock-backed application module scope.
 
-Closes #1716.
+Closes equinor/fusion-core-tasks#1716.

--- a/packages/app/src/__tests__/mock/msal-hoisting.test.ts
+++ b/packages/app/src/__tests__/mock/msal-hoisting.test.ts
@@ -31,13 +31,15 @@ describe('msal hoisting', () => {
 
   it('surfaces the parent’s acquisition failures instead of falling back to its own client', async () => {
     const fusion = await mockFramework();
-    vi.spyOn(fusion.modules.auth, 'acquireToken').mockRejectedValue(new Error('acquisition failed'));
+    vi.spyOn(fusion.modules.auth, 'acquireToken').mockRejectedValue(
+      new Error('acquisition failed'),
+    );
 
     const modules = await mockAppModules(undefined, env, fusion);
 
-    await expect(
-      modules.auth.acquireToken({ request: { scopes: ['User.Read'] } }),
-    ).rejects.toThrow('acquisition failed');
+    await expect(modules.auth.acquireToken({ request: { scopes: ['User.Read'] } })).rejects.toThrow(
+      'acquisition failed',
+    );
   });
 
   it('reflects the parent’s signed-in account rather than signing in its own', async () => {

--- a/packages/app/src/__tests__/mock/msal-hoisting.test.ts
+++ b/packages/app/src/__tests__/mock/msal-hoisting.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import type { AuthenticationResult } from '@equinor/fusion-framework-module-msal';
+
+import { mockAppModules } from '../../mock/mock-app-modules.js';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+describe('msal hoisting', () => {
+  it('delegates acquireToken to the parent’s auth module instead of building its own client', async () => {
+    const fusion = await mockFramework();
+    const result = { accessToken: 'parent-issued-token' } as AuthenticationResult;
+    vi.spyOn(fusion.modules.auth, 'acquireToken').mockResolvedValue(result);
+
+    const modules = await mockAppModules(undefined, env, fusion);
+
+    // the app's own `auth` is a distinct (proxying) object, not the parent's instance itself
+    expect(modules.auth).not.toBe(fusion.modules.auth);
+    await expect(
+      modules.auth.acquireToken({ request: { scopes: ['User.Read'] } }),
+    ).resolves.toMatchObject({ accessToken: 'parent-issued-token' });
+  });
+
+  it('surfaces the parent’s acquisition failures instead of falling back to its own client', async () => {
+    const fusion = await mockFramework();
+    vi.spyOn(fusion.modules.auth, 'acquireToken').mockRejectedValue(new Error('acquisition failed'));
+
+    const modules = await mockAppModules(undefined, env, fusion);
+
+    await expect(
+      modules.auth.acquireToken({ request: { scopes: ['User.Read'] } }),
+    ).rejects.toThrow('acquisition failed');
+  });
+
+  it('reflects the parent’s signed-in account rather than signing in its own', async () => {
+    const fusion = await mockFramework((configurator) => {
+      configurator.msal.setAccount({ name: 'Ada Lovelace' });
+    });
+
+    const modules = await mockAppModules(undefined, env, fusion);
+
+    expect(modules.auth.account?.name).toBe('Ada Lovelace');
+  });
+});

--- a/packages/app/src/mock/enable-app-manifest-mock.ts
+++ b/packages/app/src/mock/enable-app-manifest-mock.ts
@@ -39,8 +39,9 @@ export function enableAppManifestMock<TEnv extends AppEnv>(
   assetUri?: string,
 ): void {
   enableAppModule(configurator, (builder) => {
-    // only override the default asset base when the caller supplies one
-    if (assetUri) {
+    // only override the default asset base when the caller supplies one; an
+    // explicit empty string is meaningful (selects a root-relative script path)
+    if (assetUri !== undefined) {
       builder.setAssetUri(assetUri);
     }
     builder.setClient(async ({ requireInstance }) => {
@@ -49,7 +50,11 @@ export function enableAppManifestMock<TEnv extends AppEnv>(
         ? http.createClient('apps')
         : await (await requireInstance('serviceDiscovery')).createClient('apps');
       // fall back to a trivial config so `App.initialize()` can resolve without a caller-supplied one
-      return new MockAppClient(client, env.manifest, env.config ?? new AppConfig<ConfigEnvironment>({ environment: {} }));
+      return new MockAppClient(
+        client,
+        env.manifest,
+        env.config ?? new AppConfig<ConfigEnvironment>({ environment: {} }),
+      );
     });
   });
 }

--- a/packages/app/src/mock/enable-app-manifest-mock.ts
+++ b/packages/app/src/mock/enable-app-manifest-mock.ts
@@ -1,6 +1,7 @@
 import type { FrameworkMockConfigurator } from '@equinor/fusion-framework/mock';
-import { enableAppModule, type AppModule } from '@equinor/fusion-framework-module-app';
+import { AppConfig, enableAppModule, type AppModule } from '@equinor/fusion-framework-module-app';
 import { MockAppClient } from '@equinor/fusion-framework-module-app/mock';
+import type { ConfigEnvironment } from '@equinor/fusion-framework-module-app';
 
 import type { AppEnv } from '../types.js';
 
@@ -20,6 +21,7 @@ import type { AppEnv } from '../types.js';
  *
  * @param configurator - The parent framework's mock configurator, with `app` in its module set.
  * @param env - The application environment whose manifest (and optional config) should be served.
+ * @param assetUri - Overrides the base URI a loaded app's script is imported from.
  * @template TEnv - The application environment descriptor.
  *
  * @example Custom service discovery, same manifest resolution
@@ -34,14 +36,20 @@ import type { AppEnv } from '../types.js';
 export function enableAppManifestMock<TEnv extends AppEnv>(
   configurator: FrameworkMockConfigurator<[AppModule]>,
   env: TEnv,
+  assetUri?: string,
 ): void {
   enableAppModule(configurator, (builder) => {
+    // only override the default asset base when the caller supplies one
+    if (assetUri) {
+      builder.setAssetUri(assetUri);
+    }
     builder.setClient(async ({ requireInstance }) => {
       const http = await requireInstance('http');
       const client = http.hasClient('apps')
         ? http.createClient('apps')
         : await (await requireInstance('serviceDiscovery')).createClient('apps');
-      return new MockAppClient(client, env.manifest, env.config);
+      // fall back to a trivial config so `App.initialize()` can resolve without a caller-supplied one
+      return new MockAppClient(client, env.manifest, env.config ?? new AppConfig<ConfigEnvironment>({ environment: {} }));
     });
   });
 }

--- a/packages/modules/msal/src/__tests__/create-proxy-provider.test.ts
+++ b/packages/modules/msal/src/__tests__/create-proxy-provider.test.ts
@@ -14,7 +14,9 @@ type MockMsalClient = {
 
 const createClient = (): MockMsalClient => {
   const acquireToken = vi.fn(async () => ({ accessToken: 'v4-token' }) as AuthenticationResult);
-  const handleRedirectPromise = vi.fn(async () => ({ accessToken: 'redirect-token' }) as AuthenticationResult);
+  const handleRedirectPromise = vi.fn(
+    async () => ({ accessToken: 'redirect-token' }) as AuthenticationResult,
+  );
 
   return {
     client: {

--- a/packages/modules/msal/src/__tests__/create-proxy-provider.test.ts
+++ b/packages/modules/msal/src/__tests__/create-proxy-provider.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IMsalClient } from '../MsalClient.interface';
+import type { MsalConfig } from '../MsalConfigurator';
+import { MsalProvider } from '../MsalProvider';
+import { MsalModuleVersion } from '../static';
+import type { AuthenticationResult } from '../types';
+import type { IMsalProvider as IMsalProvider_v2 } from '../v2/MsalProvider.interface';
+
+type MockMsalClient = {
+  client: IMsalClient;
+  acquireToken: ReturnType<typeof vi.fn>;
+  handleRedirectPromise: ReturnType<typeof vi.fn>;
+};
+
+const createClient = (): MockMsalClient => {
+  const acquireToken = vi.fn(async () => ({ accessToken: 'v4-token' }) as AuthenticationResult);
+  const handleRedirectPromise = vi.fn(async () => ({ accessToken: 'redirect-token' }) as AuthenticationResult);
+
+  return {
+    client: {
+      clientId: 'test-client-id',
+      initialize: vi.fn(async () => undefined),
+      acquireToken,
+      handleRedirectPromise,
+      setActiveAccount: vi.fn(),
+      getActiveAccount: vi.fn(() => null),
+    } as unknown as IMsalClient,
+    acquireToken,
+    handleRedirectPromise,
+  };
+};
+
+const createConfig = (client: IMsalClient): MsalConfig => ({
+  client,
+  version: '7.0.0',
+  requiresAuth: false,
+  telemetry: {
+    metadata: { module: 'msal', version: '7.0.0' },
+    scope: ['framework', 'authentication'],
+  },
+});
+
+describe('MsalProvider.createProxyProvider (v2)', () => {
+  it('tags the proxy as v2 while delegating through the same v4 provider', () => {
+    const mockClient = createClient();
+    const provider = new MsalProvider(createConfig(mockClient.client));
+
+    const v2Provider = provider.createProxyProvider<IMsalProvider_v2>(MsalModuleVersion.V2);
+
+    expect(v2Provider.msalVersion).toBe(MsalModuleVersion.V2);
+  });
+
+  it('adapts the legacy v2 acquireToken shape into a v4 request before delegating', async () => {
+    const mockClient = createClient();
+    const provider = new MsalProvider(createConfig(mockClient.client));
+    const v2Provider = provider.createProxyProvider<IMsalProvider_v2>(MsalModuleVersion.V2);
+
+    await expect(v2Provider.acquireToken({ scopes: ['User.Read'] })).resolves.toMatchObject({
+      accessToken: 'v4-token',
+    });
+
+    expect(mockClient.acquireToken).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.objectContaining({ scopes: ['User.Read'] }) }),
+    );
+  });
+
+  it('discards the host’s redirect result, honoring v2’s null contract, while still processing it', async () => {
+    const mockClient = createClient();
+    const provider = new MsalProvider(createConfig(mockClient.client));
+    const v2Provider = provider.createProxyProvider<IMsalProvider_v2>(MsalModuleVersion.V2);
+
+    await expect(v2Provider.handleRedirect()).resolves.toBeNull();
+    expect(mockClient.handleRedirectPromise).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/app/README.md
+++ b/packages/react/app/README.md
@@ -25,7 +25,7 @@ pnpm add @equinor/fusion-framework-react-app
 import type { AppModuleInitiator } from '@equinor/fusion-framework-react-app';
 
 export const configure: AppModuleInitiator = (configurator) => {
-  configurator.http.configureClient('my-api', {
+  configurator.configureHttpClient('my-api', {
     baseUri: 'https://api.example.com',
     defaultScopes: ['api://my-api/.default'],
   });
@@ -225,7 +225,7 @@ Application configuration is done via a callback passed to `renderApp` (or `make
 ```ts
 const configure: AppModuleInitiator = (configurator) => {
   // HTTP clients
-  configurator.http.configureClient('my-api', { baseUri: '...' });
+  configurator.configureHttpClient('my-api', { baseUri: '...' });
 
   // Feature flags
   enableFeatureFlag(configurator, [{ key: 'beta', title: 'Beta' }]);

--- a/packages/react/app/README.md
+++ b/packages/react/app/README.md
@@ -170,7 +170,9 @@ const EnvInfo = () => {
 
 `renderAppHook` renders a hook inside a real, mock-backed application module scope — a
 `FrameworkProvider` and `ModuleProvider` wired the same way `renderApp` wires them in
-production, just with the network boundary faked (via `@equinor/fusion-framework-app/mock`).
+production, just with the network boundary faked for requests a seeded middleware answers
+(via `@equinor/fusion-framework-app/mock`) — an unmatched request still reaches the real
+network.
 
 ```tsx
 import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
@@ -216,7 +218,7 @@ test('resolves an access token', async () => {
 | `/apploader` | `Apploader`, `useApploader` |
 | `/framework` | `useFramework`, `useCurrentUser`, `useFrameworkHttpClient` |
 | `/widget` | Widget entry-point |
-| `/testing` | `renderAppHook` — pre-wrapped `renderHook` for testing app-scoped hooks |
+| `/testing` | `renderAppHook`, `renderAppComponent` — pre-wrapped `renderHook`/`render` for testing app-scoped hooks and components |
 
 ## Configuration
 

--- a/packages/react/app/README.md
+++ b/packages/react/app/README.md
@@ -164,6 +164,26 @@ const EnvInfo = () => {
 };
 ```
 
+### Testing a hook
+
+> **Note:** Requires `@testing-library/react` (optional peer dependency).
+
+`renderAppHook` renders a hook inside a real, mock-backed application module scope — a
+`FrameworkProvider` and `ModuleProvider` wired the same way `renderApp` wires them in
+production, just with the network boundary faked (via `@equinor/fusion-framework-app/mock`).
+
+```tsx
+import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
+import { waitFor } from '@testing-library/react';
+import { useAccessToken } from '@equinor/fusion-framework-react-app/msal';
+
+test('resolves an access token', async () => {
+  const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+  await waitFor(() => expect(result.current.pending).toBe(false));
+  expect(result.current.token).toBeDefined();
+});
+```
+
 ## API Reference
 
 ### Core exports (main entry-point)
@@ -196,6 +216,7 @@ const EnvInfo = () => {
 | `/apploader` | `Apploader`, `useApploader` |
 | `/framework` | `useFramework`, `useCurrentUser`, `useFrameworkHttpClient` |
 | `/widget` | Widget entry-point |
+| `/testing` | `renderAppHook` — pre-wrapped `renderHook` for testing app-scoped hooks |
 
 ## Configuration
 

--- a/packages/react/app/docs/bookmark.md
+++ b/packages/react/app/docs/bookmark.md
@@ -78,6 +78,13 @@ const MyApp = () => {
 };
 ```
 
+> [!WARNING]
+> If your app has **not** called `enableBookmark`, `useCurrentBookmark` falls back to the
+> portal's framework-scoped bookmark provider and logs a `@deprecation` console warning
+> (`"application has not enabled bookmarks, this will not work in the future"`). This
+> fallback is deprecated and will be removed — always call `enableBookmark` in apps that
+> use bookmarks.
+
 ## useBookmark (Deprecated)
 
 > [!CAUTION]

--- a/packages/react/app/docs/context.md
+++ b/packages/react/app/docs/context.md
@@ -29,11 +29,13 @@ Returns the currently selected context from the application-scoped context modul
 ```ts
 function useCurrentContext(): {
   currentContext: ContextItem | null | undefined;
-  setCurrentContext: (context?: ContextItem | string | null) => void;
+  setCurrentContext: (context?: ContextItem | string | null) => void | Promise<ContextItem | null>;
 };
 ```
 
 **Returns:** An object with the current context (`ContextItem | null | undefined`) and a setter to change it.
+
+`setCurrentContext` clears the context when called with no argument (or `null`), resolves an item by `id` when given a `string`, or sets the given `ContextItem` directly. Clearing returns `void`; setting by `id` or by item returns a `Promise` that resolves once the switch completes — `await` it when you need to know the new context has taken effect (e.g. before navigating).
 
 ### Example
 

--- a/packages/react/app/docs/framework.md
+++ b/packages/react/app/docs/framework.md
@@ -31,11 +31,11 @@ Use this when your app hasn't configured its own context module but still needs 
 ```ts
 function useFrameworkCurrentContext(): {
   currentContext: ContextItem | undefined;
-  setCurrentContext: (entry?: ContextItem | string | null) => void;
+  setCurrentContext: (entry?: ContextItem | string | null) => void | Promise<ContextItem | null>;
 };
 ```
 
-**Returns:** An object with `currentContext` (the portal's active context, or `undefined` if none is selected) and `setCurrentContext` to change it.
+**Returns:** An object with `currentContext` (the portal's active context, or `undefined` if none is selected) and `setCurrentContext` to change it. Clearing (no argument or `null`) returns `void`; setting by `id` or by item returns a `Promise` that resolves once the switch completes.
 
 **Example:**
 

--- a/packages/react/app/docs/msal.md
+++ b/packages/react/app/docs/msal.md
@@ -116,7 +116,7 @@ const TokenInfo = () => {
   return (
     <div>
       <p>Access Token: {token.accessToken.substring(0, 20)}...</p>
-      <p>Expires: {new Date(token.expiresOn).toLocaleString()}</p>
+      <p>Expires: {token.expiresOn?.toLocaleString() ?? 'unknown'}</p>
       <p>Token Type: {token.tokenType}</p>
       <p>Scope: {token.scopes.join(', ')}</p>
     </div>
@@ -134,8 +134,8 @@ const TokenInfo = () => {
 
 **Note:** The `AuthenticationResult` type includes:
 - `accessToken: string`
-- `account: AccountInfo`
-- `expiresOn: Date`
+- `account: AccountInfo | null`
+- `expiresOn: Date | null`
 - `tokenType: string`
 - `scopes: string[]`
 - And more...

--- a/packages/react/app/docs/testing.md
+++ b/packages/react/app/docs/testing.md
@@ -23,7 +23,8 @@ instance) around a `ModuleProvider` (the app's own modules).
 `renderAppHook` and `renderAppComponent` build that nesting for you, using
 `mockFramework` (`@equinor/fusion-framework/mock`) and `mockAppModules`
 (`@equinor/fusion-framework-app/mock`) — the **real** `event`/`http`/`msal` module
-pipeline, with only the network boundary faked. This means:
+pipeline. Only requests a seeded middleware answers are faked; a request with no
+matching middleware still reaches the real network. This means:
 
 - MSAL signs in a default "Test User" with zero configuration — `useAccessToken`/`useToken`
   resolve a real, structurally-valid (unsigned) JWT out of the box.
@@ -167,6 +168,23 @@ test('mounts the child app once its script loads', async () => {
   // the loading state renders synchronously, before the script's dynamic import resolves
   expect(container.textContent).toContain('Loading child-app');
   await waitFor(() => expect(container.textContent).toContain('mounted: child-app'));
+});
+
+test('surfaces the load error instead of throwing when the script fails to import', async () => {
+  const manifest: AppManifest = {
+    appKey: 'broken-app',
+    displayName: 'Broken App',
+    description: 'An application whose build entry point does not exist',
+    type: 'standalone',
+    build: { version: '1.0.0', entryPoint: 'does-not-exist.ts', assetPath: '' },
+  };
+  const fusion = await mockFramework<[AppModule]>((configurator) =>
+    enableAppManifestMock(configurator, { manifest }, someFixturesUri),
+  );
+
+  const { container } = await renderAppComponent(<Apploader appKey="broken-app" />, { fusion });
+
+  await waitFor(() => expect(container.textContent).toContain('Error loading broken-app'));
 });
 ```
 

--- a/packages/react/app/docs/testing.md
+++ b/packages/react/app/docs/testing.md
@@ -1,0 +1,183 @@
+# Testing
+
+Render app-scoped hooks and components against a real, mock-backed application module
+scope using `renderAppHook` and `renderAppComponent`.
+
+**Import:**
+
+```ts
+import { renderAppHook, renderAppComponent } from '@equinor/fusion-framework-react-app/testing';
+```
+
+> [!IMPORTANT]
+> Requires `@testing-library/react` (optional peer dependency) to be installed.
+
+## Overview
+
+Any hook or component that reads from the application module scope — `useAppModule`,
+`useAccessToken`, `useCurrentContext`, `useCurrentBookmark`, `useAppSetting`, and so on — or
+from the parent framework via `useFramework`, needs to run inside the same provider nesting
+`renderApp`/`createComponent` wire up in production: a `FrameworkProvider` (the parent Fusion
+instance) around a `ModuleProvider` (the app's own modules).
+
+`renderAppHook` and `renderAppComponent` build that nesting for you, using
+`mockFramework` (`@equinor/fusion-framework/mock`) and `mockAppModules`
+(`@equinor/fusion-framework-app/mock`) — the **real** `event`/`http`/`msal` module
+pipeline, with only the network boundary faked. This means:
+
+- MSAL signs in a default "Test User" with zero configuration — `useAccessToken`/`useToken`
+  resolve a real, structurally-valid (unsigned) JWT out of the box.
+- `event` dispatches and listens for real `FrameworkEvent`s.
+- Anything that talks to an HTTP endpoint (e.g. an app's own manifest, settings) is answered
+  by a mock client rather than a real network call — see each hook's own docs for what's
+  pre-wired versus what you need to seed yourself (e.g. via `enableBookmarkMock`,
+  `enableContextMock`, `enableFeatureFlagMock`, or a `configurator.http.addMiddleware(...)`
+  router).
+
+Use `renderAppHook` for a hook in isolation; use `renderAppComponent` when you need to
+assert on rendered output (e.g. loading/error states, DOM structure).
+
+## renderAppHook
+
+Renders a hook inside a real, mock-backed application module scope.
+
+**Signature:**
+
+```ts
+function renderAppHook<Result, Props = undefined, TModules = unknown, TEnv extends AppEnv = AppEnv>(
+  render: (initialProps: Props) => Result,
+  options?: {
+    configure?: AppMockConfigureFn<TModules, TEnv>;
+    env?: TEnv;
+    fusion?: Fusion;
+  } & Omit<RenderHookOptions<Props>, 'wrapper'>,
+): Promise<RenderHookResult<Result, Props>>;
+```
+
+| Option      | Description                                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------------------------|
+| `configure` | Callback forwarded to `mockAppModules` for seeding app-scope modules (bookmark, context, feature-flag, msal, etc.) |
+| `env`       | The application environment (manifest); defaults to a generic standalone `test-app`                                |
+| `fusion`    | The parent Fusion instance; defaults to a fresh `mockFramework` instance serving this app's own manifest           |
+
+Any other `renderHook` option (e.g. `initialProps`) is forwarded as-is.
+
+### Basic Usage
+
+```tsx
+import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
+import { waitFor } from '@testing-library/react';
+import { useAccessToken } from '@equinor/fusion-framework-react-app/msal';
+
+test('resolves an access token', async () => {
+  const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+  await waitFor(() => expect(result.current.pending).toBe(false));
+  expect(result.current.token).toBeDefined();
+});
+```
+
+### Sign In a Named User
+
+Pass `configure` to reach the msal mock's builder before the hook renders:
+
+```tsx
+import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
+import { useCurrentAccount } from '@equinor/fusion-framework-react-app/msal';
+
+test('reads the configured account', async () => {
+  const { result } = await renderAppHook(() => useCurrentAccount(), {
+    configure: (configurator) => configurator.msal.setAccount({ name: 'Ada Lovelace' }),
+  });
+  expect(result.current).toMatchObject({ name: 'Ada Lovelace' });
+});
+```
+
+### Reuse a Pre-Built Parent Fusion Instance
+
+Build the `fusion` instance yourself when a test needs to pre-configure parent-level
+modules (`http`, `context`, `serviceDiscovery`) or share one instance across multiple render
+calls:
+
+```tsx
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { renderAppHook } from '@equinor/fusion-framework-react-app/testing';
+import { useAccessToken } from '@equinor/fusion-framework-react-app/msal';
+import { useCurrentAccount } from '@equinor/fusion-framework-react-app/msal';
+
+const env = { manifest: { appKey: 'test-app', displayName: 'Test App', description: '', type: 'standalone' as const } };
+
+test('shares one fusion instance across two renders', async () => {
+  const fusion = await mockFramework<[AppModule]>((configurator) =>
+    enableAppManifestMock(configurator, env),
+  );
+
+  const { result: a } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }), { fusion });
+  const { result: b } = await renderAppHook(() => useCurrentAccount(), { fusion });
+});
+```
+
+## renderAppComponent
+
+Renders a component inside the same real, mock-backed application module scope as
+`renderAppHook`. Use this when you need to assert on rendered output rather than a hook's
+return value — e.g. a component with its own loading/error states.
+
+**Signature:**
+
+```ts
+function renderAppComponent<TModules = unknown, TEnv extends AppEnv = AppEnv>(
+  ui: ReactElement,
+  options?: {
+    configure?: AppMockConfigureFn<TModules, TEnv>;
+    env?: TEnv;
+    fusion?: Fusion;
+  } & Omit<RenderOptions, 'wrapper'>,
+): Promise<RenderResult>;
+```
+
+Options are the same shape as `renderAppHook`'s — `configure`, `env`, `fusion` — plus any
+other `@testing-library/react` `render` option.
+
+### Example: Asserting Loading and Error States
+
+```tsx
+import { waitFor } from '@testing-library/react';
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppManifest, AppModule } from '@equinor/fusion-framework-module-app';
+import { renderAppComponent } from '@equinor/fusion-framework-react-app/testing';
+import { Apploader } from '@equinor/fusion-framework-react-app/apploader';
+
+test('mounts the child app once its script loads', async () => {
+  const manifest: AppManifest = {
+    appKey: 'child-app',
+    displayName: 'Child App',
+    description: 'A child application',
+    type: 'standalone',
+    build: { version: '1.0.0', entryPoint: 'child-script.ts', assetPath: '' },
+  };
+  const fusion = await mockFramework<[AppModule]>((configurator) =>
+    enableAppManifestMock(configurator, { manifest }, someFixturesUri),
+  );
+
+  const { container } = await renderAppComponent(<Apploader appKey="child-app" />, { fusion });
+
+  // the loading state renders synchronously, before the script's dynamic import resolves
+  expect(container.textContent).toContain('Loading child-app');
+  await waitFor(() => expect(container.textContent).toContain('mounted: child-app'));
+});
+```
+
+## Notes
+
+- Both helpers are `async` — always `await` them, since the mocked application module scope
+  (app manifest, module initialization) resolves asynchronously before the first render.
+- Seeding a module beyond the default set (bookmark, context, feature-flag) requires its own
+  mock enabler passed through `configure` — e.g. `enableBookmarkMock`, `enableContextMock`,
+  `enableFeatureFlagMock` from that module's own `/mock` sub-path.
+- `msal` ships enabled by default with a signed-in "Test User" — no `configure` needed unless
+  a test cares about a specific account or a signed-out state.
+- Prefer these helpers over hand-wiring `mockFramework`, `mockAppModules`,
+  `FrameworkProvider`, and `ModuleProvider` directly in every test.

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -152,6 +152,7 @@
     "@equinor/fusion-framework-module-event": "workspace:*",
     "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@equinor/fusion-framework-module-msal": "workspace:*",
+    "@equinor/fusion-framework-module-telemetry": "workspace:*",
     "@equinor/fusion-framework-react-module-bookmark": "workspace:*",
     "@equinor/fusion-framework-react-module-context": "workspace:*",
     "@equinor/fusion-framework-react-router": "workspace:*",

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -152,6 +152,7 @@
     "@equinor/fusion-framework-module-event": "workspace:*",
     "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@equinor/fusion-framework-module-bookmark": "workspace:*",
+    "@equinor/fusion-framework-module-context": "workspace:*",
     "@equinor/fusion-framework-module-msal": "workspace:*",
     "@equinor/fusion-framework-module-telemetry": "workspace:*",
     "@equinor/fusion-framework-react-module-bookmark": "workspace:*",

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -151,6 +151,7 @@
     "@equinor/fusion-framework-module-analytics": "workspace:*",
     "@equinor/fusion-framework-module-event": "workspace:*",
     "@equinor/fusion-framework-module-feature-flag": "workspace:*",
+    "@equinor/fusion-framework-module-bookmark": "workspace:*",
     "@equinor/fusion-framework-module-msal": "workspace:*",
     "@equinor/fusion-framework-module-telemetry": "workspace:*",
     "@equinor/fusion-framework-react-module-bookmark": "workspace:*",

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -64,6 +64,10 @@
     "./routing": {
       "types": "./dist/types/routing/index.d.ts",
       "import": "./dist/esm/routing/index.js"
+    },
+    "./testing": {
+      "types": "./dist/types/testing/index.d.ts",
+      "import": "./dist/esm/testing/index.js"
     }
   },
   "typesVersions": {
@@ -109,6 +113,9 @@
       ],
       "routing": [
         "dist/types/routing/index.d.ts"
+      ],
+      "testing": [
+        "dist/types/testing/index.d.ts"
       ]
     }
   },
@@ -129,6 +136,7 @@
     "directory": "packages/react"
   },
   "dependencies": {
+    "@equinor/fusion-framework": "workspace:*",
     "@equinor/fusion-framework-app": "workspace:*",
     "@equinor/fusion-framework-module": "workspace:*",
     "@equinor/fusion-framework-module-app": "workspace:*",
@@ -148,6 +156,7 @@
     "@equinor/fusion-framework-react-module-context": "workspace:*",
     "@equinor/fusion-framework-react-router": "workspace:*",
     "@equinor/fusion-observable": "workspace:*",
+    "@testing-library/react": "^16.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "happy-dom": "^20.8.4",
@@ -160,6 +169,7 @@
   "peerDependencies": {
     "@equinor/fusion-framework-module-msal": "workspace:^",
     "@equinor/fusion-framework-react-router": "workspace:^",
+    "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
@@ -194,6 +204,9 @@
       "optional": true
     },
     "@equinor/fusion-framework-react-router": {
+      "optional": true
+    },
+    "@testing-library/react": {
       "optional": true
     }
   }

--- a/packages/react/app/src/__tests__/Apploader.test.tsx
+++ b/packages/react/app/src/__tests__/Apploader.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppManifest, AppModule } from '@equinor/fusion-framework-module-app';
+
+import { Apploader } from '../apploader/Apploader';
+import { renderAppComponent } from '../testing/render-app-component';
+
+// resolved from this test file rather than hardcoded, so it survives a package move
+const fixturesUri = new URL('./fixtures', import.meta.url).pathname;
+
+describe('Apploader', () => {
+  it('mounts the child app’s rendered content once its script loads', async () => {
+    const manifest: AppManifest = {
+      appKey: 'child-app',
+      displayName: 'Child App',
+      description: 'A child application',
+      type: 'standalone',
+      build: { version: '1.0.0', entryPoint: 'apploader-child-script.ts', assetPath: '' },
+    };
+
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, { manifest }, fixturesUri),
+    );
+
+    const { container } = await renderAppComponent(<Apploader appKey="child-app" />, { fusion });
+
+    // the loading state renders synchronously, before the script's dynamic import resolves
+    expect(container.textContent).toContain('Loading child-app');
+    await waitFor(() => expect(container.textContent).toContain('mounted: child-app'));
+  });
+
+  it('surfaces the load error instead of throwing when the app’s script fails to import', async () => {
+    const manifest: AppManifest = {
+      appKey: 'broken-app',
+      displayName: 'Broken App',
+      description: 'An application whose build entry point does not exist',
+      type: 'standalone',
+      build: { version: '1.0.0', entryPoint: 'does-not-exist.ts', assetPath: '' },
+    };
+
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, { manifest }, fixturesUri),
+    );
+
+    const { container } = await renderAppComponent(<Apploader appKey="broken-app" />, { fusion });
+
+    await waitFor(() => expect(container.textContent).toContain('Error loading broken-app'));
+  });
+});

--- a/packages/react/app/src/__tests__/fixtures/apploader-child-script.ts
+++ b/packages/react/app/src/__tests__/fixtures/apploader-child-script.ts
@@ -1,0 +1,9 @@
+import type { AppScriptModule } from '@equinor/fusion-framework-module-app';
+
+// a minimal stand-in for a real app bundle's entry point, dynamically imported by `App.initialize()`
+export const renderApp: AppScriptModule['renderApp'] = (el, { env }) => {
+  el.textContent = `mounted: ${env.manifest?.appKey}`;
+  return () => {
+    el.textContent = '';
+  };
+};

--- a/packages/react/app/src/__tests__/useAccessToken.test.tsx
+++ b/packages/react/app/src/__tests__/useAccessToken.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+
+import { useAccessToken } from '../msal/useAccessToken';
+import { renderAppHook } from '../testing/render-app-hook';
+
+describe('useAccessToken', () => {
+  it('resolves an access token from the app scope’s real, mock-backed auth module', async () => {
+    // `renderAppHook` runs the real msal module against an in-process mock client,
+    // so `auth` behaves exactly as it would with a signed-in user in production.
+    const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.token).toBeUndefined();
+
+    await waitFor(() => expect(result.current.pending).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    // a structurally valid JWT has three dot-separated segments
+    expect(result.current.token?.split('.')).toHaveLength(3);
+  });
+
+  it('surfaces an acquisition error instead of throwing', async () => {
+    const fusion = await mockFramework();
+    // persistent, not `-Once`: the app module hoists via a version-compat proxy that
+    // may call through before the hook's own effect does, consuming a one-shot mock
+    vi.spyOn(fusion.modules.auth, 'acquireToken').mockRejectedValue(
+      new Error('acquisition failed'),
+    );
+
+    const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }), {
+      fusion,
+    });
+
+    await waitFor(() => expect(result.current.pending).toBe(false));
+
+    expect(result.current.token).toBeUndefined();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+
+

--- a/packages/react/app/src/__tests__/useAccessToken.test.tsx
+++ b/packages/react/app/src/__tests__/useAccessToken.test.tsx
@@ -10,7 +10,9 @@ describe('useAccessToken', () => {
   it('resolves an access token from the app scope’s real, mock-backed auth module', async () => {
     // `renderAppHook` runs the real msal module against an in-process mock client,
     // so `auth` behaves exactly as it would with a signed-in user in production.
-    const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+    const { result, unmount } = await renderAppHook(() =>
+      useAccessToken({ scopes: ['User.Read'] }),
+    );
 
     expect(result.current.pending).toBe(true);
     expect(result.current.token).toBeUndefined();
@@ -20,6 +22,10 @@ describe('useAccessToken', () => {
     expect(result.current.error).toBeNull();
     // a structurally valid JWT has three dot-separated segments
     expect(result.current.token?.split('.')).toHaveLength(3);
+
+    // unmount before the next test's environment tears down, so no acquisition
+    // effect can flush a state update against an already-destroyed `window`
+    unmount();
   });
 
   it('surfaces an acquisition error instead of throwing', async () => {
@@ -30,16 +36,18 @@ describe('useAccessToken', () => {
       new Error('acquisition failed'),
     );
 
-    const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }), {
-      fusion,
-    });
+    const { result, unmount } = await renderAppHook(
+      () => useAccessToken({ scopes: ['User.Read'] }),
+      {
+        fusion,
+      },
+    );
 
     await waitFor(() => expect(result.current.pending).toBe(false));
 
     expect(result.current.token).toBeUndefined();
     expect(result.current.error).toBeInstanceOf(Error);
+
+    unmount();
   });
 });
-
-
-

--- a/packages/react/app/src/__tests__/useAppSetting.test.tsx
+++ b/packages/react/app/src/__tests__/useAppSetting.test.tsx
@@ -1,0 +1,133 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { createRouterMiddleware } from '@equinor/fusion-framework-module-http/mock';
+
+import { useAppSetting } from '../settings/useAppSetting';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+/**
+ * Boots a parent framework whose `apps` client serves per-user settings from an
+ * in-memory store, so `useAppSetting` exercises the real fetch/update round-trip
+ * instead of a stubbed provider.
+ *
+ * @param initial - The settings the store starts seeded with.
+ * @param putResponse - Overrides the response a PUT request resolves to, to simulate a failed update.
+ */
+const mockSettingsFusion = async (
+  initial: Record<string, unknown> = {},
+  putResponse?: () => Response,
+) => {
+  const store: Record<string, unknown> = { ...initial };
+  const fusion = await mockFramework<[AppModule]>((configurator) => {
+    configurator.http.addMiddleware(
+      createRouterMiddleware('https://apps.fusion.test', (router) => {
+        router.get('/persons/me/apps/:appKey/settings', () => Response.json(store));
+        router.put('/persons/me/apps/:appKey/settings', async ({ request }) => {
+          // a caller-supplied response simulates a failed persistence request
+          if (putResponse) return putResponse();
+          // the PUT body replaces the seeded keys it targets, leaving the rest of the store untouched
+          Object.assign(store, await request.json());
+          return Response.json(store);
+        });
+      }),
+    );
+    enableAppManifestMock(configurator, env);
+  });
+  fusion.modules.app.setCurrentApp(env.manifest.appKey);
+  return fusion;
+};
+
+describe('useAppSetting', () => {
+  it('resolves the persisted value for a single setting key', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark' });
+
+    const { result } = await renderAppHook(
+      () => useAppSetting<{ theme: string }, 'theme'>('theme'),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toBe('dark'));
+  });
+
+  it('falls back to the default value until the persisted settings resolve', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark' });
+
+    const { result } = await renderAppHook(
+      () => useAppSetting<{ theme: string }, 'theme'>('theme', 'light'),
+      { env, fusion },
+    );
+
+    expect(result.current[0]).toBe('light');
+    await waitFor(() => expect(result.current[0]).toBe('dark'));
+  });
+
+  it('persists an updated value and notifies onUpdated', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark' });
+    const onUpdated = vi.fn();
+
+    const { result } = await renderAppHook(
+      () => useAppSetting<{ theme: string }, 'theme'>('theme', undefined, { onUpdated }),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toBe('dark'));
+
+    act(() => {
+      result.current[1]('light');
+    });
+
+    await waitFor(() => expect(result.current[0]).toBe('light'));
+    await waitFor(() => expect(onUpdated).toHaveBeenCalled());
+  });
+
+  it('resolves the next value from the previous one when given an updater function', async () => {
+    const fusion = await mockSettingsFusion({ count: 1 });
+
+    const { result } = await renderAppHook(
+      () => useAppSetting<{ count: number }, 'count'>('count'),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toBe(1));
+
+    act(() => {
+      result.current[1]((current) => (current ?? 0) + 1);
+    });
+
+    await waitFor(() => expect(result.current[0]).toBe(2));
+  });
+
+  it('surfaces a persistence failure through onError instead of throwing', async () => {
+    const fusion = await mockSettingsFusion(
+      { theme: 'dark' },
+      () => new Response(null, { status: 500 }),
+    );
+    const onError = vi.fn();
+
+    const { result } = await renderAppHook(
+      () => useAppSetting<{ theme: string }, 'theme'>('theme', undefined, { onError }),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toBe('dark'));
+
+    act(() => {
+      result.current[1]('light');
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(Error)));
+  });
+});

--- a/packages/react/app/src/__tests__/useAppSettings.test.tsx
+++ b/packages/react/app/src/__tests__/useAppSettings.test.tsx
@@ -1,0 +1,139 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { createRouterMiddleware } from '@equinor/fusion-framework-module-http/mock';
+
+import { useAppSettings } from '../settings/useAppSettings';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+/**
+ * Boots a parent framework whose `apps` client serves per-user settings from an
+ * in-memory store, so `useAppSettings` exercises the real fetch/update round-trip
+ * instead of a stubbed provider.
+ *
+ * @param initial - The settings the store starts seeded with.
+ * @param putResponse - Overrides the response a PUT request resolves to, to simulate a failed update.
+ */
+const mockSettingsFusion = async (
+  initial: Record<string, unknown> = {},
+  putResponse?: () => Response,
+) => {
+  const store: Record<string, unknown> = { ...initial };
+  const fusion = await mockFramework<[AppModule]>((configurator) => {
+    configurator.http.addMiddleware(
+      createRouterMiddleware('https://apps.fusion.test', (router) => {
+        router.get('/persons/me/apps/:appKey/settings', () => Response.json(store));
+        router.put('/persons/me/apps/:appKey/settings', async ({ request }) => {
+          // a caller-supplied response simulates a failed persistence request
+          if (putResponse) return putResponse();
+          // the PUT body replaces the seeded keys it targets, leaving the rest of the store untouched
+          Object.assign(store, await request.json());
+          return Response.json(store);
+        });
+      }),
+    );
+    enableAppManifestMock(configurator, env);
+  });
+  fusion.modules.app.setCurrentApp(env.manifest.appKey);
+  return fusion;
+};
+
+interface TestSettings extends Record<string, unknown> {
+  theme: string;
+  layout: string;
+}
+
+describe('useAppSettings', () => {
+  it('resolves the full persisted settings object', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark', layout: 'grid' });
+
+    const { result } = await renderAppHook(() => useAppSettings<TestSettings>(), { env, fusion });
+
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }));
+  });
+
+  it('falls back to the default value until the persisted settings resolve', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark', layout: 'grid' });
+
+    const { result } = await renderAppHook(
+      () => useAppSettings<TestSettings>({ theme: 'light', layout: 'list' }),
+      { env, fusion },
+    );
+
+    expect(result.current[0]).toMatchObject({ theme: 'light', layout: 'list' });
+    await waitFor(() =>
+      expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }),
+    );
+  });
+
+  it('persists an updated settings object and notifies onUpdated', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark', layout: 'grid' });
+    const onUpdated = vi.fn();
+
+    const { result } = await renderAppHook(
+      () => useAppSettings<TestSettings>(undefined, { onUpdated }),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }));
+
+    act(() => {
+      result.current[1]({ theme: 'light', layout: 'grid' });
+    });
+
+    await waitFor(() =>
+      expect(result.current[0]).toMatchObject({ theme: 'light', layout: 'grid' }),
+    );
+    await waitFor(() => expect(onUpdated).toHaveBeenCalled());
+  });
+
+  it('resolves the next settings object from the previous one when given an updater function', async () => {
+    const fusion = await mockSettingsFusion({ theme: 'dark', layout: 'grid' });
+
+    const { result } = await renderAppHook(() => useAppSettings<TestSettings>(), { env, fusion });
+
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }));
+
+    act(() => {
+      // `current` is typed as possibly undefined even though it's already resolved by this point
+      result.current[1]((current) => ({ theme: current?.theme ?? 'dark', layout: 'list' }));
+    });
+
+    await waitFor(() =>
+      expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'list' }),
+    );
+  });
+
+  it('surfaces a persistence failure through onError instead of throwing', async () => {
+    const fusion = await mockSettingsFusion(
+      { theme: 'dark', layout: 'grid' },
+      () => new Response(null, { status: 500 }),
+    );
+    const onError = vi.fn();
+
+    const { result } = await renderAppHook(
+      () => useAppSettings<TestSettings>(undefined, { onError }),
+      { env, fusion },
+    );
+
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }));
+
+    act(() => {
+      result.current[1]({ theme: 'light', layout: 'grid' });
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(Error)));
+  });
+});

--- a/packages/react/app/src/__tests__/useAppSettings.test.tsx
+++ b/packages/react/app/src/__tests__/useAppSettings.test.tsx
@@ -73,9 +73,7 @@ describe('useAppSettings', () => {
     );
 
     expect(result.current[0]).toMatchObject({ theme: 'light', layout: 'list' });
-    await waitFor(() =>
-      expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }),
-    );
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'grid' }));
   });
 
   it('persists an updated settings object and notifies onUpdated', async () => {
@@ -111,9 +109,7 @@ describe('useAppSettings', () => {
       result.current[1]((current) => ({ theme: current?.theme ?? 'dark', layout: 'list' }));
     });
 
-    await waitFor(() =>
-      expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'list' }),
-    );
+    await waitFor(() => expect(result.current[0]).toMatchObject({ theme: 'dark', layout: 'list' }));
   });
 
   it('surfaces a persistence failure through onError instead of throwing', async () => {

--- a/packages/react/app/src/__tests__/useCurrentAccount.test.tsx
+++ b/packages/react/app/src/__tests__/useCurrentAccount.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { useCurrentAccount } from '../msal/useCurrentAccount';
+import { renderAppHook } from '../testing/render-app-hook';
+
+describe('useCurrentAccount', () => {
+  it('returns the default mock user signed in by the app scope’s auth module', async () => {
+    const { result } = await renderAppHook(() => useCurrentAccount());
+
+    expect(result.current).toMatchObject({
+      name: 'Test User',
+      username: 'test.user@equinor.com',
+    });
+  });
+
+  it('returns the account configured through the msal mock builder', async () => {
+    const { result } = await renderAppHook(() => useCurrentAccount(), {
+      configure: (configurator) =>
+        configurator.msal.setAccount({ name: 'Ada Lovelace', username: 'ada@equinor.com' }),
+    });
+
+    expect(result.current).toMatchObject({ name: 'Ada Lovelace', username: 'ada@equinor.com' });
+  });
+
+  it('returns undefined when no account is signed in', async () => {
+    const { result } = await renderAppHook(() => useCurrentAccount(), {
+      configure: (configurator) => configurator.msal.setAccount(null),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/react/app/src/__tests__/useCurrentBookmark.test.tsx
+++ b/packages/react/app/src/__tests__/useCurrentBookmark.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableBookmarkMock } from '@equinor/fusion-framework-module-bookmark/mock';
+import type { Bookmark, BookmarkModule } from '@equinor/fusion-framework-module-bookmark';
+
+import { useCurrentBookmark } from '../bookmark/useCurrentBookmark';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+/** A fully-formed seeded bookmark, so tests only override what they care about. */
+const createBookmark = (overrides: Partial<Bookmark> = {}): Bookmark => ({
+  id: 'bookmark-1',
+  name: 'My Bookmark',
+  appKey: 'test-app',
+  created: new Date('2024-01-01T00:00:00.000Z'),
+  createdBy: { id: 'seed-user', name: 'Seed User' },
+  ...overrides,
+});
+
+describe('useCurrentBookmark', () => {
+  it('returns the app-scoped current bookmark once it belongs to the active app', async () => {
+    const bookmark = createBookmark();
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    fusion.modules.app.setCurrentApp(env.manifest.appKey);
+
+    const configure: AppMockConfigureFn<[BookmarkModule]> = (configurator) =>
+      enableBookmarkMock(configurator, (builder) => {
+        builder.setBookmarks([bookmark]);
+        builder.setCurrentBookmark(bookmark.id);
+      });
+
+    const { result } = await renderAppHook(() => useCurrentBookmark(), { env, fusion, configure });
+
+    await waitFor(() => expect(result.current.currentBookmark).toMatchObject({ id: bookmark.id }));
+  });
+
+  it('hides the current bookmark once it belongs to a different app', async () => {
+    const bookmark = createBookmark({ appKey: 'some-other-app' });
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    fusion.modules.app.setCurrentApp(env.manifest.appKey);
+
+    const configure: AppMockConfigureFn<[BookmarkModule]> = (configurator) =>
+      enableBookmarkMock(configurator, (builder) => {
+        builder.setBookmarks([bookmark]);
+        builder.setCurrentBookmark(bookmark.id);
+      });
+
+    const { result } = await renderAppHook(() => useCurrentBookmark(), { env, fusion, configure });
+
+    // give the app-scoped bookmark provider a chance to resolve before asserting it stays hidden
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current.currentBookmark).toBeNull();
+  });
+
+  it('falls back to the framework-scoped bookmark provider, warning about the deprecation', async () => {
+    const bookmark = createBookmark();
+    const fusion = await mockFramework<[AppModule, BookmarkModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+      enableBookmarkMock(configurator, (builder) => {
+        builder.setBookmarks([bookmark]);
+        builder.setCurrentBookmark(bookmark.id);
+      });
+    });
+    fusion.modules.app.setCurrentApp(env.manifest.appKey);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = await renderAppHook(() => useCurrentBookmark(), { env, fusion });
+
+    await waitFor(() => expect(result.current.currentBookmark).toMatchObject({ id: bookmark.id }));
+    expect(warnSpy).toHaveBeenCalledWith(
+      '@deprecation',
+      expect.stringContaining('has not enabled bookmarks'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/react/app/src/__tests__/useCurrentBookmark.test.tsx
+++ b/packages/react/app/src/__tests__/useCurrentBookmark.test.tsx
@@ -10,6 +10,7 @@ import type { Bookmark, BookmarkModule } from '@equinor/fusion-framework-module-
 
 import { useCurrentBookmark } from '../bookmark/useCurrentBookmark';
 import { renderAppHook } from '../testing/render-app-hook';
+import { useAppModules } from '../useAppModules';
 
 const env = {
   manifest: {
@@ -62,11 +63,20 @@ describe('useCurrentBookmark', () => {
         builder.setCurrentBookmark(bookmark.id);
       });
 
-    const { result } = await renderAppHook(() => useCurrentBookmark(), { env, fusion, configure });
+    const { result } = await renderAppHook(
+      () => ({
+        bookmark: useCurrentBookmark(),
+        // unfiltered provider state, so we can tell the seeded bookmark actually
+        // resolved rather than the filter trivially matching a still-pending value
+        provider: useAppModules<[BookmarkModule]>().bookmark,
+      }),
+      { env, fusion, configure },
+    );
 
-    // give the app-scoped bookmark provider a chance to resolve before asserting it stays hidden
-    await waitFor(() => expect(result.current).toBeDefined());
-    expect(result.current.currentBookmark).toBeNull();
+    await waitFor(() =>
+      expect(result.current.provider.currentBookmark).toMatchObject({ id: bookmark.id }),
+    );
+    expect(result.current.bookmark.currentBookmark).toBeNull();
   });
 
   it('falls back to the framework-scoped bookmark provider, warning about the deprecation', async () => {

--- a/packages/react/app/src/__tests__/useCurrentContext.test.tsx
+++ b/packages/react/app/src/__tests__/useCurrentContext.test.tsx
@@ -1,0 +1,60 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableContextMock } from '@equinor/fusion-framework-module-context/mock';
+import type { ContextItem, ContextModule } from '@equinor/fusion-framework-module-context';
+
+import { useCurrentContext } from '../context/useCurrentContext';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+const project: ContextItem = { id: 'ctx-1', title: 'My project', type: { id: 'ProjectMaster' }, value: {} };
+const facility: ContextItem = { id: 'ctx-2', title: 'My facility', type: { id: 'Facility' }, value: {} };
+
+describe('useCurrentContext', () => {
+  it('resolves the context item selected on startup from the app-scoped context module', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    const configure: AppMockConfigureFn<[ContextModule]> = (configurator) =>
+      enableContextMock(configurator, (mock) => {
+        mock.setCurrentContext(project);
+      });
+
+    const { result } = await renderAppHook(() => useCurrentContext(), { env, fusion, configure });
+
+    await waitFor(() => expect(result.current.currentContext).toMatchObject({ id: project.id }));
+  });
+
+  it('switches the current context when setCurrentContext is called with another seeded item', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    const configure: AppMockConfigureFn<[ContextModule]> = (configurator) =>
+      enableContextMock(configurator, (mock) => {
+        mock.setCurrentContext(project);
+        mock.addContext(facility);
+      });
+
+    const { result } = await renderAppHook(() => useCurrentContext(), { env, fusion, configure });
+    await waitFor(() => expect(result.current.currentContext).toMatchObject({ id: project.id }));
+
+    await act(async () => {
+      await result.current.setCurrentContext(facility.id);
+    });
+
+    await waitFor(() => expect(result.current.currentContext).toMatchObject({ id: facility.id }));
+  });
+});

--- a/packages/react/app/src/__tests__/useCurrentContext.test.tsx
+++ b/packages/react/app/src/__tests__/useCurrentContext.test.tsx
@@ -20,8 +20,18 @@ const env = {
   },
 };
 
-const project: ContextItem = { id: 'ctx-1', title: 'My project', type: { id: 'ProjectMaster' }, value: {} };
-const facility: ContextItem = { id: 'ctx-2', title: 'My facility', type: { id: 'Facility' }, value: {} };
+const project: ContextItem = {
+  id: 'ctx-1',
+  title: 'My project',
+  type: { id: 'ProjectMaster' },
+  value: {},
+};
+const facility: ContextItem = {
+  id: 'ctx-2',
+  title: 'My facility',
+  type: { id: 'Facility' },
+  value: {},
+};
 
 describe('useCurrentContext', () => {
   it('resolves the context item selected on startup from the app-scoped context module', async () => {

--- a/packages/react/app/src/__tests__/useFeature.test.tsx
+++ b/packages/react/app/src/__tests__/useFeature.test.tsx
@@ -1,0 +1,104 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
+import type { FeatureFlagModule } from '@equinor/fusion-framework-module-feature-flag';
+
+import { useFeature } from '../feature-flag/useFeature';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+describe('useFeature', () => {
+  it('resolves a flag seeded on the app scope when the framework has no feature-flag module', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    const configure: AppMockConfigureFn<[FeatureFlagModule]> = (configurator) => {
+      enableFeatureFlagMock(configurator, (mock) => {
+        mock.addFeature({ key: 'dark-mode', enabled: true });
+      });
+    };
+
+    const { result } = await renderAppHook(() => useFeature('dark-mode'), {
+      env,
+      fusion,
+      configure,
+    });
+
+    await waitFor(() => expect(result.current.feature?.enabled).toBe(true));
+  });
+
+  it('lets an app-scoped flag override a framework-scoped flag with the same key', async () => {
+    const fusion = await mockFramework<[AppModule, FeatureFlagModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+      enableFeatureFlagMock(configurator, (mock) => {
+        mock.addFeature({ key: 'dark-mode', enabled: false });
+      });
+    });
+    const configure: AppMockConfigureFn<[FeatureFlagModule]> = (configurator) => {
+      enableFeatureFlagMock(configurator, (mock) => {
+        mock.addFeature({ key: 'dark-mode', enabled: true });
+      });
+    };
+
+    const { result } = await renderAppHook(() => useFeature('dark-mode'), {
+      env,
+      fusion,
+      configure,
+    });
+
+    await waitFor(() => expect(result.current.feature?.enabled).toBe(true));
+  });
+
+  it('exposes a framework-only flag through the merged stream when the app has not seeded it', async () => {
+    const fusion = await mockFramework<[AppModule, FeatureFlagModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+      enableFeatureFlagMock(configurator, (mock) => {
+        mock.addFeature({ key: 'framework-only', enabled: true });
+      });
+    });
+    const configure: AppMockConfigureFn<[FeatureFlagModule]> = (configurator) => {
+      enableFeatureFlagMock(configurator);
+    };
+
+    const { result } = await renderAppHook(() => useFeature('framework-only'), {
+      env,
+      fusion,
+      configure,
+    });
+
+    await waitFor(() => expect(result.current.feature?.enabled).toBe(true));
+  });
+
+  it('inverts the current value when toggleFeature is called without an explicit value', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+    const configure: AppMockConfigureFn<[FeatureFlagModule]> = (configurator) => {
+      enableFeatureFlagMock(configurator, (mock) => {
+        mock.addFeature({ key: 'my-flag', enabled: false });
+      });
+    };
+
+    const { result } = await renderAppHook(() => useFeature('my-flag'), { env, fusion, configure });
+    await waitFor(() => expect(result.current.feature?.enabled).toBe(false));
+
+    act(() => {
+      result.current.toggleFeature();
+    });
+
+    await waitFor(() => expect(result.current.feature?.enabled).toBe(true));
+  });
+});

--- a/packages/react/app/src/__tests__/useHelpCenter.test.tsx
+++ b/packages/react/app/src/__tests__/useHelpCenter.test.tsx
@@ -1,0 +1,65 @@
+import { waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+
+import useAppModule from '../useAppModule';
+import { useHelpCenter } from '../help-center/useHelpCenter';
+import { EVENT_NAME } from '../help-center/event-name.js';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+describe('useHelpCenter', () => {
+  it('dispatches the expected page and detail for every help-center action', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, env),
+    );
+
+    const { result } = await renderAppHook(
+      () => ({ helpCenter: useHelpCenter(), eventModule: useAppModule('event') }),
+      { env, fusion },
+    );
+
+    const received: Array<{ page: string } & Record<string, unknown>> = [];
+    result.current.eventModule.addEventListener(EVENT_NAME, (event) => {
+      received.push(event.detail as { page: string } & Record<string, unknown>);
+    });
+
+    result.current.helpCenter.openHelp();
+    await waitFor(() => expect(received).toHaveLength(1));
+
+    result.current.helpCenter.openArticle('my-article');
+    await waitFor(() => expect(received).toHaveLength(2));
+
+    result.current.helpCenter.openFaqs();
+    await waitFor(() => expect(received).toHaveLength(3));
+
+    result.current.helpCenter.openSearch('my search');
+    await waitFor(() => expect(received).toHaveLength(4));
+
+    result.current.helpCenter.openGovernance();
+    await waitFor(() => expect(received).toHaveLength(5));
+
+    result.current.helpCenter.openReleaseNotes();
+    await waitFor(() => expect(received).toHaveLength(6));
+
+    expect(received).toEqual([
+      { page: 'home' },
+      { page: 'article', articleId: 'my-article' },
+      { page: 'faqs' },
+      { page: 'search', search: 'my search' },
+      { page: 'governance' },
+      { page: 'release-notes' },
+    ]);
+  });
+});

--- a/packages/react/app/src/__tests__/useToken.test.tsx
+++ b/packages/react/app/src/__tests__/useToken.test.tsx
@@ -8,7 +8,7 @@ import { renderAppHook } from '../testing/render-app-hook';
 
 describe('useToken', () => {
   it('resolves a full AuthenticationResult from the app scope’s real, mock-backed auth module', async () => {
-    const { result } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }));
+    const { result, unmount } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }));
 
     expect(result.current.pending).toBe(true);
     expect(result.current.token).toBeUndefined();
@@ -20,6 +20,10 @@ describe('useToken', () => {
     // a structurally valid JWT has three dot-separated segments
     expect(result.current.token?.accessToken.split('.')).toHaveLength(3);
     expect(result.current.token?.account).toMatchObject({ username: 'test.user@equinor.com' });
+
+    // unmount before the next test's environment tears down, so no acquisition
+    // effect can flush a state update against an already-destroyed `window`
+    unmount();
   });
 
   it('surfaces an acquisition error instead of throwing', async () => {
@@ -30,11 +34,15 @@ describe('useToken', () => {
       new Error('acquisition failed'),
     );
 
-    const { result } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }), { fusion });
+    const { result, unmount } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }), {
+      fusion,
+    });
 
     await waitFor(() => expect(result.current.pending).toBe(false));
 
     expect(result.current.token).toBeUndefined();
     expect(result.current.error).toBeInstanceOf(Error);
+
+    unmount();
   });
 });

--- a/packages/react/app/src/__tests__/useToken.test.tsx
+++ b/packages/react/app/src/__tests__/useToken.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+
+import { useToken } from '../msal/useToken';
+import { renderAppHook } from '../testing/render-app-hook';
+
+describe('useToken', () => {
+  it('resolves a full AuthenticationResult from the app scope’s real, mock-backed auth module', async () => {
+    const { result } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }));
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.token).toBeUndefined();
+
+    await waitFor(() => expect(result.current.pending).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.token?.scopes).toEqual(['User.Read']);
+    // a structurally valid JWT has three dot-separated segments
+    expect(result.current.token?.accessToken.split('.')).toHaveLength(3);
+    expect(result.current.token?.account).toMatchObject({ username: 'test.user@equinor.com' });
+  });
+
+  it('surfaces an acquisition error instead of throwing', async () => {
+    const fusion = await mockFramework();
+    // persistent, not `-Once`: the app module hoists via a version-compat proxy that
+    // may call through before the hook's own effect does, consuming a one-shot mock
+    vi.spyOn(fusion.modules.auth, 'acquireToken').mockRejectedValue(
+      new Error('acquisition failed'),
+    );
+
+    const { result } = await renderAppHook(() => useToken({ scopes: ['User.Read'] }), { fusion });
+
+    await waitFor(() => expect(result.current.pending).toBe(false));
+
+    expect(result.current.token).toBeUndefined();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/packages/react/app/src/__tests__/useTrackFeature.test.tsx
+++ b/packages/react/app/src/__tests__/useTrackFeature.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableAnalytics, type AnalyticsModule } from '@equinor/fusion-framework-module-analytics';
+import { MockAnalyticsAdapter } from '@equinor/fusion-framework-module-analytics/mock';
+import type { MockTelemetryAdapter } from '@equinor/fusion-framework-module-telemetry/mock';
+
+import { useTrackFeature } from '../analytics/useTrackFeature';
+import { renderAppHook } from '../testing/render-app-hook';
+
+const env = {
+  manifest: {
+    appKey: 'test-app',
+    displayName: 'Test App',
+    description: 'A test application',
+    type: 'standalone' as const,
+  },
+};
+
+describe('useTrackFeature', () => {
+  it('tracks an app-feature analytics event carrying the current app’s key, leaving telemetry untouched', async () => {
+    const recorder = new MockAnalyticsAdapter();
+
+    const fusion = await mockFramework<[AppModule, AnalyticsModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+      enableAnalytics(configurator, (builder) => {
+        builder.setAdapter('mock', async () => recorder);
+      });
+    });
+    fusion.modules.app.setCurrentApp('test-app');
+
+    const { result } = await renderAppHook(() => useTrackFeature(), { env, fusion });
+    result.current('button-click', { section: 'header' });
+
+    // analytics is the only channel a successful call should reach
+    expect(recorder.getAnalytics()).toMatchObject([
+      {
+        name: 'app-feature',
+        value: { feature: 'button-click', data: { section: 'header' } },
+        attributes: { appKey: 'test-app', context: undefined },
+      },
+    ]);
+    // the framework logs its own telemetry regardless; the fallback diagnostic
+    // specifically must not fire when analytics was reached successfully
+    const telemetry = fusion.modules.telemetry.getAdapter('mock') as MockTelemetryAdapter;
+    expect(telemetry.getItems('AnalyticsProviderNotFound')).toHaveLength(0);
+  });
+
+  it('includes the current context alongside the app key', async () => {
+    const recorder = new MockAnalyticsAdapter();
+    const project = { id: 'ctx-1', title: 'My project', type: { id: 'ProjectMaster' }, value: {} };
+
+    const fusion = await mockFramework<[AppModule, AnalyticsModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+      enableAnalytics(configurator, (builder) => {
+        builder.setAdapter('mock', async () => recorder);
+      });
+      configurator.context.setCurrentContext(project);
+    });
+
+    const { result } = await renderAppHook(() => useTrackFeature(), { env, fusion });
+    result.current('button-click');
+
+    const [event] = recorder.getAnalytics('app-feature');
+    expect(event.attributes?.context).toMatchObject({ id: project.id, type: 'ProjectMaster' });
+  });
+
+  it('reports to telemetry instead of throwing when no analytics provider is registered', async () => {
+    const fusion = await mockFramework<[AppModule]>((configurator) => {
+      enableAppManifestMock(configurator, env);
+    });
+
+    const { result } = await renderAppHook(() => useTrackFeature(), { env, fusion });
+
+    // the missing-analytics diagnostic is a telemetry concern, not an analytics one —
+    // it must not throw and must not fabricate an analytics event of its own
+    expect(() => result.current('button-click')).not.toThrow();
+    const telemetry = fusion.modules.telemetry.getAdapter('mock') as MockTelemetryAdapter;
+    expect(telemetry.getItems('AnalyticsProviderNotFound')).toHaveLength(1);
+  });
+});

--- a/packages/react/app/src/create-component.tsx
+++ b/packages/react/app/src/create-component.tsx
@@ -41,7 +41,7 @@ export type ComponentRenderer<TFusion extends Fusion = Fusion, TEnv = AppEnv> = 
  * @example
  * ```tsx
  * const configCallback: AppConfigurator = (configurator) => {
- *  configurator.http.configureClient(
+ *  configurator.configureHttpClient(
  *     'bar', {
  *       baseUri: 'https://somewhere-test.com',
  *       defaultScopes: ['foo/.default']

--- a/packages/react/app/src/testing/index.ts
+++ b/packages/react/app/src/testing/index.ts
@@ -1,1 +1,2 @@
 export { renderAppHook, type RenderAppHookOptions } from './render-app-hook';
+export { renderAppComponent, type RenderAppComponentOptions } from './render-app-component';

--- a/packages/react/app/src/testing/index.ts
+++ b/packages/react/app/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { renderAppHook, type RenderAppHookOptions } from './render-app-hook';

--- a/packages/react/app/src/testing/render-app-component.tsx
+++ b/packages/react/app/src/testing/render-app-component.tsx
@@ -53,7 +53,6 @@ export interface RenderAppComponentOptions<
  * from `mockAppModules`, `@equinor/fusion-framework-app/mock`). See {@link renderAppHook}
  * for the equivalent helper when testing a hook in isolation, rather than a component.
  *
- * @template Result - Unused; retained for parity with `RenderResult`'s generic shape.
  * @template TModules - Module descriptors beyond the default set.
  * @template TEnv - The application environment descriptor.
  * @param ui - The component to render.
@@ -73,10 +72,7 @@ export interface RenderAppComponentOptions<
 export async function renderAppComponent<
   TModules extends Array<AnyModule> | unknown = unknown,
   TEnv extends AppEnv = AppEnv,
->(
-  ui: ReactElement,
-  options?: RenderAppComponentOptions<TModules, TEnv>,
-): Promise<RenderResult> {
+>(ui: ReactElement, options?: RenderAppComponentOptions<TModules, TEnv>): Promise<RenderResult> {
   const { configure, env, fusion: providedFusion, ...renderOptions } = options ?? {};
   const resolvedEnv = env ?? ({ manifest: defaultManifest } as TEnv);
   // Built explicitly (rather than left to `mockAppModules`'s own default) so the same

--- a/packages/react/app/src/testing/render-app-component.tsx
+++ b/packages/react/app/src/testing/render-app-component.tsx
@@ -1,0 +1,101 @@
+import type { ReactElement } from 'react';
+import { render } from '@testing-library/react';
+import type { RenderOptions, RenderResult } from '@testing-library/react';
+
+import { mockAppModules, enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
+import type { AppEnv } from '@equinor/fusion-framework-app';
+import type { Fusion } from '@equinor/fusion-framework';
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import type { AnyModule } from '@equinor/fusion-framework-module';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { FrameworkProvider } from '@equinor/fusion-framework-react';
+import { ModuleProvider } from '@equinor/fusion-framework-react-module';
+
+/** Manifest used when a test does not care about its own app identity. */
+const defaultManifest: AppEnv['manifest'] = {
+  appKey: 'test-app',
+  displayName: 'Test App',
+  description: 'A test application',
+  type: 'standalone',
+};
+
+/**
+ * Options for {@link renderAppComponent}.
+ *
+ * @template TModules - Module descriptors beyond the default set.
+ * @template TEnv - The application environment descriptor.
+ */
+export interface RenderAppComponentOptions<
+  TModules extends Array<AnyModule> | unknown = unknown,
+  TEnv extends AppEnv = AppEnv,
+> extends Omit<RenderOptions, 'wrapper'> {
+  /** Configuration callback forwarded to {@link mockAppModules}. */
+  configure?: AppMockConfigureFn<TModules, TEnv>;
+  /** The application environment; defaults to a generic standalone test app. */
+  env?: TEnv;
+  /**
+   * The parent Fusion instance; defaults to a fresh {@link mockFramework} instance with
+   * this app's own manifest served. Pass one built beforehand to reuse a single instance
+   * across multiple render calls, or to pre-configure parent-level modules (e.g. `http`,
+   * `context`, `serviceDiscovery`, or `app` itself for a component that loads another app).
+   */
+  fusion?: Fusion;
+}
+
+/**
+ * Renders a component inside a real, mock-backed application module scope.
+ *
+ * @remarks
+ * Wraps `@testing-library/react`'s `render` with the same provider nesting
+ * `createComponent` uses in production — a `FrameworkProvider` (the parent Fusion
+ * instance, from `mockFramework`) around a `ModuleProvider` (this app's own modules,
+ * from `mockAppModules`, `@equinor/fusion-framework-app/mock`). See {@link renderAppHook}
+ * for the equivalent helper when testing a hook in isolation, rather than a component.
+ *
+ * @template Result - Unused; retained for parity with `RenderResult`'s generic shape.
+ * @template TModules - Module descriptors beyond the default set.
+ * @template TEnv - The application environment descriptor.
+ * @param ui - The component to render.
+ * @param options - A `configure` callback and `env` for `mockAppModules`, plus any other `render` option.
+ * @returns The `render` result, once the mocked application module scope resolves.
+ *
+ * @example
+ * ```tsx
+ * const { getByText } = await renderAppComponent(<Apploader appKey="child-app" />, {
+ *   fusion: await mockFramework<[AppModule]>((configurator) => {
+ *     // register the child app's own manifest against the `app` module
+ *   }),
+ * });
+ * await waitFor(() => expect(getByText(/mounted/)).toBeInTheDocument());
+ * ```
+ */
+export async function renderAppComponent<
+  TModules extends Array<AnyModule> | unknown = unknown,
+  TEnv extends AppEnv = AppEnv,
+>(
+  ui: ReactElement,
+  options?: RenderAppComponentOptions<TModules, TEnv>,
+): Promise<RenderResult> {
+  const { configure, env, fusion: providedFusion, ...renderOptions } = options ?? {};
+  const resolvedEnv = env ?? ({ manifest: defaultManifest } as TEnv);
+  // Built explicitly (rather than left to `mockAppModules`'s own default) so the same
+  // instance can also be handed to `FrameworkProvider` below — mirroring `createComponent`'s
+  // `enableAppManifestMock` + `mockAppModules(cb, env, fusion)` composition.
+  const fusion =
+    providedFusion ??
+    (await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, resolvedEnv),
+    ));
+  const modules = await mockAppModules(configure, resolvedEnv, fusion);
+  return render(ui, {
+    ...renderOptions,
+    wrapper: ({ children }) => (
+      <FrameworkProvider value={fusion}>
+        <ModuleProvider value={modules}>{children}</ModuleProvider>
+      </FrameworkProvider>
+    ),
+  });
+}
+
+export default renderAppComponent;

--- a/packages/react/app/src/testing/render-app-hook.tsx
+++ b/packages/react/app/src/testing/render-app-hook.tsx
@@ -52,7 +52,8 @@ export interface RenderAppHookOptions<
  * `createComponent` uses in production — a `FrameworkProvider` (the parent Fusion
  * instance, from `mockFramework`) around a `ModuleProvider` (this app's own modules,
  * from `mockAppModules`, `@equinor/fusion-framework-app/mock`) — the real
- * `event`/`http`/`msal` module pipeline, with only the network boundary faked. Use this
+ * `event`/`http`/`msal` module pipeline. Only requests a seeded middleware answers are
+ * faked; a request with no matching middleware still reaches the real network. Use this
  * for any hook that reads from the application module scope or the parent framework
  * (e.g. `useAppModule`, `useAccessToken`, `useFramework`), instead of hand-wiring
  * `mockFramework`, `mockAppModules`, `FrameworkProvider` and `ModuleProvider` in every test.

--- a/packages/react/app/src/testing/render-app-hook.tsx
+++ b/packages/react/app/src/testing/render-app-hook.tsx
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react';
+import type { RenderHookOptions, RenderHookResult } from '@testing-library/react';
+
+import { mockAppModules, enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
+import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
+import type { AppEnv } from '@equinor/fusion-framework-app';
+import type { Fusion } from '@equinor/fusion-framework';
+import { mockFramework } from '@equinor/fusion-framework/mock';
+import type { AnyModule } from '@equinor/fusion-framework-module';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { FrameworkProvider } from '@equinor/fusion-framework-react';
+import { ModuleProvider } from '@equinor/fusion-framework-react-module';
+
+/** Manifest used when a test does not care about its own app identity. */
+const defaultManifest: AppEnv['manifest'] = {
+  appKey: 'test-app',
+  displayName: 'Test App',
+  description: 'A test application',
+  type: 'standalone',
+};
+
+/**
+ * Options for {@link renderAppHook}.
+ *
+ * @template TModules - Module descriptors beyond the default set.
+ * @template TEnv - The application environment descriptor.
+ * @template Props - The props type accepted by the rendered hook.
+ */
+export interface RenderAppHookOptions<
+  TModules extends Array<AnyModule> | unknown = unknown,
+  TEnv extends AppEnv = AppEnv,
+  Props = undefined,
+> extends Omit<RenderHookOptions<Props>, 'wrapper'> {
+  /** Configuration callback forwarded to {@link mockAppModules}. */
+  configure?: AppMockConfigureFn<TModules, TEnv>;
+  /** The application environment; defaults to a generic standalone test app. */
+  env?: TEnv;
+  /**
+   * The parent Fusion instance; defaults to a fresh {@link mockFramework} instance with
+   * this app's own manifest served. Pass one built beforehand to reuse a single instance
+   * across multiple `renderAppHook` calls, or to pre-configure parent-level modules (e.g.
+   * `http`, `context`, `serviceDiscovery`) the app reads through `useFramework`.
+   */
+  fusion?: Fusion;
+}
+
+/**
+ * Renders a hook inside a real, mock-backed application module scope.
+ *
+ * @remarks
+ * Wraps `@testing-library/react`'s `renderHook` with the same provider nesting
+ * `createComponent` uses in production — a `FrameworkProvider` (the parent Fusion
+ * instance, from `mockFramework`) around a `ModuleProvider` (this app's own modules,
+ * from `mockAppModules`, `@equinor/fusion-framework-app/mock`) — the real
+ * `event`/`http`/`msal` module pipeline, with only the network boundary faked. Use this
+ * for any hook that reads from the application module scope or the parent framework
+ * (e.g. `useAppModule`, `useAccessToken`, `useFramework`), instead of hand-wiring
+ * `mockFramework`, `mockAppModules`, `FrameworkProvider` and `ModuleProvider` in every test.
+ *
+ * @template Result - The value returned by the rendered hook.
+ * @template Props - The props accepted by the rendered hook.
+ * @template TModules - Module descriptors beyond the default set.
+ * @template TEnv - The application environment descriptor.
+ * @param render - The hook to render, receiving `initialProps`.
+ * @param options - A `configure` callback and `env` for `mockAppModules`, plus any other
+ *   `renderHook` option.
+ * @returns The `renderHook` result, once the mocked application module scope resolves.
+ *
+ * @example
+ * ```tsx
+ * const { result } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }));
+ * await waitFor(() => expect(result.current.pending).toBe(false));
+ * ```
+ *
+ * @example Sign in a named user
+ * ```tsx
+ * const { result } = await renderAppHook(() => useCurrentAccount(), {
+ *   configure: (configurator) => configurator.msal.setAccount({ name: 'Ada Lovelace' }),
+ * });
+ * ```
+ *
+ * @example Reuse a pre-built parent Fusion instance
+ * ```tsx
+ * const fusion = await mockFramework<[AppModule]>((configurator) =>
+ *   enableAppManifestMock(configurator, env),
+ * );
+ *
+ * const { result: a } = await renderAppHook(() => useAccessToken({ scopes: ['User.Read'] }), { fusion });
+ * const { result: b } = await renderAppHook(() => useCurrentAccount(), { fusion });
+ * ```
+ */
+export async function renderAppHook<
+  Result,
+  Props = undefined,
+  TModules extends Array<AnyModule> | unknown = unknown,
+  TEnv extends AppEnv = AppEnv,
+>(
+  render: (initialProps: Props) => Result,
+  options?: RenderAppHookOptions<TModules, TEnv, Props>,
+): Promise<RenderHookResult<Result, Props>> {
+  const { configure, env, fusion: providedFusion, ...renderHookOptions } = options ?? {};
+  const resolvedEnv = env ?? ({ manifest: defaultManifest } as TEnv);
+  // Built explicitly (rather than left to `mockAppModules`'s own default) so the same
+  // instance can also be handed to `FrameworkProvider` below — mirroring `createComponent`'s
+  // `enableAppManifestMock` + `mockAppModules(cb, env, fusion)` composition.
+  const fusion =
+    providedFusion ??
+    (await mockFramework<[AppModule]>((configurator) =>
+      enableAppManifestMock(configurator, resolvedEnv),
+    ));
+  const modules = await mockAppModules(configure, resolvedEnv, fusion);
+  return renderHook(render, {
+    ...renderHookOptions,
+    wrapper: ({ children }) => (
+      <FrameworkProvider value={fusion}>
+        <ModuleProvider value={modules}>{children}</ModuleProvider>
+      </FrameworkProvider>
+    ),
+  });
+}
+
+export default renderAppHook;

--- a/packages/react/app/tsconfig.json
+++ b/packages/react/app/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../app"
     },
     {
+      "path": "../../framework"
+    },
+    {
       "path": "../framework"
     },
     {

--- a/packages/react/app/vitest.config.ts
+++ b/packages/react/app/vitest.config.ts
@@ -3,12 +3,8 @@ import { defineProject } from 'vitest/config';
 import { name, version } from './package.json';
 
 export default defineProject({
-  resolve: {
-    // @ts-expect-error -- tsconfigPaths is a Vite 8 option; vitest 4.x ships Vite 7 types
-    tsconfigPaths: true,
-  },
   test: {
-    include: ['src/__tests__/**'],
+    include: ['src/__tests__/**/*.{test,spec}.{ts,tsx}'],
     name: `${name}@${version}`,
     environment: 'happy-dom',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2251,6 +2251,9 @@ importers:
       '@equinor/fusion-framework-module-bookmark':
         specifier: workspace:*
         version: link:../../modules/bookmark
+      '@equinor/fusion-framework-module-context':
+        specifier: workspace:*
+        version: link:../../modules/context
       '@equinor/fusion-framework-module-event':
         specifier: workspace:*
         version: link:../../modules/event

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2248,6 +2248,9 @@ importers:
       '@equinor/fusion-framework-module-analytics':
         specifier: workspace:*
         version: link:../../modules/analytics
+      '@equinor/fusion-framework-module-bookmark':
+        specifier: workspace:*
+        version: link:../../modules/bookmark
       '@equinor/fusion-framework-module-event':
         specifier: workspace:*
         version: link:../../modules/event

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2214,6 +2214,9 @@ importers:
 
   packages/react/app:
     dependencies:
+      '@equinor/fusion-framework':
+        specifier: workspace:*
+        version: link:../../framework
       '@equinor/fusion-framework-app':
         specifier: workspace:*
         version: link:../../app
@@ -2266,6 +2269,9 @@ importers:
       '@equinor/fusion-observable':
         specifier: workspace:*
         version: link:../../utils/observable
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.18
@@ -15613,7 +15619,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -16095,7 +16101,7 @@ snapshots:
       msw: 2.15.0(@types/node@24.12.2)(typescript@7.0.2)
       vite: 8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
 
-  '@vitest/mocker@4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))':
+  '@vitest/mocker@4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
@@ -17685,7 +17691,7 @@ snapshots:
 
   downshift@9.3.2(react@19.2.8):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
       react: 19.2.8
@@ -21082,7 +21088,7 @@ snapshots:
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -21124,7 +21130,7 @@ snapshots:
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2257,6 +2257,9 @@ importers:
       '@equinor/fusion-framework-module-msal':
         specifier: workspace:*
         version: link:../../modules/msal
+      '@equinor/fusion-framework-module-telemetry':
+        specifier: workspace:*
+        version: link:../../modules/telemetry
       '@equinor/fusion-framework-react-module-bookmark':
         specifier: workspace:*
         version: link:../modules/bookmark


### PR DESCRIPTION
**Why is this change needed?**

App teams need a supported way to verify app-scoped hooks and components without hand-wiring providers or recreating the application module stack in every test.

**What is the current behavior?**

`packages/react/app` did not have a dedicated testing guide for the app-scoped helpers, so consumers had to infer the provider setup and module-seeding pattern from source or neighboring packages.

**What is the new behavior?**

`packages/react/app/docs/testing.md` now documents `renderAppHook` and `renderAppComponent`, including the mocked framework/app module scope, configuration hooks for seeding state, and example coverage for loading and error states.

**What is the intended behavior or invariant?**

App-scoped hooks and components should be testable through the same framework/module nesting they receive in production, while still keeping the network boundary mocked and the rest of the module pipeline real.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: Documentation only; no runtime API changes.
- Downstream impact: No code-path change, but package release metadata is updated through a changeset.

**Review guidance:**

Focus on whether the documented helper behavior, examples, and seeded-state guidance accurately reflect the exported API surface and the actual app testing workflow.

**Additional context**

A patch changeset was added for `@equinor/fusion-framework-react-app` to keep release metadata aligned with the package docs update.

**Related issues**

Closes #1716
Ref: #1654

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [ ] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [ ] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - [x] Included files validated
  - [x] No new linting warnings
  - [x] Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)