### PR TITLE
feat(module-navigation): add mock entry point for deterministic test navigation

### DIFF
--- a/.changeset/module-navigation_add-mock.md
+++ b/.changeset/module-navigation_add-mock.md
@@ -1,0 +1,24 @@
+---
+"@equinor/fusion-framework-module-navigation": minor
+---
+
+Add `enableNavigationMock` under `@equinor/fusion-framework-module-navigation/mock`, so tests get deterministic in-memory navigation instead of the real browser history.
+
+`NavigationConfigurator`'s default history provider picks browser history whenever `window` is defined — true in jsdom/happy-dom test environments — so a test's navigation state could leak into (and depend on) the real document location. `enableNavigationMock` forces `MemoryHistory` unconditionally, while the real `NavigationConfigurator`, `NavigationProvider`, basename localization, and navigate/push/replace flows all run unmodified.
+
+```typescript
+import { enableNavigationMock } from '@equinor/fusion-framework-module-navigation/mock';
+
+enableNavigationMock(configurator, {
+  configure: (config) => {
+    config.setBasename('/apps/my-app');
+    config.setInitialLocation('/users/42');
+  },
+});
+```
+
+A plain string still works as a basename-only shortcut, same as `enableNavigation`:
+
+```typescript
+enableNavigationMock(configurator, '/apps/my-app');
+```

--- a/packages/modules/navigation/README.md
+++ b/packages/modules/navigation/README.md
@@ -124,6 +124,39 @@ const unblock = navigation.history.block((transition) => {
 });
 ```
 
+## Testing
+
+Import from `@equinor/fusion-framework-module-navigation/mock` to force in-memory history in a test, regardless of `window`. The real `NavigationConfigurator`, `NavigationProvider`, basename localization, and navigate/push/replace flows still run — only the history's origin (browser vs. memory) is substituted.
+
+```ts
+import { enableNavigationMock } from '@equinor/fusion-framework-module-navigation/mock';
+
+enableNavigationMock(configurator, {
+  configure: (config) => {
+    config.setBasename('/apps/my-app');
+    config.setInitialLocation('/users/42');
+  },
+});
+```
+
+A test environment (jsdom/happy-dom) always defines `window`, which is exactly what makes `NavigationConfigurator`'s default fall back to real browser history. `enableNavigationMock` forces `MemoryHistory` unconditionally, so a test's navigation state never touches — or leaks from — the real document location.
+
+`setInitialLocation` seeds the location the memory history starts at, so a test can assert against a specific route without an initial `navigate()` call:
+
+```ts
+enableNavigationMock(configurator, {
+  configure: (config) => config.setInitialLocation('/users/42?tab=info'),
+});
+```
+
+The string shortcut for a basename-only setup works the same as `enableNavigation`:
+
+```ts
+enableNavigationMock(configurator, '/apps/my-app');
+```
+
+`NavigationMockConfigurator` extends `NavigationConfigurator` directly, so the whole builder API — `setHistory`, telemetry, event provider — stays available; an explicit `setHistory()` call still replaces the mock history outright.
+
 ## API Reference
 
 ### Functions

--- a/packages/modules/navigation/package.json
+++ b/packages/modules/navigation/package.json
@@ -17,6 +17,10 @@
     "./utils": {
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/types/utils/index.d.ts"
+    },
+    "./mock": {
+      "import": "./dist/esm/mock/index.js",
+      "types": "./dist/types/mock/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/modules/navigation/src/__tests__/MemoryHistory.test.ts
+++ b/packages/modules/navigation/src/__tests__/MemoryHistory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { firstValueFrom, skip } from 'rxjs';
 import { MemoryHistory } from '../lib/MemoryHistory';
+import { Action } from '../lib/types';
 
 describe('MemoryHistory', () => {
   let history: MemoryHistory;
@@ -22,13 +23,15 @@ describe('MemoryHistory', () => {
     it('should initialize with custom initial location', () => {
       const customHistory = new MemoryHistory({
         initialLocation: {
-          action: 'POP',
+          delta: 0,
+          action: Action.Pop,
           location: {
             pathname: '/custom',
             search: '',
             hash: '',
             key: 'custom-key',
             state: { test: 'value' },
+            unstable_mask: undefined,
           },
         },
       });
@@ -46,6 +49,7 @@ describe('MemoryHistory', () => {
       const initialPathname = window.location.pathname;
       const initialHash = window.location.hash;
 
+      // skip the replayed current value; wait for the update from the push below
       const updatePromise = firstValueFrom(history.state$.pipe(skip(1)));
       history.push('/about', { test: 'test' });
       await updatePromise;
@@ -62,6 +66,7 @@ describe('MemoryHistory', () => {
       const initialPathname = window.location.pathname;
       const initialHash = window.location.hash;
 
+      // skip the replayed current value; wait for the update from the replace below
       const updatePromise = firstValueFrom(history.state$.pipe(skip(1)));
       history.replace('/profile', { userId: 123 });
       await updatePromise;
@@ -77,14 +82,17 @@ describe('MemoryHistory', () => {
     it('should maintain in-memory history stack', async () => {
       // Push multiple entries
       history.push('/page1', { page: 1 });
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page1');
 
       history.push('/page2', { page: 2 });
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page2');
 
       history.push('/page3', { page: 3 });
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page3');
 
@@ -115,6 +123,7 @@ describe('MemoryHistory', () => {
 
     it('should clamp go() to history bounds', async () => {
       history.push('/page1');
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page1');
 
@@ -156,6 +165,7 @@ describe('MemoryHistory', () => {
 
   describe('state$ observable', () => {
     it('should emit state updates on navigation', async () => {
+      // skip the replayed current value; wait for the update from the push below
       const updatePromise = firstValueFrom(history.state$.pipe(skip(1)));
       history.push('/test', { data: 'test' });
       const update = await updatePromise;
@@ -167,13 +177,16 @@ describe('MemoryHistory', () => {
 
     it('should emit state updates on go()', async () => {
       history.push('/page1');
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page1');
 
       history.push('/page2');
+      // skip the replayed current value; wait for the update from the push above
       await firstValueFrom(history.state$.pipe(skip(1)));
       expect(history.location.pathname).toBe('/page2');
 
+      // skip the replayed current value; wait for the update from the go() below
       const goPromise = firstValueFrom(history.state$.pipe(skip(1)));
       history.go(-1);
       const update = await goPromise;

--- a/packages/modules/navigation/src/__tests__/mock/navigation-mock.test.ts
+++ b/packages/modules/navigation/src/__tests__/mock/navigation-mock.test.ts
@@ -1,4 +1,5 @@
 import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+import { firstValueFrom, take, toArray } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
 import { module as realModule } from '../../module';
@@ -68,13 +69,20 @@ describe('enableNavigationMock', () => {
     // A test environment (jsdom/happy-dom) always defines `window`, which is exactly
     // what makes NavigationConfigurator's default fall back to real browser history.
     expect(typeof window).not.toBe('undefined');
-    window.history.pushState({}, '', '/somewhere-else');
 
-    const provider = await initializeMockWith();
+    const originalUrl = window.location.href;
+    // replaceState avoids adding a stack entry; restored in `finally` so this
+    // test doesn't leak document-location state into tests that run after it.
+    window.history.replaceState({}, '', '/somewhere-else');
+    try {
+      const provider = await initializeMockWith();
 
-    // Unaffected by the real document location - proof the history is in-memory.
-    // (NavigationProvider normalizes the root path to '', not '/'.)
-    expect(provider.path.pathname).toBe('');
+      // Unaffected by the real document location - proof the history is in-memory.
+      // (NavigationProvider normalizes the root path to '', not '/'.)
+      expect(provider.path.pathname).toBe('');
+    } finally {
+      window.history.replaceState({}, '', originalUrl);
+    }
   });
 
   it('replaces a navigation module that is already registered', async () => {
@@ -108,5 +116,19 @@ describe('enableNavigationMock', () => {
 
     expect(provider.path.pathname).toBe('/users/42');
     expect(provider.path.search).toBe('?tab=info');
+  });
+
+  it('scopes setInitialLocation() under a basename set beforehand, like navigate()/push()/replace()', async () => {
+    const provider = await initializeMockWith((configurator) => {
+      configurator.setBasename('/apps/my-app');
+      configurator.setInitialLocation('/users/42');
+    });
+
+    expect(provider.basename).toBe('/apps/my-app');
+    // localized path stays basename-relative ...
+    expect(provider.path.pathname).toBe('/users/42');
+    // ... while the seeded route is actually within the basename's scope on state$.
+    const [update] = await firstValueFrom(provider.state$.pipe(take(1), toArray()));
+    expect(update.location.pathname).toBe('/apps/my-app/users/42');
   });
 });

--- a/packages/modules/navigation/src/__tests__/mock/navigation-mock.test.ts
+++ b/packages/modules/navigation/src/__tests__/mock/navigation-mock.test.ts
@@ -1,0 +1,112 @@
+import { ModulesConfigurator } from '@equinor/fusion-framework-module';
+import { describe, expect, it } from 'vitest';
+
+import { module as realModule } from '../../module';
+import type { INavigationProvider } from '../../NavigationProvider.interface';
+import { NavigationConfigurator } from '../../NavigationConfigurator';
+import { NavigationProvider } from '../../NavigationProvider';
+
+import { enableNavigationMock, NavigationMockConfigurator, navigationMockModule } from '../../mock';
+
+/**
+ * Initializes the mock module through the real module system.
+ *
+ * @remarks
+ * Deliberately avoids hand-building initialization arguments — faking the
+ * module system is the very cost this mock removes.
+ *
+ * @param configure - Optional callback to seed the initial location or configure the module further.
+ * @returns The `INavigationProvider` the module produced.
+ */
+const initializeMockWith = async (
+  configure?: (configurator: NavigationMockConfigurator) => void,
+): Promise<INavigationProvider> => {
+  const configurator = new ModulesConfigurator([]);
+  enableNavigationMock(configurator, configure && { configure });
+  const instances = await configurator.initialize();
+  return getNavigation(instances);
+};
+
+/**
+ * Reads the `navigation` provider off a resolved module instance map.
+ *
+ * @remarks
+ * `ModulesConfigurator<[]>.initialize()` only knows about the modules in its
+ * own generic — none here — so the `navigation` key added by
+ * `enableNavigationMock` is invisible to its return type. The cast is safe:
+ * `enableNavigationMock` always registers the navigation module.
+ * @param instances - The resolved instance map returned by `configurator.initialize()`.
+ * @returns The `INavigationProvider` instance.
+ */
+const getNavigation = (instances: unknown): INavigationProvider =>
+  (instances as { navigation: INavigationProvider }).navigation;
+
+describe('navigationMockModule', () => {
+  it('changes nothing but the configurator', () => {
+    expect(navigationMockModule.name).toBe(realModule.name);
+    expect(navigationMockModule.version).toBe(realModule.version);
+    // The production initializer, untouched — the mock has no lifecycle of its own
+    expect(navigationMockModule.initialize).toBe(realModule.initialize);
+  });
+
+  it('builds a real NavigationConfigurator, so the whole builder stays available', () => {
+    const configurator = navigationMockModule.configure?.();
+
+    expect(configurator).toBeInstanceOf(NavigationConfigurator);
+    expect(configurator).toBeInstanceOf(NavigationMockConfigurator);
+  });
+});
+
+describe('enableNavigationMock', () => {
+  it('produces the real NavigationProvider, not a stand-in', async () => {
+    const provider = await initializeMockWith();
+
+    expect(provider).toBeInstanceOf(NavigationProvider);
+  });
+
+  it('uses memory history even though `window` is defined in this test environment', async () => {
+    // A test environment (jsdom/happy-dom) always defines `window`, which is exactly
+    // what makes NavigationConfigurator's default fall back to real browser history.
+    expect(typeof window).not.toBe('undefined');
+    window.history.pushState({}, '', '/somewhere-else');
+
+    const provider = await initializeMockWith();
+
+    // Unaffected by the real document location - proof the history is in-memory.
+    // (NavigationProvider normalizes the root path to '', not '/'.)
+    expect(provider.path.pathname).toBe('');
+  });
+
+  it('replaces a navigation module that is already registered', async () => {
+    // A FrameworkConfigurator pre-registers the real navigation module, so the
+    // mock is only useful if registering it afterwards wins
+    const configurator = new ModulesConfigurator([realModule]);
+    enableNavigationMock(configurator);
+
+    const instances = await configurator.initialize();
+    const provider = getNavigation(instances);
+
+    expect(provider.path.pathname).toBe('');
+  });
+
+  it('sets the basename from the string shortcut', async () => {
+    const provider = await initializeMockWith();
+    expect(provider.basename).toBe('');
+
+    const configurator = new ModulesConfigurator([]);
+    enableNavigationMock(configurator, '/apps/my-app');
+    const instances = await configurator.initialize();
+    const withBasename = getNavigation(instances);
+
+    expect(withBasename.basename).toBe('/apps/my-app');
+  });
+
+  it('seeds the initial location through setInitialLocation()', async () => {
+    const provider = await initializeMockWith((configurator) => {
+      configurator.setInitialLocation('/users/42?tab=info');
+    });
+
+    expect(provider.path.pathname).toBe('/users/42');
+    expect(provider.path.search).toBe('?tab=info');
+  });
+});

--- a/packages/modules/navigation/src/mock/NavigationMockConfigurator.ts
+++ b/packages/modules/navigation/src/mock/NavigationMockConfigurator.ts
@@ -1,0 +1,50 @@
+import { v7 as generateId } from 'uuid';
+
+import { createHistory } from '../lib/create-history';
+import { Action, type To } from '../lib/types';
+import { resolvePath } from '../lib/utils';
+import { NavigationConfigurator } from '../NavigationConfigurator';
+
+/**
+ * Navigation configurator for tests: always resolves to {@link MemoryHistory},
+ * regardless of whether `window` is defined.
+ *
+ * @remarks
+ * The real configurator falls back to browser history whenever `window`
+ * exists — true in a happy-dom/jsdom test environment — so a test would
+ * otherwise navigate (and leak state across test cases via) the real,
+ * shared document location. Forcing memory history is the only behavioral
+ * difference from {@link NavigationConfigurator}.
+ */
+export class NavigationMockConfigurator extends NavigationConfigurator {
+  /**
+   * Creates the configurator with memory history already set as the default,
+   * overriding {@link NavigationConfigurator}'s `window`-dependent fallback.
+   */
+  constructor() {
+    super();
+    this.setHistory(createHistory('memory'));
+  }
+
+  /**
+   * Seeds the location the memory history starts at, so a test can assert
+   * against a specific route without an initial `navigate()` call.
+   *
+   * @param to - The path to seed as the current location.
+   * @param state - Optional state to attach to the seeded location.
+   * @returns The configurator instance for method chaining.
+   */
+  public setInitialLocation(to: To, state: unknown = null): this {
+    const path = resolvePath(to);
+    this.setHistory(
+      createHistory('memory', {
+        initialLocation: {
+          delta: 0,
+          action: Action.Pop,
+          location: { ...path, state, key: generateId(), unstable_mask: undefined },
+        },
+      }),
+    );
+    return this;
+  }
+}

--- a/packages/modules/navigation/src/mock/NavigationMockConfigurator.ts
+++ b/packages/modules/navigation/src/mock/NavigationMockConfigurator.ts
@@ -1,9 +1,14 @@
+import type { ConfigBuilderCallback } from '@equinor/fusion-framework-module';
 import { v7 as generateId } from 'uuid';
 
 import { createHistory } from '../lib/create-history';
 import { Action, type To } from '../lib/types';
 import { resolvePath } from '../lib/utils';
 import { NavigationConfigurator } from '../NavigationConfigurator';
+
+// Mirrors NavigationProvider's private helper of the same name — collapses repeated
+// slashes so a prepended basename never produces a doubled or trailing separator.
+const normalizePathname = (path: string) => path.replace(/\/+/g, '/').replace(/\/$/, '');
 
 /**
  * Navigation configurator for tests: always resolves to {@link MemoryHistory},
@@ -18,32 +23,59 @@ import { NavigationConfigurator } from '../NavigationConfigurator';
  */
 export class NavigationMockConfigurator extends NavigationConfigurator {
   /**
+   * Basename seen through {@link setBasename}, cached so {@link setInitialLocation}
+   * can prepend it without waiting for the async config-builder resolution.
+   */
+  #basename?: string;
+
+  /**
    * Creates the configurator with memory history already set as the default,
    * overriding {@link NavigationConfigurator}'s `window`-dependent fallback.
    */
   constructor() {
     super();
-    this.setHistory(createHistory('memory'));
+    // proxy: false — this memory history is created and owned by the mock itself,
+    // matching NavigationConfigurator's own default-history path, so it is torn
+    // down on dispose instead of being silently kept alive by an unowned ProxyHistory.
+    this.setHistory(createHistory('memory'), { proxy: false });
+  }
+
+  /**
+   * @param basenameOrCallback - Basename string or configuration callback.
+   * @returns The configurator instance for method chaining.
+   */
+  public override setBasename(basenameOrCallback?: string | ConfigBuilderCallback<string>): this {
+    // Only a plain string is knowable synchronously; a callback resolves later
+    // through the real config builder and is left out of setInitialLocation's basename.
+    this.#basename = typeof basenameOrCallback === 'string' ? basenameOrCallback : undefined;
+    return super.setBasename(basenameOrCallback);
   }
 
   /**
    * Seeds the location the memory history starts at, so a test can assert
    * against a specific route without an initial `navigate()` call.
    *
-   * @param to - The path to seed as the current location.
+   * @remarks
+   * `to` is basename-relative, matching {@link NavigationProvider.navigate}/`push`/`replace` —
+   * call `setBasename()` first if the seeded route should be scoped under one.
+   *
+   * @param to - The path to seed as the current location, relative to the configured basename.
    * @param state - Optional state to attach to the seeded location.
    * @returns The configurator instance for method chaining.
    */
   public setInitialLocation(to: To, state: unknown = null): this {
     const path = resolvePath(to);
+    const pathname = normalizePathname(`${this.#basename ?? ''}/${path.pathname}`);
     this.setHistory(
       createHistory('memory', {
         initialLocation: {
           delta: 0,
           action: Action.Pop,
-          location: { ...path, state, key: generateId(), unstable_mask: undefined },
+          location: { ...path, pathname, state, key: generateId(), unstable_mask: undefined },
         },
       }),
+      // proxy: false — same ownership reasoning as the constructor's default history.
+      { proxy: false },
     );
     return this;
   }

--- a/packages/modules/navigation/src/mock/index.ts
+++ b/packages/modules/navigation/src/mock/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Mock navigation module for tests: real provider, real configurator,
+ * in-memory history.
+ *
+ * @remarks
+ * Forcing {@link MemoryHistory} is the smallest change that removes real
+ * browser navigation — and its cross-test leakage — from a test. Everything
+ * above it — the `NavigationProvider`, basename localization, and
+ * navigate/push/replace flows — is the production code path.
+ *
+ * @example
+ * ```typescript
+ * import { enableNavigationMock } from '@equinor/fusion-framework-module-navigation/mock';
+ *
+ * enableNavigationMock(configurator, {
+ *   configure: (config) => config.setInitialLocation('/users/42'),
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+export { NavigationMockConfigurator } from './NavigationMockConfigurator';
+export { enableNavigationMock, navigationMockModule, type NavigationMockConfigFn } from './module';

--- a/packages/modules/navigation/src/mock/module.ts
+++ b/packages/modules/navigation/src/mock/module.ts
@@ -1,0 +1,67 @@
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
+
+import { module, type NavigationModule } from '../module';
+
+import { NavigationMockConfigurator } from './NavigationMockConfigurator';
+
+/**
+ * The navigation module with a mock configurator that always resolves to
+ * {@link MemoryHistory}, instead of falling back to real browser history.
+ *
+ * @remarks
+ * Only `configure` differs from the real module. `initialize` is the
+ * production one, untouched, so the real `NavigationProvider`, basename
+ * localization, and navigate/push/replace flows run exactly as they do in
+ * production — a test observes real navigation behavior against an
+ * in-memory history, not a reimplementation of it.
+ */
+export const navigationMockModule: NavigationModule = {
+  ...module,
+  configure: () => new NavigationMockConfigurator(),
+};
+
+/**
+ * Configuration callback for {@link enableNavigationMock}.
+ *
+ * @template TRef - Reference type forwarded to the callback.
+ */
+export type NavigationMockConfigFn<TRef = unknown> = (
+  configurator: NavigationMockConfigurator,
+  ref: TRef,
+) => void;
+
+/**
+ * Enables the navigation module against an in-memory {@link MemoryHistory},
+ * so a test's navigation state never touches (or leaks from) the real
+ * browser location.
+ *
+ * @param configurator - The modules configurator to register on.
+ * @param basenameOrOptions - Optional basename string, or a `configure` callback for seeding the initial location or further setup.
+ * @template TRef - Reference type forwarded to `configure`.
+ *
+ * @example
+ * ```typescript
+ * enableNavigationMock(configurator, {
+ *   configure: (config) => config.setInitialLocation('/users/42'),
+ * });
+ * ```
+ */
+export const enableNavigationMock = <TRef = unknown>(
+  // biome-ignore lint/suspicious/noExplicitAny: must be any to support all module types
+  configurator: IModulesConfigurator<any, any>,
+  basenameOrOptions?: string | { configure: NavigationMockConfigFn<TRef> },
+): void => {
+  configurator.addConfig({
+    module: navigationMockModule,
+    configure(config, ref) {
+      // A string shortcut sets the basename directly; otherwise defer to the caller's configure callback.
+      if (typeof basenameOrOptions === 'string') {
+        config.setBasename(basenameOrOptions);
+      } else if (typeof basenameOrOptions === 'object' && 'configure' in basenameOrOptions) {
+        basenameOrOptions.configure(config as NavigationMockConfigurator, ref);
+      }
+    },
+  });
+};
+
+export default enableNavigationMock;


### PR DESCRIPTION
**Why is this change needed?**
Part of the App Testability epic (equinor/fusion-core-tasks#1654). Tests that use the navigation module currently have no way to get deterministic, in-memory navigation state — the real configurator falls back to browser history whenever `window` is defined, which is always true in jsdom/happy-dom.

**What is the current behavior?**
`NavigationConfigurator`'s default history resolution is:
```ts
if (history) return new ProxyHistory(history);
if (typeof window !== 'undefined') return createHistory('browser');
return createHistory('memory');
```
In a test environment `window` is always defined, so an app under test gets real, document-shared `window.history` — state can leak between tests, and the starting path depends on whatever the test runner's page happens to be at.

**What is the new behavior?**
Adds a `./mock` subpath exporting `NavigationMockConfigurator` and `enableNavigationMock`. The configurator forces in-memory history unconditionally, regardless of `window`, and adds `setInitialLocation(to, state?)` to seed a starting route without hand-constructing a `NavigationUpdate`/`Location` object. Mirrors the `context`/`bookmark`/`msal` mock precedents — same `enable*Mock(configurator, basenameOrOptions?)` shape, same override-already-registered-module behavior.

Also includes a small, unrelated fix to `packages/modules/navigation/src/__tests__/MemoryHistory.test.ts` (a pre-existing file): its custom initial-location fixture used a bare `'POP'` string and was missing `unstable_mask`, both of which no longer satisfy `NavigationUpdate`; also adds intent comments above repeated `.pipe(skip(1))` calls flagged by fusion-lint.

**What is the intended behavior or invariant?**
The mock always resolves to `MemoryHistory`, never browser history, no matter the test environment. The existing `setHistory()` escape hatch and basename/other builder options keep working unmodified — only the default history resolution changes. No default flags/state are assumed beyond what a test seeds.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-module-navigation`)
- Consumer impact: New opt-in `./mock` subpath only; no changes to existing exports
- Downstream impact: None — `@equinor/fusion-framework` is untouched

**Review guidance:**
Focus on `NavigationMockConfigurator.ts` (the forced-memory-history override and `setInitialLocation`) and `mock/module.ts` (mirrors `enable-navigation.ts`'s signature). The 2nd-export-per-file fusion-lint warning in `mock/module.ts` is left unresolved by design, matching the identical pre-existing pattern in `bookmark`'s `mock/module.ts`.

**Additional context**
Follows the same shape as `.changeset/module-bookmark_mock-entry-point.md` and `.changeset/module-context_mock-entry-point.md`.

**Related issues**
closes: equinor/fusion-core-tasks#1719

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable (N/A — no React changes)
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated (Biome + fusion-lint clean, `vitest run` passing: 50/50 navigation module tests)
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct