### PR TITLE
fix(context-navigation): build before pack

### DIFF
--- a/.changeset/fusion-framework-plugin-context-navigation_build-before-pack.md
+++ b/.changeset/fusion-framework-plugin-context-navigation_build-before-pack.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-plugin-context-navigation": patch
+---
+
+Internal: build the package before `prepack` so packed and published artifacts always include fresh generated output.

--- a/packages/plugins/context-navigation/package.json
+++ b/packages/plugins/context-navigation/package.json
@@ -25,7 +25,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@equinor/fusion-framework-module": "workspace:^",


### PR DESCRIPTION
**Why is this change needed?**
`@equinor/fusion-framework-plugin-context-navigation` could be packed or published without rebuilding first, which made the tarball depend on whatever generated output happened to exist locally.

**What is the current behavior?**
`prepack` was not defined, so packaging did not guarantee a fresh build step for this package.

**What is the new behavior?**
`prepack` now runs `pnpm build`, ensuring packaging always includes up-to-date generated artifacts.

**What is the intended behavior or invariant?**
The published package should always reflect the current source tree and freshly generated output before it is packed or published.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch
- Consumer impact: No API changes; only the packaging workflow changes.
- Downstream impact: None expected.

**Review guidance:**
Focus on the packaging lifecycle: this change only adds a build step before packing, and should not alter runtime exports or module behavior.

**Additional context**
A changeset is included for the package bump.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - [x] Included files validated
  - [x] No new linting warnings
  - [x] Not a duplicate PR
- [x] Confirm adherence to the Code of Conduct