### PR TITLE
feat(cli): add `ffc app test` command

### DIFF
--- a/.changeset/cli_app-test-command.md
+++ b/.changeset/cli_app-test-command.md
@@ -1,0 +1,11 @@
+---
+"@equinor/fusion-framework-cli": minor
+---
+
+Add `ffc app test` command, running the application's own Vitest suite with its manifest, config, and module-configurator resolved and exposed to `@equinor/fusion-framework-react-app/vitest`'s `test`/`render` fixtures with zero per-test wiring — the same resolution `ffc app build`/`ffc app dev` already do.
+
+```sh
+ffc app test
+ffc app test --watch
+ffc app test --manifest ./app.manifest.local.ts --config ./app.config.ts
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/types/lib/dev-server.d.ts",
       "import": "./dist/esm/lib/dev-server.js"
     },
+    "./vitest": {
+      "types": "./dist/types/lib/vitest/index.d.ts",
+      "import": "./dist/esm/lib/vitest/index.js"
+    },
     "./bin": {
       "types": "./dist/types/bin/index.d.ts",
       "import": "./bin/build/bin.mjs"
@@ -76,6 +80,9 @@
       ],
       "dev-server": [
         "dist/types/lib/dev-server.d.ts"
+      ],
+      "vitest": [
+        "dist/types/lib/vitest/index.d.ts"
       ],
       "bin": [
         "dist/types/bin/index.d.ts"
@@ -139,7 +146,7 @@
     "@types/adm-zip": "^0.5.0",
     "@types/normalize-package-data": "^2.4.4",
     "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.10",
     "adm-zip": "^0.6.0",
     "ajv": "^8.17.1",
     "is-ci": "^4.1.0",
@@ -150,7 +157,7 @@
     "rxjs": "^7.8.1",
     "type-fest": "^5.0.0",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.10"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -18,6 +18,7 @@ export { checkApp } from './check-app.js';
 export { loadAppManifest } from './load-app-manifest.js';
 export { uploadApplication } from './upload-application.js';
 export { tagApplication } from './tag-application.js';
+export { testApplication, type TestApplicationOptions } from './test-application.js';
 
 export { startPortalDevServer } from './start-portal-dev-server.js';
 export { servePortal, type ServePortalOptions } from './serve-portal.js';

--- a/packages/cli/src/bin/test-application.ts
+++ b/packages/cli/src/bin/test-application.ts
@@ -102,6 +102,7 @@ const APP_TEST_CONFIG_FILENAME = '.ffc-app-test.vitest.config.mjs';
  * @returns The absolute path to the config file, or `undefined` if none of the candidates exist.
  */
 const resolveVitestConfigFile = (root: string): string | undefined =>
+  // first candidate that exists on disk wins; callers only need the winner's absolute path
   VITEST_CONFIG_CANDIDATES.map((file) => resolve(root, file)).find((file) => existsSync(file));
 
 /**

--- a/packages/cli/src/bin/test-application.ts
+++ b/packages/cli/src/bin/test-application.ts
@@ -1,0 +1,161 @@
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { existsSync } from 'node:fs';
+import { rm, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { UserConfig } from 'vite';
+import type { startVitest as StartVitest } from 'vitest/node';
+
+import type { AppTestVitePluginOptions } from '../lib/vitest/app-test-vite-plugin.js';
+
+import type { ConsoleLogger } from './utils/index.js';
+import { resolveProjectPackage } from './helpers/resolve-project-package.js';
+
+/**
+ * Options for {@link testApplication}.
+ * @public
+ */
+export interface TestApplicationOptions {
+  /** Path to the application manifest file. */
+  manifest?: string;
+  /** Path to the application config file. */
+  config?: string;
+  /** Path to the application's module-configurator file. */
+  configure?: string;
+  /** Re-run tests on file changes instead of exiting after a single run. */
+  watch?: boolean;
+  /** Logger instance for outputting progress and debug information. */
+  log?: ConsoleLogger | null;
+}
+
+/**
+ * Runs the application's own Vitest suite with its manifest, config, and module-configurator
+ * wired up automatically — the same resolution `ffc app build`/`ffc app dev` use.
+ *
+ * @remarks
+ * Runs the application's own installed `vitest`, so no `vitest` dependency of the CLI itself is
+ * ever loaded — this avoids a duplicate/mismatched `vitest` in the application's module graph.
+ * Any test file using `@equinor/fusion-framework-react-app/vitest` picks up the resolved
+ * manifest/config/`configure` with no per-file wiring.
+ *
+ * A throwaway `vitest.config` wrapping the application's own config (if any) plus the app-test
+ * Vite plugin is written next to the application's config and passed to `startVitest` as an
+ * explicit `configFile`. This is necessary because Vitest's `browser` mode re-resolves its own
+ * Vite server straight from the on-disk config file for each test project — a plugin handed to
+ * `startVitest` only as an in-memory `viteOverrides` object never reaches that resolution.
+ *
+ * @param options - Options controlling manifest/config/configure resolution and watch mode.
+ * @returns A promise that resolves once the run completes (or immediately in watch mode).
+ * @throws If `vitest` is not resolvable from the application package, or the run itself fails.
+ * @public
+ */
+export const testApplication = async (options?: TestApplicationOptions): Promise<void> => {
+  const { log } = options ?? {};
+  const pkg = await resolveProjectPackage(log);
+
+  log?.start('resolving local vitest...');
+  const startVitest = await resolveLocalStartVitest(pkg.root);
+  log?.succeed('resolved local vitest');
+
+  const configFile = await writeAppTestVitestConfig(pkg.root, {
+    cwd: pkg.root,
+    manifestPath: options?.manifest,
+    configPath: options?.config,
+    configureModule: options?.configure,
+  });
+
+  try {
+    await startVitest(
+      'test',
+      [],
+      { root: pkg.root, watch: options?.watch ?? false },
+      // `configFile` lives on Vite's `InlineConfig` (which `viteOverrides` is merged into at
+      // runtime), not on the plain `UserConfig` type `startVitest` declares for this parameter
+      { configFile } as UserConfig,
+    );
+  } finally {
+    await rm(configFile, { force: true });
+  }
+};
+
+const VITEST_CONFIG_CANDIDATES = [
+  'vitest.config.ts',
+  'vitest.config.mts',
+  'vitest.config.cts',
+  'vitest.config.js',
+  'vitest.config.mjs',
+  'vitest.config.cjs',
+];
+
+/** Filename for the throwaway config {@link writeAppTestVitestConfig} generates. */
+const APP_TEST_CONFIG_FILENAME = '.ffc-app-test.vitest.config.mjs';
+
+/**
+ * Finds the application's own `vitest.config.*` file.
+ *
+ * @remarks
+ * `vite`'s config loader only auto-discovers `vite.config.*` by default — it never looks for
+ * `vitest.config.*` on its own, so callers must supply the concrete path themselves.
+ *
+ * @param root - The application package root to search in.
+ * @returns The absolute path to the config file, or `undefined` if none of the candidates exist.
+ */
+const resolveVitestConfigFile = (root: string): string | undefined =>
+  VITEST_CONFIG_CANDIDATES.map((file) => resolve(root, file)).find((file) => existsSync(file));
+
+/**
+ * Writes a throwaway `vitest.config` next to the application's own config, re-exporting it
+ * merged with the app-test Vite plugin, so Vitest's own on-disk config resolution (used for
+ * every test project, including each `browser`-mode one) always sees the plugin.
+ *
+ * @param root - The application package root.
+ * @param pluginOptions - Options forwarded to `appTestVitePlugin`.
+ * @returns The absolute path to the generated config file; the caller is responsible for
+ * removing it once the run completes.
+ */
+const writeAppTestVitestConfig = async (
+  root: string,
+  pluginOptions: AppTestVitePluginOptions,
+): Promise<string> => {
+  const configFile = resolve(root, APP_TEST_CONFIG_FILENAME);
+  const userConfigFile = resolveVitestConfigFile(root);
+  const userConfigImport = userConfigFile
+    ? `import userConfig from ${JSON.stringify(pathToFileURL(userConfigFile).href)};`
+    : 'const userConfig = {};';
+
+  // spread rather than a deep-merge helper (e.g. `vite`'s `mergeConfig`) since this file is
+  // resolved from the application's own `node_modules`, which has no direct dependency on `vite`
+  const source = [
+    "import { appTestVitePlugin } from '@equinor/fusion-framework-cli/vitest';",
+    userConfigImport,
+    '',
+    'export default {',
+    '  ...userConfig,',
+    `  plugins: [...(userConfig.plugins ?? []), appTestVitePlugin(${JSON.stringify(pluginOptions)})],`,
+    '};',
+    '',
+  ].join('\n');
+
+  await writeFile(configFile, source, 'utf8');
+  return configFile;
+};
+
+/**
+ * Resolves `vitest/node`'s `startVitest` from the application package's own `node_modules`,
+ * rather than whatever `vitest` (if any) is installed alongside the CLI itself.
+ */
+const resolveLocalStartVitest = async (root: string): Promise<typeof StartVitest> => {
+  const require = createRequire(pathToFileURL(resolve(root, 'package.json')));
+  try {
+    const vitestNode = await import(require.resolve('vitest/node'));
+    return vitestNode.startVitest;
+  } catch (err) {
+    throw new Error(
+      '`ffc app test` requires "vitest" to be installed in the application package.',
+      { cause: err },
+    );
+  }
+};
+
+export default testApplication;

--- a/packages/cli/src/cli/commands/app/index.ts
+++ b/packages/cli/src/cli/commands/app/index.ts
@@ -8,6 +8,7 @@ import configCommand from './config.command.js';
 import tagCommand from './tag.command.js';
 import devCommand from './dev.command.js';
 import serveCommand from './serve.command.js';
+import testCommand from './test.command.js';
 import manifestCommand from './manifest.command.js';
 import publishCommand from './publish.command.js';
 import createAppCommand from '../create/create-app-command.js';
@@ -48,6 +49,7 @@ export const command = createCommand('app')
   .addCommand(tagCommand)
   .addCommand(devCommand)
   .addCommand(serveCommand)
+  .addCommand(testCommand)
   .addCommand(manifestCommand)
   .addCommand(publishCommand)
   .addCommand(createAppCommand('create'));

--- a/packages/cli/src/cli/commands/app/test.command.ts
+++ b/packages/cli/src/cli/commands/app/test.command.ts
@@ -1,0 +1,63 @@
+import { createCommand } from 'commander';
+
+import { ConsoleLogger, testApplication } from '@equinor/fusion-framework-cli/bin';
+
+/**
+ * CLI command: `test`
+ *
+ * Runs the application's own Vitest suite with its manifest, config, and module-configurator
+ * resolved and wired up automatically — no per-test-file fixture setup required.
+ *
+ * Usage:
+ *   $ ffc app test [options]
+ *
+ * Options:
+ *   --manifest <path>    Path to the app manifest file (app.manifest[.env]?.[ts,js,json])
+ *   --config <path>      Path to the app config file (app.config[.env]?.[ts,js,json])
+ *   --configure <path>   Path to the app's module-configurator file (default: src/config.*)
+ *   --watch              Re-run tests on file changes instead of exiting after one run
+ *   --debug              Enable debug mode
+ *
+ * Example:
+ *   $ ffc app test
+ *   $ ffc app test --watch
+ *   $ ffc app test --manifest ./app.manifest.local.ts --config ./app.config.ts
+ *
+ * @see testApplication for implementation details
+ */
+export const command = createCommand('test')
+  .description("Run the application's own test suite with manifest/config/configure resolved.")
+  .addHelpText(
+    'after',
+    [
+      '',
+      "Runs the application's own installed Vitest, with its manifest, config, and",
+      'module-configurator resolved the same way `ffc app build`/`ffc app dev` do, and exposed',
+      "to `@equinor/fusion-framework-react-app/vitest`'s `test` with zero per-test wiring.",
+      '',
+      'Examples:',
+      '  $ ffc app test',
+      '  $ ffc app test --watch',
+      '  $ ffc app test --manifest ./app.manifest.local.ts --config ./app.config.ts',
+    ].join('\n'),
+  )
+  .option('--debug', 'Enable debug mode', !!process.env.RUNNER_DEBUG)
+  .option('--manifest <path>', 'Path to the app manifest file (app.manifest[.env]?.[ts,js,json])')
+  .option('--config <path>', 'Path to the app config file (app.config[.env]?.[ts,js,json])')
+  .option('--configure <path>', "Path to the app's module-configurator file (default: src/config.*)")
+  .option('--watch', 'Re-run tests on file changes instead of exiting after one run', false)
+  .action(async (options) => {
+    const log = new ConsoleLogger('app:test', { debug: options.debug });
+
+    log.start('Running application test suite...');
+    await testApplication({
+      log,
+      manifest: options.manifest,
+      config: options.config,
+      configure: options.configure,
+      watch: options.watch,
+    });
+    log.succeed('Application test suite finished.');
+  });
+
+export default command;

--- a/packages/cli/src/cli/commands/app/test.command.ts
+++ b/packages/cli/src/cli/commands/app/test.command.ts
@@ -44,7 +44,10 @@ export const command = createCommand('test')
   .option('--debug', 'Enable debug mode', !!process.env.RUNNER_DEBUG)
   .option('--manifest <path>', 'Path to the app manifest file (app.manifest[.env]?.[ts,js,json])')
   .option('--config <path>', 'Path to the app config file (app.config[.env]?.[ts,js,json])')
-  .option('--configure <path>', "Path to the app's module-configurator file (default: src/config.*)")
+  .option(
+    '--configure <path>',
+    "Path to the app's module-configurator file (default: src/config.*)",
+  )
   .option('--watch', 'Re-run tests on file changes instead of exiting after one run', false)
   .action(async (options) => {
     const log = new ConsoleLogger('app:test', { debug: options.debug });

--- a/packages/cli/src/lib/vitest/app-test-vite-plugin.ts
+++ b/packages/cli/src/lib/vitest/app-test-vite-plugin.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { FileNotFoundError } from '@equinor/fusion-imports';
 import type { Plugin } from 'vite';
 
 import { resolveAppTestEnv, type ResolveAppTestEnvOptions } from './resolve-app-test-env.js';
@@ -47,10 +48,12 @@ export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin =>
     resolveId(id) {
       // claim only our two virtual specifiers, leave everything else to the normal resolvers
       if (id === ENV_MODULE_ID) return RESOLVED_ENV_MODULE_ID;
+      // second virtual specifier, same rule as above
       if (id === CONFIGURE_MODULE_ID) return RESOLVED_CONFIGURE_MODULE_ID;
       return null;
     },
     async load(id) {
+      // serves manifest/config resolved lazily here, not at plugin-creation time, so options.cwd changes between test runs are respected
       if (id === RESOLVED_ENV_MODULE_ID) {
         const { manifest, config } = await resolveAppTestEnv(options);
         return [
@@ -58,8 +61,8 @@ export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin =>
           `export const config = ${JSON.stringify(config)};`,
         ].join('\n');
       }
+      // no conventional module means the app registers no extra modules, same as omitting `configure` from `makeComponent`
       if (id === RESOLVED_CONFIGURE_MODULE_ID) {
-        // no conventional module means the app registers no extra modules, same as omitting `configure` from `makeComponent`
         return configureModulePath
           ? `export { default as configure } from ${JSON.stringify(configureModulePath)};`
           : 'export const configure = undefined;';
@@ -72,10 +75,23 @@ export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin =>
 /**
  * Resolves the app's module-configurator file: the explicit `file` if given, otherwise the
  * first existing candidate in {@link DEFAULT_CONFIGURE_CANDIDATES}.
+ *
+ * @throws {@link FileNotFoundError} If an explicitly requested `file` does not exist — unlike
+ * the convention-based lookup, a typo here should fail loudly instead of silently running the
+ * test suite without the application's modules.
  */
 const resolveConfigureModulePath = (cwd: string, file?: string): string | undefined => {
-  const candidates = file ? [file] : DEFAULT_CONFIGURE_CANDIDATES;
-  const found = candidates.find((candidate) => existsSync(resolve(cwd, candidate)));
+  // an explicit path is a user request, not a convention lookup, so a typo must fail loudly
+  if (file) {
+    const resolved = resolve(cwd, file);
+    // fail fast rather than silently falling back to "no configurator"
+    if (!existsSync(resolved)) {
+      throw new FileNotFoundError(`Configure module not found: ${resolved}`);
+    }
+    return resolved;
+  }
+  // first candidate that exists wins; none existing is a valid "no configurator" state
+  const found = DEFAULT_CONFIGURE_CANDIDATES.find((candidate) => existsSync(resolve(cwd, candidate)));
   return found ? resolve(cwd, found) : undefined;
 };
 

--- a/packages/cli/src/lib/vitest/app-test-vite-plugin.ts
+++ b/packages/cli/src/lib/vitest/app-test-vite-plugin.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import type { Plugin } from 'vite';
+
+import { resolveAppTestEnv, type ResolveAppTestEnvOptions } from './resolve-app-test-env.js';
+
+const ENV_MODULE_ID = 'virtual:fusion-app-test-env';
+const CONFIGURE_MODULE_ID = 'virtual:fusion-app-test-configure';
+const RESOLVED_ENV_MODULE_ID = `\0${ENV_MODULE_ID}`;
+const RESOLVED_CONFIGURE_MODULE_ID = `\0${CONFIGURE_MODULE_ID}`;
+
+const DEFAULT_CONFIGURE_CANDIDATES = ['src/config.ts', 'src/config.tsx', 'src/config.js'];
+
+/**
+ * Options for {@link appTestVitePlugin}.
+ */
+export type AppTestVitePluginOptions = ResolveAppTestEnvOptions & {
+  /**
+   * Path (relative to `cwd`) to the app's module-configurator export, mirroring the `configure`
+   * argument passed to `makeComponent` in the app's own entry point. Defaults to the first of
+   * `src/config.ts`, `src/config.tsx`, `src/config.js` that exists.
+   */
+  configureModule?: string;
+};
+
+/**
+ * Vite plugin backing `ffc app test`: serves the application's manifest/config (resolved the
+ * same way `ffc app build`/`ffc app dev` do) and its own module-configurator export as virtual
+ * modules, so `@equinor/fusion-framework-react-app/vitest`'s `test` needs no per-test
+ * `env`/`configure` wiring.
+ *
+ * @remarks
+ * Exposes two virtual modules: `virtual:fusion-app-test-env` (`manifest`/`config`, as JSON) and
+ * `virtual:fusion-app-test-configure` (a re-export of the resolved `configure` module, or
+ * `undefined` if none exists). Not intended to be imported directly by application code.
+ *
+ * @param options - Resolution options; `cwd` defaults to the current working directory.
+ * @returns A Vite plugin instance.
+ */
+export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin => {
+  const cwd = options?.cwd ?? process.cwd();
+  const configureModulePath = resolveConfigureModulePath(cwd, options?.configureModule);
+
+  return {
+    name: 'fusion:app-test',
+    resolveId(id) {
+      // claim only our two virtual specifiers, leave everything else to the normal resolvers
+      if (id === ENV_MODULE_ID) return RESOLVED_ENV_MODULE_ID;
+      if (id === CONFIGURE_MODULE_ID) return RESOLVED_CONFIGURE_MODULE_ID;
+      return null;
+    },
+    async load(id) {
+      if (id === RESOLVED_ENV_MODULE_ID) {
+        const { manifest, config } = await resolveAppTestEnv(options);
+        return [
+          `export const manifest = ${JSON.stringify(manifest)};`,
+          `export const config = ${JSON.stringify(config)};`,
+        ].join('\n');
+      }
+      if (id === RESOLVED_CONFIGURE_MODULE_ID) {
+        // no conventional module means the app registers no extra modules, same as omitting `configure` from `makeComponent`
+        return configureModulePath
+          ? `export { default as configure } from ${JSON.stringify(configureModulePath)};`
+          : 'export const configure = undefined;';
+      }
+      return null;
+    },
+  };
+};
+
+/**
+ * Resolves the app's module-configurator file: the explicit `file` if given, otherwise the
+ * first existing candidate in {@link DEFAULT_CONFIGURE_CANDIDATES}.
+ */
+const resolveConfigureModulePath = (cwd: string, file?: string): string | undefined => {
+  const candidates = file ? [file] : DEFAULT_CONFIGURE_CANDIDATES;
+  const found = candidates.find((candidate) => existsSync(resolve(cwd, candidate)));
+  return found ? resolve(cwd, found) : undefined;
+};
+
+export default appTestVitePlugin;

--- a/packages/cli/src/lib/vitest/index.ts
+++ b/packages/cli/src/lib/vitest/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Testing utilities for `@equinor/fusion-framework-cli/vitest`.
+ *
+ * Resolves an application's manifest and config using the same pipeline `ffc app build`/
+ * `ffc app dev` use, for seeding test fixtures.
+ *
+ * @packageDocumentation
+ */
+export {
+  resolveAppTestEnv,
+  type AppTestEnv,
+  type ResolveAppTestEnvOptions,
+} from './resolve-app-test-env.js';
+export { appTestVitePlugin, type AppTestVitePluginOptions } from './app-test-vite-plugin.js';

--- a/packages/cli/src/lib/vitest/resolve-app-test-env.ts
+++ b/packages/cli/src/lib/vitest/resolve-app-test-env.ts
@@ -1,0 +1,106 @@
+import { FileNotFoundError } from '@equinor/fusion-imports';
+import type { AppManifest } from '@equinor/fusion-framework-module-app';
+
+import { resolvePackage, type ResolvedPackage } from '../utils/resolve-package.js';
+import { createAppManifestFromPackage } from '../app/create-app-manifest-from-package.js';
+import { loadAppManifest } from '../app/load-app-manifest.js';
+import { loadAppConfig } from '../app/load-app-config.js';
+import type { ApiAppConfig } from '../app/api-app-config-schema.js';
+import type { RuntimeEnv } from '../types.js';
+
+/**
+ * The application manifest and config resolved for a test run.
+ */
+export type AppTestEnv = {
+  manifest: AppManifest;
+  config: ApiAppConfig;
+};
+
+/**
+ * Options for {@link resolveAppTestEnv}.
+ */
+export type ResolveAppTestEnvOptions = {
+  /** Directory to resolve the package, manifest, and config from. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Explicit manifest file to load instead of the default `app.manifest(.*)?` lookup. */
+  manifestPath?: string;
+  /** Explicit config file to load instead of the default `app.config(.*)?` lookup. */
+  configPath?: string;
+};
+
+/**
+ * Resolves an application's manifest and config using the same pipeline `ffc app build`/
+ * `ffc app dev` use: a base manifest generated from `package.json`, merged with a local
+ * `app.manifest.ts` if one exists; and `app.config.ts` for endpoints/environment, falling
+ * back to an empty config if none exists.
+ *
+ * @remarks
+ * Intended to seed `@equinor/fusion-framework-react-app/vitest`'s `testApp` `env` fixture, so
+ * a test suite exercises the application's real manifest/config instead of a hand-maintained
+ * duplicate. Anything a specific test still needs faked (a missing endpoint, a different
+ * `appKey`) can be layered on top with `testApp.extend('env', ...)` or a per-test
+ * `test.override('env', ...)`.
+ *
+ * @param options - Resolution options; `cwd` defaults to the current working directory.
+ * @returns The resolved application manifest and config.
+ * @throws If no `package.json` can be found from `cwd` upward, or an explicitly requested
+ * `manifestPath`/`configPath` does not exist.
+ * @example
+ * ```ts
+ * import { resolveAppTestEnv } from '@equinor/fusion-framework-cli/vitest';
+ * import { testApp } from '@equinor/fusion-framework-react-app/vitest';
+ * import { configure } from '../config';
+ *
+ * const test = testApp
+ *   .extend('env', { injected: true }, () => resolveAppTestEnv())
+ *   .extend('configure', { injected: true }, () => configure);
+ * ```
+ */
+export const resolveAppTestEnv = async (
+  options?: ResolveAppTestEnvOptions,
+): Promise<AppTestEnv> => {
+  const pkg: ResolvedPackage = await resolvePackage({ cwd: options?.cwd });
+  const env: RuntimeEnv = { command: 'build', mode: 'test', root: pkg.root, environment: 'test' };
+
+  const baseManifest = createAppManifestFromPackage(env, pkg.packageJson);
+  const [manifest, config] = await Promise.all([
+    resolveManifest(env, baseManifest, options?.manifestPath),
+    resolveConfig(env, options?.configPath),
+  ]);
+
+  return { manifest, config };
+};
+
+/**
+ * Loads `app.manifest(.*)?`, falling back to the package-derived manifest when none exists —
+ * mirrors `ffc app build`'s own fallback so a test env matches a real build with zero manifest file.
+ */
+const resolveManifest = async (
+  env: RuntimeEnv,
+  base: AppManifest,
+  file?: string,
+): Promise<AppManifest> => {
+  try {
+    return (await loadAppManifest(env, { base, file })).manifest;
+  } catch (err) {
+    // an explicitly requested manifest that's missing is a real error; only the default lookup falls back
+    if (err instanceof FileNotFoundError && !file) return base;
+    throw err;
+  }
+};
+
+/**
+ * Loads `app.config(.*)?`, falling back to an empty config when none exists — mirrors
+ * `ffc app build`'s own fallback so a test env matches a real build with zero config file.
+ */
+const resolveConfig = async (env: RuntimeEnv, file?: string): Promise<ApiAppConfig> => {
+  try {
+    return (await loadAppConfig(env, { file })).config;
+  } catch (err) {
+    // an explicitly requested config that's missing is a real error; only the default lookup falls back
+    if (err instanceof FileNotFoundError && !file) return { environment: {} };
+    throw err;
+  }
+};
+
+export default resolveAppTestEnv;

--- a/packages/cli/src/lib/vitest/tests/resolve-app-test-env.test.ts
+++ b/packages/cli/src/lib/vitest/tests/resolve-app-test-env.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveAppTestEnv } from '../resolve-app-test-env.js';
+
+describe('resolveAppTestEnv', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'fusion-cli-testing-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('falls back to a package-derived manifest and an empty config with no local files', async () => {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: '@equinor/my-app', version: '1.2.3', description: 'a test app' }),
+    );
+
+    const { manifest, config } = await resolveAppTestEnv({ cwd: dir });
+
+    expect(manifest).toMatchObject({
+      appKey: 'my-app',
+      displayName: '@equinor/my-app',
+      description: 'a test app',
+      type: 'standalone',
+    });
+    expect(config).toEqual({ environment: {} });
+  });
+
+  it('merges a local app.manifest.ts and app.config.ts, same as ffc app build', async () => {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: '@equinor/my-app', version: '1.2.3' }),
+    );
+    await writeFile(
+      join(dir, 'app.manifest.ts'),
+      "export default { displayName: 'My Custom App' };",
+    );
+    await writeFile(
+      join(dir, 'app.config.ts'),
+      "export default { environment: {}, endpoints: { api: { url: 'https://example.com' } } };",
+    );
+
+    const { manifest, config } = await resolveAppTestEnv({ cwd: dir });
+
+    expect(manifest).toMatchObject({ appKey: 'my-app', displayName: 'My Custom App' });
+    expect(config).toEqual({
+      environment: {},
+      endpoints: { api: { url: 'https://example.com', scopes: [] } },
+    });
+  });
+
+  it('propagates an error for an explicitly requested manifest file that does not exist', async () => {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: '@equinor/my-app', version: '1.2.3' }),
+    );
+
+    await expect(
+      resolveAppTestEnv({ cwd: dir, manifestPath: 'does-not-exist.manifest.ts' }),
+    ).rejects.toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,8 +1090,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
-        version: 4.1.4(vitest@4.1.4)
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       adm-zip:
         specifier: ^0.6.0
         version: 0.6.0
@@ -1123,8 +1123,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/cli-plugins/ai-base:
     dependencies:
@@ -2304,7 +2304,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
 
   packages/react/components/bookmark:
     dependencies:
@@ -3237,10 +3237,6 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -3268,11 +3264,6 @@ packages:
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -3328,10 +3319,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -7179,15 +7166,6 @@ packages:
     peerDependencies:
       '@vitest/browser': 4.1.10
       vitest: 4.1.10
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
-  '@vitest/coverage-v8@4.1.4':
-    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
-    peerDependencies:
-      '@vitest/browser': 4.1.4
-      vitest: 4.1.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -11449,7 +11427,6 @@ packages:
       '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12266,8 +12243,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-string-parser@8.0.0': {}
@@ -12284,10 +12259,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -12358,11 +12329,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -16154,20 +16120,6 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)
 
-  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.4
-      ast-v8-to-istanbul: 1.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.0.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
-
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -18956,8 +18908,8 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -21313,7 +21265,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(happy-dom@20.11.1)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.0)(tsx@4.23.1))
@@ -21338,11 +21290,22 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.2
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.11.1
       jsdom: 30.0.1
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-jsonrpc@8.2.1(patch_hash=d78796f2e6ae0a6c190cb4da47138eafba7404e190b66f5ac22b382e16f04eca): {}
 


### PR DESCRIPTION
**Why is this change needed?**
Testing an app cookbook currently requires each test file to manually resolve the app's manifest, config, and module-configurator before rendering anything — repetitive boilerplate duplicated across every cookbook.

**What is the current behavior?**
No CLI command runs an application's own test suite with its manifest/config/module-configurator pre-resolved.

**What is the new behavior?**
Adds `ffc app test` (`--manifest`, `--config`, `--configure`, `--watch`, `--debug`), which runs the app's installed Vitest with those resolved the same way `ffc app build`/`ffc app dev` do, and exposes them to `@equinor/fusion-framework-react-app/vitest`'s `test`/`render` fixtures via a Vite plugin registering virtual modules — zero per-test-file wiring required.

Also renames `packages/cli/src/lib/testing` → `lib/vitest` and the `./testing` package export → `./vitest`, for naming consistency with `@equinor/fusion-framework-react-app/vitest`.

**Does this PR introduce a breaking change?**
No — new command and new export subpath only.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-cli`)
- Downstream impact: Enables `packages/react/app`'s upcoming `vitest` test fixtures and cookbook test suites (follow-up PRs), which depend on this command's virtual-module plugin to resolve app context at test time.

**Review guidance**
Base branch is `feat/fusion-testing` (this branch is split out of a larger combined testing-infrastructure branch); it is not yet targeting `main`.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated (`tsc -b`, `vitest run` — both pass)
  - No new linting warnings
- [x] Confirm adherence to code of conduct
