### PR TITLE
fix(bookmark): remove empty menu rows

### DIFF
--- a/.changeset/react-bookmark_filter-empty-menu.md
+++ b/.changeset/react-bookmark_filter-empty-menu.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-react-components-bookmark": patch
+---
+
+Prevent conditional bookmark actions from rendering an empty options-menu row.
+
+Fixes: https://github.com/equinor/fusion/issues/903

--- a/packages/react/components/bookmark/src/__tests__/MoreMenu.test.tsx
+++ b/packages/react/components/bookmark/src/__tests__/MoreMenu.test.tsx
@@ -1,0 +1,32 @@
+import { Children, isValidElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { MoreMenu } from '../components/row/MoreMenu';
+
+describe('MoreMenu', () => {
+  it('renders only actionable menu options when conditional entries are false', () => {
+    const menu = MoreMenu({
+      pRef: { current: null },
+      onClose: vi.fn(),
+      open: true,
+      options: [
+        {
+          name: 'Edit',
+          disabled: false,
+          onClick: vi.fn(),
+        },
+        false,
+      ],
+    });
+    const items = Children.toArray(menu.props.children);
+
+    expect(items).toHaveLength(1);
+    expect(isValidElement(items[0])).toBe(true);
+
+    // Guard the element shape before inspecting the rendered action label.
+    if (!isValidElement<{ children: ReactNode }>(items[0])) {
+      throw new Error('Expected a valid menu item');
+    }
+
+    expect(Children.toArray(items[0].props.children)).toContain('Edit');
+  });
+});

--- a/packages/react/components/bookmark/src/components/row/MoreMenu.tsx
+++ b/packages/react/components/bookmark/src/components/row/MoreMenu.tsx
@@ -6,7 +6,7 @@ type MenuProps = {
   readonly pRef: MutableRefObject<HTMLElement | null>;
   readonly onClose: VoidFunction;
   readonly open: boolean;
-  readonly options: MenuOption[];
+  readonly options: Array<MenuOption | false | null | undefined>;
 };
 
 /**
@@ -16,22 +16,25 @@ type MenuProps = {
  * @returns The menu
  */
 export const MoreMenu = ({ pRef, onClose, open, options }: MenuProps) => {
-  // Render one menu item per configured row action
-  const items = options.map(({ onClick, name, disabled, Icon }) => (
-    <Menu.Item
-      disabled={disabled}
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        onClick();
-        onClose();
-      }}
-      key={name}
-    >
-      {Icon && Icon}
-      {name}
-    </Menu.Item>
-  ));
+  const items = options
+    // Conditional action arrays can contain placeholders that must not become empty EDS menu rows.
+    .filter((option): option is MenuOption => Boolean(option))
+    // Render one menu item per configured row action.
+    .map(({ onClick, name, disabled, Icon }) => (
+      <Menu.Item
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onClick();
+          onClose();
+        }}
+        key={name}
+      >
+        {Icon && Icon}
+        {name}
+      </Menu.Item>
+    ));
 
   return (
     <Menu open={open} anchorEl={pRef.current}>


### PR DESCRIPTION
**Why is this change needed?**

Bookmark option arrays can contain conditional placeholders such as `bookmark.isShared && option`. When the condition is false, the placeholder currently reaches the EDS menu and appears as an empty action row.

**What is the current behavior?**

`MoreMenu` maps every options-array entry to `Menu.Item`. A false/nullish conditional entry therefore creates a menu item with no icon, label, or valid action.

**What is the new behavior?**

`MoreMenu` removes false/nullish placeholders before mapping valid bookmark actions to EDS menu items. A regression test verifies that a false conditional entry does not render while the valid action remains available.

**What is the intended behavior or invariant?**

Every rendered bookmark menu row must represent a valid configured action. Conditional placeholders must never become visible menu items, and valid action labels and handlers must remain unchanged.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No.
- Version bump: Patch via `.changeset/react-bookmark_filter-empty-menu.md`.
- Consumer impact: Bookmark option menus no longer show an empty row when an optional action is unavailable.
- Downstream impact: Limited to `@equinor/fusion-framework-react-components-bookmark`; valid menu options and click behavior are unchanged.
- Risk: Low. The change only filters `false`, `null`, and `undefined` entries before rendering.

**Review guidance:**

Focus on the conditional-entry type guard in `MoreMenu` and the regression assertion that only the valid action is rendered. Verify that the filter occurs before EDS `Menu.Item` creation and does not alter valid option ordering or handlers.

**Additional context**

Validation completed:

- `pnpm exec vitest run --project '*react-components-bookmark*'` - 2 test files and 3 tests passed.
- `pnpm --filter @equinor/fusion-framework-react-components-bookmark exec tsc -b --force` - passed.
- `pnpm exec biome check packages/react/components/bookmark/src/components/row/MoreMenu.tsx packages/react/components/bookmark/src/__tests__/MoreMenu.test.tsx .changeset/react-bookmark_filter-empty-menu.md` - passed with no fixes.
- `pnpm build:lint && pnpm exec fusion-lint changed --against origin/main` - all 6 lint packages built and Fusion lint reported no problems.

The regression test failed before the fix with two rendered items instead of one, confirming the blank-row path.

**Related issues**

Fixes equinor/fusion#903

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes (not applicable; no public API or documentation change)
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
