### PR TITLE
fix(module-context): restore path-based initial context resolution

### DIFF
--- a/.changeset/module-context_restore-path-based-initial-context.md
+++ b/.changeset/module-context_restore-path-based-initial-context.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-module-context": patch
+---
+
+Restore path-based resolution as a fallback in `resolveInitialContext`, composed with parent-context resolution. The context-navigation plugin introduced in #4751 removed this from the module, but consumers not yet migrated to the plugin lost initial-context resolution from the URL. `resolveInitialContext` now accepts a `path` option (`extract`/`validate`) used to resolve context from the URL before falling back to the parent context.

--- a/.changeset/plugin-context-navigation_path-adapter-app-route-guard.md
+++ b/.changeset/plugin-context-navigation_path-adapter-app-route-guard.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-plugin-context-navigation": patch
+---
+
+Fix `createPathAdapter` matching on non-app routes. `canHandle` now rejects a URL when `currentURL.pathname` does not parse as a valid app route (e.g. portal chrome), preventing the path adapter from incorrectly claiming ownership of URLs where there is no app route to encode context into.

--- a/packages/modules/context/src/configurator.ts
+++ b/packages/modules/context/src/configurator.ts
@@ -249,7 +249,12 @@ export class ContextModuleConfigurator implements IContextModuleConfigurator {
       Promise.resolve({} as Partial<ContextModuleConfig>),
     );
 
-    config.resolveInitialContext ??= resolveInitialContext();
+    config.resolveInitialContext ??= resolveInitialContext({
+      path: {
+        extract: config.extractContextIdFromPath,
+        validate: config.extractContextIdFromPath ? () => true : undefined,
+      },
+    });
 
     // TODO(#5119) - make less lazy
     config.client ??= await (async (): Promise<ContextModuleConfig['client']> => {

--- a/packages/modules/context/src/utils/resolve-initial-context.ts
+++ b/packages/modules/context/src/utils/resolve-initial-context.ts
@@ -34,7 +34,7 @@ export const resolveContextFromParent: ContextModuleConfig['resolveInitialContex
 // Deliberately co-located with resolveContextFromParent, which it composes with
 // fusion-lint-disable-next-line single-export-per-file
 export const resolveInitialContext =
-  (options: {
+  (options?: {
     path?: ContextPathResolveArgs;
   }): Required<ContextModuleConfig>['resolveInitialContext'] =>
   ({ ref, modules }) => {

--- a/packages/modules/context/src/utils/resolve-initial-context.ts
+++ b/packages/modules/context/src/utils/resolve-initial-context.ts
@@ -1,7 +1,9 @@
 import type { ModulesInstance } from '@equinor/fusion-framework-module';
 import type { ContextModule } from '../module';
 import type { ContextModuleConfig } from '../configurator';
-import { concat, EMPTY, of, take } from 'rxjs';
+import { concat, EMPTY, first, of } from 'rxjs';
+import resolveContextFromPath, { type ContextPathResolveArgs } from './resolve-context-from-path';
+import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
 
 /**
  * Resolves the initial context from the parent module.
@@ -11,6 +13,7 @@ import { concat, EMPTY, of, take } from 'rxjs';
  */
 export const resolveContextFromParent: ContextModuleConfig['resolveInitialContext'] = ({ ref }) => {
   const parentContext = (ref as ModulesInstance<[ContextModule]>)?.context;
+  // check if the parent has context module
   if (!parentContext) {
     // No parent context available — either portal level or parent lacks context module.
     return EMPTY;
@@ -22,19 +25,31 @@ export const resolveContextFromParent: ContextModuleConfig['resolveInitialContex
 /**
  * Resolves the initial context for a Fusion Framework context module.
  *
- * Attempts to resolve the initial context from the parent context provider.
- * URL-based resolution is handled by the context-navigation plugin.
+ * will try to resolve the initial context from the path, and if that fails, it will try to resolve the context from the parent.
  *
+ * @param options - Optional configuration for resolving the context path.
  * @returns A function that accepts the module's reference and modules, and returns an Observable of the resolved initial context.
  */
+
 // Deliberately co-located with resolveContextFromParent, which it composes with
 // fusion-lint-disable-next-line single-export-per-file
 export const resolveInitialContext =
-  (): Required<ContextModuleConfig>['resolveInitialContext'] =>
+  (options: {
+    path?: ContextPathResolveArgs;
+  }): Required<ContextModuleConfig>['resolveInitialContext'] =>
   ({ ref, modules }) => {
-    // Resolve from parent context if available.
-    // URL-based resolution is handled by the context-navigation plugin.
-    return concat(resolveContextFromParent({ ref, modules })).pipe(take(1));
+    const { context, navigation } = modules;
+    // create a path resolver from the context module
+    const pathResolver = resolveContextFromPath(context, options?.path);
+    // use the path from the navigation module, or the path from the parent navigation module
+    const pathname =
+      navigation?.path.pathname ??
+      (ref as Partial<ModulesInstance<[NavigationModule]>>).navigation?.path.pathname;
+    // try to resolve the context from the path, and if that fails, try to resolve the context from the parent
+    return concat(
+      pathname ? pathResolver(pathname) : EMPTY,
+      resolveContextFromParent({ ref, modules }),
+    ).pipe(first());
   };
 
 export default resolveInitialContext;

--- a/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
+++ b/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
@@ -41,9 +41,14 @@ export function createPathAdapter(): ContextNavigationAdapter {
      * Accepts apps with explicit `'path'` strategy or no declared strategy
      * (the path adapter serves as the system-wide default fallback).
      */
-    canHandle({ appContext, routingStrategy }: AdapterResolutionContext): boolean {
+    canHandle({ appContext, routingStrategy, currentURL }: AdapterResolutionContext): boolean {
       // Custom generators mean the app owns its URL shape — the custom adapter handles it, not us
       if (hasCustomContextGenerators(appContext)) {
+        return false;
+      }
+
+      // Not an app route (e.g. portal chrome) — nothing for this adapter to encode context into
+      if (!parseAppRoute(currentURL.pathname)) {
         return false;
       }
 


### PR DESCRIPTION
**Why is this change needed?**
The context-navigation plugin (#4751) simplified `resolveInitialContext` in `@equinor/fusion-framework-module-context` to only resolve from the parent context, moving URL-based resolution into the plugin. Consumers that haven't adopted the plugin yet lost the ability to resolve their initial context from the URL path.

**What is the current behavior?**
`resolveInitialContext()` only resolves the initial context from the parent context module; it no longer looks at the URL path at all.

**What is the new behavior?**
`resolveInitialContext(options)` first attempts to resolve the context from the URL path (via `resolveContextFromPath`, using the configurator's `extractContextIdFromPath`), and falls back to the parent context if that yields nothing — restoring the pre-plugin behavior. `ContextModuleConfigurator.createConfig` now passes `path.extract`/`path.validate` derived from `extractContextIdFromPath`.

Also included: a fix in `@equinor/fusion-framework-plugin-context-navigation`'s `createPathAdapter` — `canHandle` now rejects URLs that don't parse as a valid app route (e.g. portal chrome), so the path adapter doesn't incorrectly claim ownership of non-app URLs.

**What is the intended behavior or invariant?**
`resolveInitialContext` must try path-based resolution first, then parent-context resolution, emitting only the first non-empty result (`first()` over the concatenated observables). The path adapter must only claim URLs that parse as valid app routes.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch for both `@equinor/fusion-framework-module-context` and `@equinor/fusion-framework-plugin-context-navigation` (changesets included)
- Consumer impact: Consumers relying on the module's own URL-based initial context resolution (without the context-navigation plugin) regain that behavior.
- Downstream impact: None expected; the context-navigation plugin's own routing is unaffected.

**Review guidance:**
Focus on the `concat(...).pipe(first())` composition in `resolve-initial-context.ts` and the app-route guard added to `create-path-adapter.ts`'s `canHandle`.

**Related issues**
N/A

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable (n/a, no React code)
- [ ] Confirm README/docs are updated for user-facing changes (n/a, no public docs reference this internal fallback)
- [x] Confirm changes to target branch validation
  - Included files validated (build + lint pass)
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
