### PR TITLE
feat(ag-grid): add license-banner test helper and app sub-path wiring

### DIFF
--- a/.changeset/module-ag-grid_suppress-license-banner-testing.md
+++ b/.changeset/module-ag-grid_suppress-license-banner-testing.md
@@ -1,0 +1,16 @@
+---
+"@equinor/fusion-framework-module-ag-grid": minor
+---
+
+Add `suppressAgGridLicenseBanner`, a test helper exported from a new `/testing` subpath (`@equinor/fusion-framework-module-ag-grid/testing`).
+
+Without a license key, AG Grid Enterprise logs a "License Key Not Found" banner through `console.error` on every grid mount — expected in tests, but it buries real assertion failures in the reporter output. Applications previously had to hand-roll a `console.error` filter in their own test setup file to work around this; that logic now lives here instead.
+
+```typescript
+// src/test/setupTests.ts
+import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-module-ag-grid/testing';
+
+suppressAgGridLicenseBanner();
+```
+
+The helper only filters the license banner and passes every other `console.error` call through unchanged. It returns a function to restore the original `console.error`. To remove the banner from a running application (not just tests), configure a real license key via `enableAgGrid`/`setLicenseKey` instead.

--- a/.changeset/react-ag-grid_suppress-license-banner-testing.md
+++ b/.changeset/react-ag-grid_suppress-license-banner-testing.md
@@ -1,0 +1,14 @@
+---
+"@equinor/fusion-framework-react-ag-grid": minor
+---
+
+Re-export `suppressAgGridLicenseBanner` from a new `/testing` subpath (`@equinor/fusion-framework-react-ag-grid/testing`), forwarding to `@equinor/fusion-framework-module-ag-grid/testing`.
+
+```typescript
+// src/test/setupTests.ts
+import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-react-ag-grid/testing';
+
+suppressAgGridLicenseBanner();
+```
+
+Apps already depending on `@equinor/fusion-framework-react-ag-grid` no longer need a direct dependency on `@equinor/fusion-framework-module-ag-grid` just to reach this test helper.

--- a/.changeset/react-app_ag-grid-subpaths.md
+++ b/.changeset/react-app_ag-grid-subpaths.md
@@ -1,0 +1,19 @@
+---
+"@equinor/fusion-framework-react-app": minor
+---
+
+Add AG Grid sub-path entry-points:
+
+- `@equinor/fusion-framework-react-app/ag-grid` — `AgGridReact`, `enableAgGrid`, and related types, forwarded from `@equinor/fusion-framework-react-ag-grid/react`.
+- `@equinor/fusion-framework-react-app/ag-grid/community` — forwards `@equinor/fusion-framework-react-ag-grid/community` (`ag-grid-community`).
+- `@equinor/fusion-framework-react-app/ag-grid/enterprise` — forwards `@equinor/fusion-framework-react-ag-grid/enterprise` (`ag-grid-enterprise`).
+- `@equinor/fusion-framework-react-app/ag-grid/theme` — Fusion theme utilities (`fusionTheme`, `createTheme`, `createThemeFromTheme`, `Theme`) plus the application-scoped `useTheme` hook.
+- `@equinor/fusion-framework-react-app/ag-grid/testing` — `suppressAgGridLicenseBanner`, forwarded from `@equinor/fusion-framework-module-ag-grid/testing`.
+
+```typescript
+import { AgGridReact } from '@equinor/fusion-framework-react-app/ag-grid';
+import { useTheme } from '@equinor/fusion-framework-react-app/ag-grid/theme';
+import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-react-app/ag-grid/testing';
+```
+
+`@equinor/fusion-framework-module-ag-grid` and `@equinor/fusion-framework-react-ag-grid` are now optional peer dependencies of `@equinor/fusion-framework-react-app`.

--- a/packages/modules/ag-grid/README.md
+++ b/packages/modules/ag-grid/README.md
@@ -158,6 +158,21 @@ Registers the AG Grid module. The optional callback receives an `IAgGridConfigur
 
 Themes configured in a parent scope (portal) are automatically inherited by child scopes (applications). The module clones inherited themes via `createThemeFromTheme` to avoid `instanceof` mismatches across module-federation boundaries.
 
+## Testing
+
+Without a license key, AG Grid Enterprise logs a "License Key Not Found" banner through `console.error` on every grid mount, which is expected in tests but buries real assertion failures in the reporter output.
+Call `suppressAgGridLicenseBanner` once from your test setup file to filter just that banner:
+
+```ts
+// src/test/setupTests.ts
+import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-module-ag-grid/testing';
+
+suppressAgGridLicenseBanner();
+```
+
+> [!TIP]
+> This only hides the banner in tests. To remove it from a running application, configure a real license key via `enableAgGrid`/`setLicenseKey` instead.
+
 ## Migration from AG Grid 32 to 33
 
 AG Grid 33 consolidated all feature modules into single `ag-grid-community` and `ag-grid-enterprise` packages. Key changes:

--- a/packages/modules/ag-grid/package.json
+++ b/packages/modules/ag-grid/package.json
@@ -13,6 +13,10 @@
       "import": "./dist/esm/themes.js",
       "types": "./dist/types/themes.d.ts"
     },
+    "./testing": {
+      "import": "./dist/esm/suppress-ag-grid-license-banner.js",
+      "types": "./dist/types/suppress-ag-grid-license-banner.d.ts"
+    },
     "./package.json": "./package.json",
     "./README.md": "./README.md"
   },
@@ -23,6 +27,9 @@
       ],
       "themes": [
         "dist/types/themes.d.ts"
+      ],
+      "testing": [
+        "dist/types/suppress-ag-grid-license-banner.d.ts"
       ]
     }
   },

--- a/packages/modules/ag-grid/src/__tests__/suppress-ag-grid-license-banner.test.ts
+++ b/packages/modules/ag-grid/src/__tests__/suppress-ag-grid-license-banner.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { suppressAgGridLicenseBanner } from '../suppress-ag-grid-license-banner';
+
+describe('suppressAgGridLicenseBanner', () => {
+  const originalConsoleError = console.error;
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('drops AG Grid license banner lines logged through console.error', () => {
+    const spy = vi.fn();
+    console.error = spy;
+
+    const restore = suppressAgGridLicenseBanner();
+    console.error('*'.repeat(20));
+    console.error('AG Grid: License Key Not Found');
+    console.error('See https://www.ag-grid.com/react-data-grid/licensing/ for details.');
+    restore();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('passes unrelated console.error calls through unchanged', () => {
+    const spy = vi.fn();
+    console.error = spy;
+
+    const restore = suppressAgGridLicenseBanner();
+    console.error('boom', { cause: 'network' });
+    restore();
+
+    expect(spy).toHaveBeenCalledWith('boom', { cause: 'network' });
+  });
+
+  it('restores the original console.error after calling the returned function', () => {
+    const spy = vi.fn();
+    console.error = spy;
+
+    const restore = suppressAgGridLicenseBanner();
+    restore();
+    console.error('AG Grid: License Key Not Found');
+
+    expect(spy).toHaveBeenCalledWith('AG Grid: License Key Not Found');
+  });
+});

--- a/packages/modules/ag-grid/src/suppress-ag-grid-license-banner.ts
+++ b/packages/modules/ag-grid/src/suppress-ag-grid-license-banner.ts
@@ -1,0 +1,54 @@
+/**
+ * Test helpers for the AG Grid Fusion module.
+ *
+ * @remarks
+ * Import from `@equinor/fusion-framework-module-ag-grid/testing` in test setup
+ * files only — these helpers patch global state and are not meant for
+ * application runtime code.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Matches the lines AG Grid Enterprise writes through `console.error` when no
+ * license key is configured: the "License Key Not Found" message itself, its
+ * surrounding asterisk banner, and the `ag-grid.com` links it includes.
+ */
+const AG_GRID_LICENSE_BANNER = /AG Grid|ag-grid\.com|License Key Not Found|^\*+$|^\*.*\*$/;
+
+/**
+ * Silences AG Grid Enterprise's unlicensed "License Key Not Found" banner on
+ * `console.error` so it doesn't bury real failures in test output.
+ *
+ * @remarks
+ * AG Grid Enterprise logs this banner on every grid mount when no license key
+ * is configured, which is expected in test environments that don't set one.
+ * Call this once from a test setup file (e.g. Vitest's `setupFiles`); it
+ * leaves other `console.error` calls untouched. Prefer configuring a real
+ * license key via {@link enableAgGrid} to remove the banner outside of tests.
+ *
+ * @returns A function that restores the original `console.error`.
+ *
+ * @example
+ * ```ts
+ * // src/test/setupTests.ts
+ * import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-module-ag-grid/testing';
+ *
+ * suppressAgGridLicenseBanner();
+ * ```
+ */
+export const suppressAgGridLicenseBanner = (): (() => void) => {
+  const originalConsoleError = console.error;
+
+  console.error = (message?: unknown, ...rest: unknown[]): void => {
+    // AG Grid logs the banner as a plain string; anything else is a real error and must pass through
+    if (typeof message === 'string' && AG_GRID_LICENSE_BANNER.test(message)) {
+      return;
+    }
+    originalConsoleError(message, ...rest);
+  };
+
+  return () => {
+    console.error = originalConsoleError;
+  };
+};

--- a/packages/modules/ag-grid/vitest.config.ts
+++ b/packages/modules/ag-grid/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject } from 'vitest/config';
+
+import { name, version } from './package.json' with { type: 'json' };
+
+export default defineProject({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    name: `${name}@${version}`,
+  },
+});

--- a/packages/react/ag-grid/README.md
+++ b/packages/react/ag-grid/README.md
@@ -162,6 +162,17 @@ enableAgGrid(configurator, (builder) => {
 > [@equinor/fusion-framework-react-ag-charts](../ag-charts/README.md)
 > for standalone chart usage.
 
+## Testing
+
+Without a license key, AG Grid Enterprise logs a "License Key Not Found" banner through `console.error` on every grid mount. Call `suppressAgGridLicenseBanner` once from your test setup file to filter just that banner:
+
+```ts
+// src/test/setupTests.ts
+import { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-react-ag-grid/testing';
+
+suppressAgGridLicenseBanner();
+```
+
 ## Upgrade Guides
 
 ### Upgrading to v35

--- a/packages/react/ag-grid/package.json
+++ b/packages/react/ag-grid/package.json
@@ -25,6 +25,10 @@
       "import": "./dist/esm/themes.js",
       "types": "./dist/types/themes.d.ts"
     },
+    "./testing": {
+      "import": "./dist/esm/testing.js",
+      "types": "./dist/types/testing.d.ts"
+    },
     "./package.json": "./package.json",
     "./README.md": "./README.md"
   },
@@ -44,6 +48,9 @@
       ],
       "themes": [
         "dist/types/themes.d.ts"
+      ],
+      "testing": [
+        "dist/types/testing.d.ts"
       ]
     }
   },

--- a/packages/react/ag-grid/src/testing.ts
+++ b/packages/react/ag-grid/src/testing.ts
@@ -1,0 +1,18 @@
+/**
+ * Test helpers for AG Grid in Fusion Framework.
+ *
+ * This entry point re-exports the AG Grid test helpers from
+ * `@equinor/fusion-framework-module-ag-grid/testing`. Import from test setup
+ * files only — these helpers patch global state and are not meant for
+ * application runtime code.
+ *
+ * @module testing
+ */
+
+/**
+ * Silences AG Grid Enterprise's unlicensed "License Key Not Found" banner on
+ * `console.error` so it doesn't bury real failures in test output.
+ *
+ * @returns A function that restores the original `console.error`.
+ */
+export { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-module-ag-grid/testing';

--- a/packages/react/app/package.json
+++ b/packages/react/app/package.json
@@ -69,6 +69,26 @@
     "./routing": {
       "types": "./dist/types/routing/index.d.ts",
       "import": "./dist/esm/routing/index.js"
+    },
+    "./ag-grid": {
+      "types": "./dist/types/ag-grid/react.d.ts",
+      "import": "./dist/esm/ag-grid/react.js"
+    },
+    "./ag-grid/community": {
+      "types": "./dist/types/ag-grid/community.d.ts",
+      "import": "./dist/esm/ag-grid/community.js"
+    },
+    "./ag-grid/enterprise": {
+      "types": "./dist/types/ag-grid/enterprise.d.ts",
+      "import": "./dist/esm/ag-grid/enterprise.js"
+    },
+    "./ag-grid/theme": {
+      "types": "./dist/types/ag-grid/theme.d.ts",
+      "import": "./dist/esm/ag-grid/theme.js"
+    },
+    "./ag-grid/testing": {
+      "types": "./dist/types/ag-grid/testing.d.ts",
+      "import": "./dist/esm/ag-grid/testing.js"
     }
   },
   "typesVersions": {
@@ -117,6 +137,21 @@
       ],
       "routing": [
         "dist/types/routing/index.d.ts"
+      ],
+      "ag-grid": [
+        "dist/types/ag-grid/react.d.ts"
+      ],
+      "ag-grid/community": [
+        "dist/types/ag-grid/community.d.ts"
+      ],
+      "ag-grid/enterprise": [
+        "dist/types/ag-grid/enterprise.d.ts"
+      ],
+      "ag-grid/theme": [
+        "dist/types/ag-grid/theme.d.ts"
+      ],
+      "ag-grid/testing": [
+        "dist/types/ag-grid/testing.d.ts"
       ]
     }
   },
@@ -149,6 +184,7 @@
   },
   "devDependencies": {
     "@equinor/fusion-framework-module-ag-grid": "workspace:*",
+    "@equinor/fusion-framework-react-ag-grid": "workspace:*",
     "@equinor/fusion-framework-module-analytics": "workspace:*",
     "@equinor/fusion-framework-module-bookmark": "workspace:*",
     "@equinor/fusion-framework-module-context": "workspace:*",
@@ -175,6 +211,8 @@
     "vitest-browser-react": "^2.2.0"
   },
   "peerDependencies": {
+    "@equinor/fusion-framework-module-ag-grid": "workspace:^",
+    "@equinor/fusion-framework-react-ag-grid": "workspace:^",
     "@equinor/fusion-framework-module-msal": "workspace:^",
     "@equinor/fusion-framework-module-state": "workspace:^",
     "@equinor/fusion-framework-react-router": "workspace:^",
@@ -184,6 +222,12 @@
     "rxjs": "^7.0.0"
   },
   "peerDependenciesMeta": {
+    "@equinor/fusion-framework-module-ag-grid": {
+      "optional": true
+    },
+    "@equinor/fusion-framework-react-ag-grid": {
+      "optional": true
+    },
     "@equinor/fusion-framework-react-module-ag-grid": {
       "optional": true
     },

--- a/packages/react/app/src/ag-grid/community.ts
+++ b/packages/react/app/src/ag-grid/community.ts
@@ -1,0 +1,11 @@
+/**
+ * AG Grid community-tier sub-path entry-point.
+ *
+ * @remarks
+ * Re-exports every public symbol from
+ * `@equinor/fusion-framework-react-ag-grid/community` so the application
+ * resolves a single shared copy of `ag-grid-community`.
+ *
+ * @packageDocumentation
+ */
+export * from '@equinor/fusion-framework-react-ag-grid/community';

--- a/packages/react/app/src/ag-grid/enterprise.ts
+++ b/packages/react/app/src/ag-grid/enterprise.ts
@@ -1,0 +1,11 @@
+/**
+ * AG Grid enterprise-tier sub-path entry-point.
+ *
+ * @remarks
+ * Re-exports every public symbol from
+ * `@equinor/fusion-framework-react-ag-grid/enterprise` so the application
+ * resolves a single shared copy of `ag-grid-enterprise`.
+ *
+ * @packageDocumentation
+ */
+export * from '@equinor/fusion-framework-react-ag-grid/enterprise';

--- a/packages/react/app/src/ag-grid/react.ts
+++ b/packages/react/app/src/ag-grid/react.ts
@@ -1,0 +1,11 @@
+/**
+ * AG Grid React component sub-path entry-point.
+ *
+ * @remarks
+ * Re-exports the AG Grid React bindings from
+ * `@equinor/fusion-framework-react-ag-grid/react`, including the
+ * `AgGridReact` component, `enableAgGrid`, and their associated types.
+ *
+ * @packageDocumentation
+ */
+export * from '@equinor/fusion-framework-react-ag-grid/react';

--- a/packages/react/app/src/ag-grid/testing.ts
+++ b/packages/react/app/src/ag-grid/testing.ts
@@ -1,0 +1,19 @@
+/**
+ * AG Grid test helpers sub-path entry-point.
+ *
+ * @remarks
+ * Re-exports the AG Grid test helpers from
+ * `@equinor/fusion-framework-module-ag-grid/testing`. Import from test setup
+ * files only — these helpers patch global state and are not meant for
+ * application runtime code.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Silences AG Grid Enterprise's unlicensed "License Key Not Found" banner on
+ * `console.error` so it doesn't bury real failures in test output.
+ *
+ * @returns A function that restores the original `console.error`.
+ */
+export { suppressAgGridLicenseBanner } from '@equinor/fusion-framework-module-ag-grid/testing';

--- a/packages/react/app/src/ag-grid/theme.ts
+++ b/packages/react/app/src/ag-grid/theme.ts
@@ -1,0 +1,17 @@
+/**
+ * AG Grid theme sub-path entry-point.
+ *
+ * @remarks
+ * Re-exports the Fusion AG Grid theme utilities from
+ * `@equinor/fusion-framework-module-ag-grid/themes`, together with the
+ * application-scoped {@link useTheme} hook.
+ *
+ * @packageDocumentation
+ */
+export {
+  fusionTheme,
+  createThemeFromTheme,
+  createTheme,
+} from '@equinor/fusion-framework-module-ag-grid/themes';
+export type { Theme } from '@equinor/fusion-framework-module-ag-grid/themes';
+export { useTheme } from './useTheme';

--- a/packages/react/app/tsconfig.json
+++ b/packages/react/app/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../router"
     },
     {
+      "path": "../ag-grid"
+    },
+    {
       "path": "../../modules/analytics"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2581,6 +2581,9 @@ importers:
       '@equinor/fusion-framework-module-telemetry':
         specifier: workspace:*
         version: link:../../modules/telemetry
+      '@equinor/fusion-framework-react-ag-grid':
+        specifier: workspace:*
+        version: link:../ag-grid
       '@equinor/fusion-framework-react-module-bookmark':
         specifier: workspace:*
         version: link:../modules/bookmark


### PR DESCRIPTION
**Why is this change needed?**
Consuming apps were hand-rolling `console.error` filters in their test setup files to suppress AG Grid Enterprise's unlicensed "License Key Not Found" banner, which drowns out real test failures in CI output. This centralizes that logic in the framework instead of duplicating it downstream. Separately, `@equinor/fusion-framework-react-app` had no dedicated AG Grid integration points at all (only an orphaned, unexported `useTheme` hook), so apps had to reach into the module/react-ag-grid packages directly and inconsistently.

**What is the current behavior?**
- No shared helper exists for silencing AG Grid's license banner in tests; each consuming app implements its own regex/console.error monkey-patch.
- `@equinor/fusion-framework-react-app` exposes no `ag-grid`-related sub-path at all.

**What is the new behavior?**
- `@equinor/fusion-framework-module-ag-grid/testing` exports `suppressAgGridLicenseBanner()`, which filters `console.error` calls matching the AG Grid license banner and returns a restore function.
- `@equinor/fusion-framework-react-ag-grid/testing` re-exports the same helper for apps that only depend on the React bindings package.
- `@equinor/fusion-framework-react-app` gains five new sub-paths: `/ag-grid` (`AgGridReact`, `enableAgGrid`), `/ag-grid/community`, `/ag-grid/enterprise`, `/ag-grid/theme` (theme utilities + the app-scoped `useTheme` hook), and `/ag-grid/testing`.

**What is the intended behavior or invariant?**
`suppressAgGridLicenseBanner()` only filters `console.error` calls whose message matches the AG Grid license banner pattern; all other `console.error` calls pass through unchanged, and calling the returned restore function always puts back the original `console.error`. It is a test-only helper — it does not replace configuring a real AG Grid license key for production/dev use.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor for `@equinor/fusion-framework-module-ag-grid`, `@equinor/fusion-framework-react-ag-grid`, and `@equinor/fusion-framework-react-app` (see changesets)
- Consumer impact: Purely additive sub-path exports; no existing exports changed
- Downstream impact: `@equinor/fusion-framework-module-ag-grid` and `@equinor/fusion-framework-react-ag-grid` are now optional peer dependencies of `@equinor/fusion-framework-react-app`

**Review guidance:**
- `packages/modules/ag-grid/src/suppress-ag-grid-license-banner.ts` is the single source of truth for the console.error filter; the react-ag-grid and react-app packages only re-export it.
- The new `packages/react/app/src/ag-grid/*` files are re-export-only sub-path entry points; `theme.ts` also wires up the previously orphaned `useTheme.ts`, which had no export path before this PR.
- New `vitest.config.ts` added for `packages/modules/ag-grid` (it had no test infrastructure before).

**Additional context**
Verified with `tsc -b --force`, `biome check`, `fusion-lint`, and `vitest run` across all three touched packages.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
- [x] Confirm adherence to code of conduct
