### PR TITLE
fix(observable): add explicit extensions to relative ESM imports

### DIFF
--- a/.changeset/observable_fix-esm-import-extensions.md
+++ b/.changeset/observable_fix-esm-import-extensions.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": patch
+---
+
+Fix relative import/export specifiers in the published ESM output missing file extensions (e.g. `./operators` instead of `./operators/index.js`). This broke strict Node.js ESM resolution for consumers not using a bundler (e.g. `vitest` running against `node_modules` directly), producing errors like `Cannot find module '.../operators'`.

--- a/packages/utils/observable/src/FlowSubject.ts
+++ b/packages/utils/observable/src/FlowSubject.ts
@@ -17,11 +17,11 @@ import {
   observeOn,
   scan,
 } from 'rxjs/operators';
-import { filterAction } from './operators';
+import { filterAction } from './operators/index.js';
 
-import type { Action, ActionType, ExtractAction } from './actions/types';
-import type { Flow, Effect } from './types/flow';
-import type { ReducerWithInitialState } from './types/reducers';
+import type { Action, ActionType, ExtractAction } from './actions/types.js';
+import type { Flow, Effect } from './types/flow.js';
+import type { ReducerWithInitialState } from './types/reducers.js';
 
 /**
  * A specialized Observable that maintains internal state mutated by dispatching actions.

--- a/packages/utils/observable/src/actions/ActionError.ts
+++ b/packages/utils/observable/src/actions/ActionError.ts
@@ -1,4 +1,4 @@
-import type { Action } from './types';
+import type { Action } from './types.js';
 
 /**
  * An error class that wraps a causal error together with the action that triggered it.

--- a/packages/utils/observable/src/actions/action-mapper.ts
+++ b/packages/utils/observable/src/actions/action-mapper.ts
@@ -1,4 +1,4 @@
-import type { ActionCreator, ActionDefinitions, ActionTypes } from './types';
+import type { ActionCreator, ActionDefinitions, ActionTypes } from './types.js';
 
 /**
  * A mapped type that converts {@link ActionDefinitions} into an object of

--- a/packages/utils/observable/src/actions/create-action.ts
+++ b/packages/utils/observable/src/actions/create-action.ts
@@ -4,13 +4,13 @@
  * taken from https://github.com/reduxjs/redux-toolkit/tree/master/packages/toolkit/src
  */
 
-import type { Action, PayloadAction } from './types';
+import type { Action, PayloadAction } from './types.js';
 import type {
   IfMaybeUndefined,
   IfVoid,
   IsAny,
   IsUnknownOrNonInferrable,
-} from '../types/ts-helpers';
+} from '../types/ts-helpers.js';
 
 /**
  * A "prepare" method to be used as the second parameter of `createAction`.
@@ -269,7 +269,7 @@ export function createAction(type: string, prepareAction?: PrepareAction<any>): 
   return actionCreator;
 }
 
-export { actionSuffixDivider, matchActionSuffix, getBaseType, getType } from './utils';
+export { actionSuffixDivider, matchActionSuffix, getBaseType, getType } from './utils.js';
 
 // helper types for more readable typings
 

--- a/packages/utils/observable/src/actions/create-async-action.ts
+++ b/packages/utils/observable/src/actions/create-async-action.ts
@@ -1,16 +1,16 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: generic constraints mirror create-action.ts's ported redux-toolkit PrepareAction<any> dispatch pattern
 
-import { actionSuffixDivider, createAction } from './create-action';
+import { actionSuffixDivider, createAction } from './create-action.js';
 import {
   isActionWithSuffix,
   isCompleteAction,
   isFailureAction,
   isRequestAction,
   isSuccessAction,
-} from './predicates';
-import type { PayloadActionCreator } from './create-action';
+} from './predicates.js';
+import type { PayloadActionCreator } from './create-action.js';
 
-import type { PrepareAction } from './create-action';
+import type { PrepareAction } from './create-action.js';
 
 /**
  * Creates an async action creator that produces request, success, and optionally failure sub-actions.

--- a/packages/utils/observable/src/actions/index.ts
+++ b/packages/utils/observable/src/actions/index.ts
@@ -6,7 +6,7 @@
  *
  * @module actions
  */
-export * from './ActionError';
+export * from './ActionError.js';
 export * from './types.js';
 
 export { actionMapper, type ActionCalls } from './action-mapper.js';
@@ -19,7 +19,7 @@ export {
   type ActionCreatorWithOptionalPayload,
   type ActionCreatorWithPreparedPayload,
   type PayloadActionCreator,
-} from './create-action';
+} from './create-action.js';
 
 export { getBaseType } from './utils.js';
 
@@ -29,4 +29,4 @@ export {
   isCompleteAction,
   isFailureAction,
   isSuccessAction,
-} from './create-async-action';
+} from './create-async-action.js';

--- a/packages/utils/observable/src/actions/predicates.ts
+++ b/packages/utils/observable/src/actions/predicates.ts
@@ -1,5 +1,5 @@
-import type { Action, ActionWithSuffix, AnyAction } from './types';
-import { matchActionSuffix } from './utils';
+import type { Action, ActionWithSuffix, AnyAction } from './types.js';
+import { matchActionSuffix } from './utils.js';
 
 /**
  * Checks whether an action type ends with a specific lifecycle suffix.

--- a/packages/utils/observable/src/actions/utils.ts
+++ b/packages/utils/observable/src/actions/utils.ts
@@ -1,4 +1,4 @@
-import type { PayloadActionCreator } from './create-action';
+import type { PayloadActionCreator } from './create-action.js';
 
 /**
  * Internal helper utilities for constructing and inspecting Redux-style

--- a/packages/utils/observable/src/create-reducer.ts
+++ b/packages/utils/observable/src/create-reducer.ts
@@ -2,9 +2,9 @@ import { produce as createNextState, isDraft, isDraftable } from 'immer';
 
 import type { Draft } from 'immer';
 
-import type { TypeGuard } from './types/ts-helpers';
-import type { Action, ActionType, AnyAction, ExtractAction } from './actions/types';
-import type { ReducerWithInitialState } from './types/reducers';
+import type { TypeGuard } from './types/ts-helpers.js';
+import type { Action, ActionType, AnyAction, ExtractAction } from './actions/types.js';
+import type { ReducerWithInitialState } from './types/reducers.js';
 
 function freezeDraftable<T>(val: T) {
   return isDraftable(val) ? createNextState(val, () => {}) : val;

--- a/packages/utils/observable/src/create-state.ts
+++ b/packages/utils/observable/src/create-state.ts
@@ -1,8 +1,8 @@
-import { actionMapper } from './actions/action-mapper';
-import { type ActionReducerMapBuilder, createReducer } from './create-reducer';
-import { FlowSubject } from './FlowSubject';
-import type { ActionDefinitions, ActionTypes } from './actions/types';
-import type { ReducerWithInitialState } from './types/reducers';
+import { actionMapper } from './actions/action-mapper.js';
+import { type ActionReducerMapBuilder, createReducer } from './create-reducer.js';
+import { FlowSubject } from './FlowSubject.js';
+import type { ActionDefinitions, ActionTypes } from './actions/types.js';
+import type { ReducerWithInitialState } from './types/reducers.js';
 
 /**
  * Describes the output of {@link createState}: a `FlowSubject`, the original

--- a/packages/utils/observable/src/index.ts
+++ b/packages/utils/observable/src/index.ts
@@ -5,17 +5,17 @@
 
 export { castDraft } from 'immer';
 
-export * from './FlowSubject';
-export * from './actions/ActionError';
-export * from './types';
+export * from './FlowSubject.js';
+export * from './actions/ActionError.js';
+export * from './types/index.js';
 
 /** @deprecated use {@link FlowSubject} */
-export { FlowSubject as ReactiveObservable } from './FlowSubject';
+export { FlowSubject as ReactiveObservable } from './FlowSubject.js';
 
-export { actionMapper, type ActionCalls } from './actions/action-mapper';
+export { actionMapper, type ActionCalls } from './actions/action-mapper.js';
 
-export { createAction, type ActionCreatorWithPreparedPayload } from './actions/create-action';
-export { getBaseType } from './actions/utils';
+export { createAction, type ActionCreatorWithPreparedPayload } from './actions/create-action.js';
+export { getBaseType } from './actions/utils.js';
 
 export {
   createAsyncAction,
@@ -23,12 +23,12 @@ export {
   isCompleteAction,
   isFailureAction,
   isSuccessAction,
-} from './actions/create-async-action';
+} from './actions/create-async-action.js';
 
-export { createReducer, ActionReducerMapBuilder } from './create-reducer';
+export { createReducer, ActionReducerMapBuilder } from './create-reducer.js';
 
-export { createState, type FlowState } from './create-state';
+export { createState, type FlowState } from './create-state.js';
 
-export { isObservableInput } from './is-observable-input';
+export { isObservableInput } from './is-observable-input.js';
 
-export { toObservable, type DynamicInputValue } from './to-observable';
+export { toObservable, type DynamicInputValue } from './to-observable.js';

--- a/packages/utils/observable/src/operators/filter-action.ts
+++ b/packages/utils/observable/src/operators/filter-action.ts
@@ -1,7 +1,7 @@
 import type { OperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import type { Action, ActionType, ExtractAction, TypeConstant } from '../types';
+import type { Action, ActionType, ExtractAction, TypeConstant } from '../types/index.js';
 
 /**
  * RxJS operator that filters an action stream to only emit actions matching

--- a/packages/utils/observable/src/operators/index.ts
+++ b/packages/utils/observable/src/operators/index.ts
@@ -3,8 +3,8 @@
  *
  * @module operators
  */
-export * from './filter-action';
-export * from './map-action';
-export * from './switch-map-action';
+export * from './filter-action.js';
+export * from './map-action.js';
+export * from './switch-map-action.js';
 
-export { mapProp } from './map-prop';
+export { mapProp } from './map-prop.js';

--- a/packages/utils/observable/src/operators/map-action.ts
+++ b/packages/utils/observable/src/operators/map-action.ts
@@ -1,6 +1,6 @@
 import { type Observable, map, type OperatorFunction } from 'rxjs';
-import { filterAction } from './filter-action';
-import type { Action, ActionType, ExtractAction } from '../types';
+import { filterAction } from './filter-action.js';
+import type { Action, ActionType, ExtractAction } from '../types/index.js';
 
 /**
  * RxJS operator that filters an action stream by type and maps matching

--- a/packages/utils/observable/src/operators/map-prop.ts
+++ b/packages/utils/observable/src/operators/map-prop.ts
@@ -1,7 +1,7 @@
 import type { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import type { NestedKeys, NestedPropType } from '../types';
+import type { NestedKeys, NestedPropType } from '../types/index.js';
 
 /**
  * RxJS operator that extracts a nested property from emitted objects using

--- a/packages/utils/observable/src/operators/switch-map-action.ts
+++ b/packages/utils/observable/src/operators/switch-map-action.ts
@@ -1,6 +1,6 @@
 import { type OperatorFunction, type ObservableInput, switchMap } from 'rxjs';
-import { filterAction } from './filter-action';
-import type { Action, ActionType, ExtractAction } from '../types';
+import { filterAction } from './filter-action.js';
+import type { Action, ActionType, ExtractAction } from '../types/index.js';
 
 /**
  * RxJS operator that filters an action stream by type and `switchMap`s

--- a/packages/utils/observable/src/react/index.ts
+++ b/packages/utils/observable/src/react/index.ts
@@ -3,16 +3,16 @@
  *
  * @module react
  */
-export * from './useObservable';
-export * from './useObservableEffect';
-export * from './useObservableInput';
-export * from './useObservableInputState';
-export { useObservableFlow } from './useObservableFlow';
-export { useObservableEpic } from './use-observable-epic';
-export * from './useObservableRef';
-export * from './useObservableState';
-export * from './useObservableSelector';
-export * from './useObservableSelectorState';
-export * from './useObservableSubscription';
-export * from './useObservableLayoutSubscription';
-export * from './useDebounce';
+export * from './useObservable.js';
+export * from './useObservableEffect.js';
+export * from './useObservableInput.js';
+export * from './useObservableInputState.js';
+export { useObservableFlow } from './useObservableFlow.js';
+export { useObservableEpic } from './use-observable-epic.js';
+export * from './useObservableRef.js';
+export * from './useObservableState.js';
+export * from './useObservableSelector.js';
+export * from './useObservableSelectorState.js';
+export * from './useObservableSubscription.js';
+export * from './useObservableLayoutSubscription.js';
+export * from './useDebounce.js';

--- a/packages/utils/observable/src/react/use-observable-epic.ts
+++ b/packages/utils/observable/src/react/use-observable-epic.ts
@@ -1,4 +1,4 @@
-import { useObservableFlow } from './useObservableFlow';
+import { useObservableFlow } from './useObservableFlow.js';
 
 /** @deprecated Renamed to {@link useObservableFlow} since 8.0.3. */
 export const useObservableEpic = useObservableFlow;

--- a/packages/utils/observable/src/react/useDebounce.ts
+++ b/packages/utils/observable/src/react/useDebounce.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { from, type Observable, type ObservableInput, Subject } from 'rxjs';
 import { debounce, debounceTime, switchMap, tap } from 'rxjs/operators';
-import type { ObservableType } from '../types';
+import type { ObservableType } from '../types/index.js';
 
 /**
  * Options for the {@link useDebounce} hook.

--- a/packages/utils/observable/src/react/useObservable.ts
+++ b/packages/utils/observable/src/react/useObservable.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { FlowSubject } from '../FlowSubject';
+import { FlowSubject } from '../FlowSubject.js';
 
-import type { Action, Reducer, ReducerWithInitialState } from '../types';
+import type { Action, Reducer, ReducerWithInitialState } from '../types/index.js';
 
 /**
  * React hook that creates and memoises a {@link FlowSubject} from a reducer and

--- a/packages/utils/observable/src/react/useObservableEffect.ts
+++ b/packages/utils/observable/src/react/useObservableEffect.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
-import type { FlowSubject } from '../FlowSubject';
-import type { Action, Effect, ActionType, ExtractAction } from '../types';
+import type { FlowSubject } from '../FlowSubject.js';
+import type { Action, Effect, ActionType, ExtractAction } from '../types/index.js';
 
 /**
  * React hook that attaches a side-effect to a {@link FlowSubject}, filtered

--- a/packages/utils/observable/src/react/useObservableFlow.ts
+++ b/packages/utils/observable/src/react/useObservableFlow.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from 'react';
-import type { FlowSubject } from '../FlowSubject';
-import type { Action, Flow } from '../types';
+import type { FlowSubject } from '../FlowSubject.js';
+import type { Action, Flow } from '../types/index.js';
 /**
  * React hook that attaches a flow (epic-style function) to a {@link FlowSubject}.
  *

--- a/packages/utils/observable/src/react/useObservableInputState.ts
+++ b/packages/utils/observable/src/react/useObservableInputState.ts
@@ -1,6 +1,6 @@
 import type { ObservableInput } from 'rxjs';
-import { useObservableState, type ObservableStateReturnType } from './useObservableState';
-import { useObservableInput } from './useObservableInput';
+import { useObservableState, type ObservableStateReturnType } from './useObservableState.js';
+import { useObservableInput } from './useObservableInput.js';
 
 /**
  * React hook that subscribes to an `ObservableInput` and tracks its latest

--- a/packages/utils/observable/src/react/useObservableRef.ts
+++ b/packages/utils/observable/src/react/useObservableRef.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 import type { BehaviorSubject } from 'rxjs';
-import { useObservableLayoutSubscription } from './useObservableLayoutSubscription';
-import type { Observable } from '../types';
+import { useObservableLayoutSubscription } from './useObservableLayoutSubscription.js';
+import type { Observable } from '../types/index.js';
 
 /**
  * React hook that keeps a `ref` synchronised with the latest value from an

--- a/packages/utils/observable/src/react/useObservableSelector.ts
+++ b/packages/utils/observable/src/react/useObservableSelector.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import type { Observable } from '../types';
+import type { Observable } from '../types/index.js';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import type { OperatorFunction } from 'rxjs';
 
-import type { NestedKeys, NestedPropType } from '../types';
-import { mapProp } from '../operators';
+import type { NestedKeys, NestedPropType } from '../types/index.js';
+import { mapProp } from '../operators/index.js';
 
 const selectorFn = <
   TType extends Record<string, unknown>,

--- a/packages/utils/observable/src/react/useObservableSelectorState.ts
+++ b/packages/utils/observable/src/react/useObservableSelectorState.ts
@@ -1,6 +1,6 @@
-import { useObservableSelector } from './useObservableSelector';
-import { useObservableState } from './useObservableState';
-import type { Observable } from '../types';
+import { useObservableSelector } from './useObservableSelector.js';
+import { useObservableState } from './useObservableState.js';
+import type { Observable } from '../types/index.js';
 
 /**
  * @deprecated Use `useObservableState(useObservableSelector(...))` instead (since ^8.1).

--- a/packages/utils/observable/src/react/useObservableState.ts
+++ b/packages/utils/observable/src/react/useObservableState.ts
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { BehaviorSubject, type Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
-import type { Observable, StatefulObservable } from '../types';
+import type { Observable, StatefulObservable } from '../types/index.js';
 
 /**
  * Options for {@link useObservableState}.

--- a/packages/utils/observable/src/to-observable.ts
+++ b/packages/utils/observable/src/to-observable.ts
@@ -1,7 +1,7 @@
 import { from, of } from 'rxjs';
 import type { ObservableInput, Observable } from 'rxjs';
 
-import { isObservableInput } from './is-observable-input';
+import { isObservableInput } from './is-observable-input.js';
 
 /**
  * Represents a value that can be:

--- a/packages/utils/observable/src/types/index.ts
+++ b/packages/utils/observable/src/types/index.ts
@@ -1,14 +1,14 @@
 import type { Observable } from 'rxjs';
 
 export * from '../actions/types.js';
-export * from './flow';
-export * from './observable';
-export * from './reducers';
+export * from './flow.js';
+export * from './observable.js';
+export * from './reducers.js';
 
-export type { NestedKeys, NestedPropType } from './ts-helpers';
+export type { NestedKeys, NestedPropType } from './ts-helpers.js';
 
 /** @deprecated Use {@link Flow} instead. */
-export { Flow as Epic } from './flow';
+export { Flow as Epic } from './flow.js';
 
 /**
  * Extracts the value type `U` from `Observable<U>`.

--- a/packages/utils/observable/src/types/reducers.ts
+++ b/packages/utils/observable/src/types/reducers.ts
@@ -1,5 +1,5 @@
 import type { Action, AnyAction } from '../actions/types.js';
-import type { NotFunction } from './ts-helpers';
+import type { NotFunction } from './ts-helpers.js';
 
 /**
  * A pure function that takes a previous state and an action, and returns

--- a/packages/utils/observable/tsconfig.json
+++ b/packages/utils/observable/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "dist/esm",
     "rootDir": "src",
     "declarationDir": "./dist/types"


### PR DESCRIPTION
**Why is this change needed?**
`@equinor/fusion-observable`'s relative import/export specifiers (e.g. `./operators`, `../types`) had no file extensions. The package's tsconfig inherits `moduleResolution: "bundler"` from the repo root, so `tsc` never rewrote these to `.js`/`/index.js` in the compiled ESM output. That's fine for bundler-based consumers (Vite/webpack), but breaks strict Node.js ESM resolution for any consumer that resolves the published `dist/esm` output directly (e.g. Vitest running without a bundler), producing module-not-found errors. A downstream consumer had already worked around this with a `yarn patch`.

**What is the current behavior?**
Compiled `dist/esm/*.js` files import sibling modules without extensions (`from './operators'`), which fails to resolve under strict Node ESM.

**What is the new behavior?**
Every relative import/export in `src/**/*.ts` now has an explicit `.js` (file) or `/index.js` (directory) extension, so the compiled output resolves correctly under both bundler and strict Node ESM resolution. The package's own `tsconfig.json` now overrides `module`/`moduleResolution` to `nodenext` so `tsc` enforces explicit extensions going forward instead of silently allowing them to be omitted again.

**What is the intended behavior or invariant?**
`@equinor/fusion-observable`'s published ESM output must be resolvable by both bundler-based and non-bundler (native Node ESM) consumers. The package-local `nodenext` override only affects how this package type-checks its own imports; it does not change how other packages (still on `moduleResolution: "bundler"`) consume this package's emitted `.d.ts`/`.js` output.

**Does this PR introduce a breaking change?**
No. Output paths and public API are unchanged; only the internal module specifiers gained explicit extensions.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (changeset included)
- Consumer impact: Fixes resolution for consumers that load the package's ESM output directly (without a bundler), e.g. Vitest/Node-based tooling.
- Downstream impact: Verified other in-repo consumers (e.g. `packages/react/app`, `packages/modules/*`, `packages/dev-portal`) still build cleanly via `tsc -b` since they still use `moduleResolution: "bundler"` and consume the emitted declaration/JS files, not the source.

**Review guidance:**
Diff is mechanical (adding extensions) across ~30 files in `packages/utils/observable/src`; the interesting parts are [tsconfig.json](packages/utils/observable/tsconfig.json) (the `nodenext` override) and [FlowSubject.ts](packages/utils/observable/src/FlowSubject.ts) as a representative example. Verified: `tsc -b --force`, `vitest run` (42/42 tests), `biome check`, and `fusion-lint` all pass; a downstream project-reference build (`packages/react/app`) also builds clean.

**Additional context**
The two dead test files under `src/__tests__/` (`Query.test.ts`, `ReactiveObservable.test.ts`) reference modules that no longer exist and are excluded from both this package's `tsconfig.json` and its `vitest.config.ts` (`test.include: ['tests/**']`); they were intentionally left untouched as out of scope.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions (no TSDoc content changed)
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist (unchanged)
- [x] Confirm React logic and derived values are resolved before markup when applicable (n/a)
- [x] Confirm README/docs are updated for user-facing changes (n/a, internal fix)
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
