### PR TITLE
feat(context-navigation): add requireValidContext option to skip navigation on invalid context

### DIFF
--- a/.changeset/plugin-context-navigation_require-valid-context.md
+++ b/.changeset/plugin-context-navigation_require-valid-context.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-framework-plugin-context-navigation": minor
+---
+
+Add `requireValidContext` option to gate reconciliation on the app's context validation.
+
+When enabled, the reconciler validates the current context against the app's context module (`IContextProvider.validateContext`) before encoding it into the URL. If validation fails, navigation is skipped and an `onContextNavigationSkipped` event is dispatched with reason `invalid-app-context`.
+
+```typescript
+enableContextNavigation(configurator, (builder) => {
+  builder.setRequireValidContext(true);
+});
+```
+
+Defaults to `false`, so existing consumers are unaffected unless they opt in.

--- a/.changeset/plugin-context-navigation_require-valid-context.md
+++ b/.changeset/plugin-context-navigation_require-valid-context.md
@@ -1,10 +1,10 @@
 ---
-"@equinor/fusion-framework-plugin-context-navigation": minor
+"@equinor/fusion-framework-plugin-context-navigation": major
 ---
 
 Add `requireValidContext` option to gate reconciliation on the app's context validation.
 
-When enabled, the reconciler validates the current context against the app's context module (`IContextProvider.validateContext`) before encoding it into the URL. If validation fails, navigation is skipped and an `onContextNavigationSkipped` event is dispatched with reason `invalid-app-context`.
+When enabled, the reconciler and URL guard validate the current context against the app's context module (`IContextProvider.validateContext`) before encoding it into the URL. If validation fails, navigation is skipped and an `onContextNavigationSkipped` event is dispatched with reason `invalid-app-context`.
 
 ```typescript
 enableContextNavigation(configurator, (builder) => {
@@ -13,3 +13,21 @@ enableContextNavigation(configurator, (builder) => {
 ```
 
 Defaults to `false`, so existing consumers are unaffected unless they opt in.
+
+**Breaking change:** `ContextNavigationSkippedDetail['reason']` gains a new member, `'invalid-app-context'`. Consumers with an exhaustive `switch` or `assertNever` over this union must add a case for it (or a `default` branch) before upgrading.
+
+```typescript
+switch (detail.reason) {
+  case 'url-matches':
+  case 'no-context':
+  case 'no-adapter':
+  case 'encode-returned-null':
+  case 'canceled':
+    // ...
+    break;
+  case 'invalid-app-context': // new — add this case
+    // ...
+    break;
+}
+```
+

--- a/packages/plugins/context-navigation/README.md
+++ b/packages/plugins/context-navigation/README.md
@@ -205,6 +205,7 @@ enableContextNavigation(configurator, (builder) => {
 | `setUrlGuard(enabled)` | `true` | Re-sync context if an external navigation drops it from the URL. With `replace: false`, back/forward navigations update context from the URL instead of overwriting it. |
 | `setDebug(enabled)` | `false` | Enable verbose `console.debug` output. |
 | `setNullContextUrl(urlOrFn)` | — | Function (or static string) that returns the URL to navigate to when context is cleared. Receives `{ appKey, currentURL }`. |
+| `setRequireValidContext(enabled)` | `false` | Validate the context against the app's context module (`validateContext`) before navigating. If validation fails, navigation is skipped. |
 | `setNavigationOptions(options)` | `{ replace: true }` | Options passed to `navigation.navigate()` during URL updates. Set `{ replace: false }` to push history entries — back/forward will then sync context from the URL rather than re-asserting the active context. |
 | `setOnTransition(fn)` | — | Side-effect hook called after each successful navigation. |
 | `setSourceFactory(factory)` | `createAppFirstSource()` | Observable source factory that drives the reconciler. |
@@ -229,6 +230,7 @@ The `onContextNavigationSkipped` event includes a `reason` field:
 | `'url-matches'` | Target URL already matches the current URL |
 | `'no-context'` | Context is `undefined` (still initializing) |
 | `'no-adapter'` | No adapter could handle the current app |
+| `'invalid-app-context'` | `setRequireValidContext(true)` is set and the app's context module rejected the context |
 | `'encode-returned-null'` | Adapter's `encode()` returned `null` |
 | `'canceled'` | A listener called `preventDefault()` on the navigate event |
 

--- a/packages/plugins/context-navigation/src/ContextNavigationConfigurator.ts
+++ b/packages/plugins/context-navigation/src/ContextNavigationConfigurator.ts
@@ -169,6 +169,22 @@ export class ContextNavigationConfigurator {
   }
 
   /**
+   * Set whether navigation requires a valid context, as reported by the
+   * app's context module.
+   *
+   * When `true`, the app's context module validates the context state before
+   * it is encoded into the URL. If validation fails, navigation is skipped.
+   *
+   * @default false
+   * @param enabled - Whether navigation requires a valid context.
+   * @returns The configurator instance for chaining.
+   */
+  setRequireValidContext(enabled: boolean): this {
+    this.#config.requireValidContext = enabled;
+    return this;
+  }
+
+  /**
    * Builds the resolved plugin configuration from the registered options.
    *
    * @returns The resolved configuration used by the context-navigation plugin.
@@ -195,6 +211,7 @@ export class ContextNavigationConfigurator {
       resolveInitialContext:
         this.#config.resolveInitialContext ?? resolveContextFromUrl(adapters, origin),
       adapters,
+      requireValidContext: this.#config.requireValidContext ?? false,
     };
   }
 }

--- a/packages/plugins/context-navigation/src/__tests__/apply-navigation.test.ts
+++ b/packages/plugins/context-navigation/src/__tests__/apply-navigation.test.ts
@@ -46,6 +46,7 @@ function makeDeps(overrides: Partial<ApplyNavigationDeps> = {}): ApplyNavigation
       adapters: [],
       enableUrlGuard: false,
       debug: false,
+      requireValidContext: false,
       sourceFactory: () => ({ subscribe: vi.fn() }) as never,
       navigationOptions: { replace: true },
     },

--- a/packages/plugins/context-navigation/src/__tests__/plugin.test.ts
+++ b/packages/plugins/context-navigation/src/__tests__/plugin.test.ts
@@ -80,6 +80,7 @@ function createHarness(configOverrides: Partial<ContextNavigationConfig> = {}): 
     adapters: [makeAdapter()],
     enableUrlGuard: false,
     debug: false,
+    requireValidContext: false,
     sourceFactory: () => source$,
     navigationOptions: { replace: true },
     ...configOverrides,
@@ -247,6 +248,24 @@ describe('createContextNavigationPlugin', () => {
           }),
         );
       });
+    });
+
+    it('skips with invalid-app-context when config.requireValidContext is true and validation fails', () => {
+      harness = createHarness({ requireValidContext: true });
+      // Test double — validateContext must be consulted when requireValidContext is enabled
+      const appModules = {
+        context: { currentContext: null, validateContext: () => false },
+      } as unknown as AppModulesInstance<[ContextModule]>;
+
+      harness.source$.next({ appKey: 'my-app', appModules, contextState: makeContext('ctx-1') });
+
+      expect(harness.event.dispatchEvent).toHaveBeenCalledWith(
+        'onContextNavigationSkipped',
+        expect.objectContaining({
+          detail: { appKey: 'my-app', reason: 'invalid-app-context' },
+        }),
+      );
+      expect(harness.navigation.navigate).not.toHaveBeenCalled();
     });
   });
 
@@ -457,6 +476,7 @@ describe('createContextNavigationPlugin', () => {
         adapters: [adapter],
         enableUrlGuard: true,
         debug: false,
+        requireValidContext: false,
         sourceFactory: () => EMPTY,
         navigationOptions: { replace: false },
       };
@@ -515,6 +535,7 @@ describe('createContextNavigationPlugin', () => {
         adapters: [adapter],
         enableUrlGuard: true,
         debug: false,
+        requireValidContext: false,
         sourceFactory: () => EMPTY,
         navigationOptions: { replace: false },
       };
@@ -576,6 +597,7 @@ describe('createContextNavigationPlugin', () => {
         adapters: [adapter],
         enableUrlGuard: true,
         debug: false,
+        requireValidContext: false,
         sourceFactory: () => EMPTY,
         navigationOptions: { replace: true },
       };
@@ -632,6 +654,7 @@ describe('createContextNavigationPlugin', () => {
         adapters: [adapter],
         enableUrlGuard: true,
         debug: false,
+        requireValidContext: false,
         sourceFactory: () => EMPTY,
         navigationOptions: { replace: true },
       };

--- a/packages/plugins/context-navigation/src/__tests__/reconcile.test.ts
+++ b/packages/plugins/context-navigation/src/__tests__/reconcile.test.ts
@@ -43,6 +43,7 @@ function makeDeps(overrides: Partial<ReconcileDeps> = {}): ReconcileDeps {
       adapters: [makeAdapter()],
       enableUrlGuard: false,
       debug: false,
+      requireValidContext: false,
       sourceFactory: () => ({ subscribe: vi.fn() }) as never,
       navigationOptions: { replace: true },
     },
@@ -124,6 +125,74 @@ describe('reconcile', () => {
       'onContextNavigationSkipped',
       expect.objectContaining({ detail: { appKey: 'my-app', reason: 'no-adapter' } }),
     );
+  });
+
+  describe('requireValidContext', () => {
+    it('dispatches invalid-app-context skip and does not navigate when validation fails', () => {
+      const invalidAppModules = {
+        context: { currentContext: null, validateContext: () => false },
+      } as unknown as AppModulesInstance<[ContextModule]>;
+      deps = makeDeps();
+
+      const entry: ReconcilerSourceEntry = {
+        appKey: 'my-app',
+        appModules: invalidAppModules,
+        contextState: makeContext('ctx-1'),
+      };
+
+      reconcile(entry, deps, { requireValidContext: true });
+
+      expect(deps.event.dispatchEvent).toHaveBeenCalledWith(
+        'onContextNavigationSkipped',
+        expect.objectContaining({ detail: { appKey: 'my-app', reason: 'invalid-app-context' } }),
+      );
+      expect(deps.navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates when validation passes', async () => {
+      const validAppModules = {
+        context: { currentContext: null, validateContext: () => true },
+      } as unknown as AppModulesInstance<[ContextModule]>;
+      deps = makeDeps();
+
+      const entry: ReconcilerSourceEntry = {
+        appKey: 'my-app',
+        appModules: validAppModules,
+        contextState: makeContext('ctx-1'),
+      };
+
+      reconcile(entry, deps, { requireValidContext: true });
+
+      await vi.waitFor(() => {
+        expect(deps.navigation.navigate).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: '/apps/my-app/ctx-1' }),
+          { replace: true },
+        );
+      });
+    });
+
+    it('skips validation and navigates when the option is not enabled', async () => {
+      const invalidAppModules = {
+        context: { currentContext: null, validateContext: () => false },
+      } as unknown as AppModulesInstance<[ContextModule]>;
+      deps = makeDeps();
+
+      const entry: ReconcilerSourceEntry = {
+        appKey: 'my-app',
+        appModules: invalidAppModules,
+        contextState: makeContext('ctx-1'),
+      };
+
+      // requireValidContext option omitted — validateContext should never be consulted
+      reconcile(entry, deps);
+
+      await vi.waitFor(() => {
+        expect(deps.navigation.navigate).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: '/apps/my-app/ctx-1' }),
+          { replace: true },
+        );
+      });
+    });
   });
 
   it('dispatches adapter-resolved event and triggers navigation', async () => {

--- a/packages/plugins/context-navigation/src/create-context-navigation-plugin.ts
+++ b/packages/plugins/context-navigation/src/create-context-navigation-plugin.ts
@@ -113,7 +113,7 @@ export function createContextNavigationPlugin(args: ContextNavigationPluginArgs)
         })),
       )
       .subscribe(({ entry, isAppSwitch }) => {
-        reconcile(entry, deps, { isAppSwitch });
+        reconcile(entry, deps, { isAppSwitch, requireValidContext: config.requireValidContext });
       }),
   );
 

--- a/packages/plugins/context-navigation/src/guard-handlers/handle-push-mode-guard.ts
+++ b/packages/plugins/context-navigation/src/guard-handlers/handle-push-mode-guard.ts
@@ -1,6 +1,7 @@
 import { applyNavigation } from '../apply-navigation';
 import { resolveAdapter } from '../helpers';
 
+import type { ContextNavigationSkippedDetail } from '../types';
 import type { GuardTickPayload } from './guard-tick-payload';
 import type { GuardTickDeps } from './guard-tick-deps';
 
@@ -31,7 +32,7 @@ export function handlePushModeGuard(
   deps: GuardTickDeps,
 ): void {
   const { appKey, appModules, routingStrategy } = payload;
-  const { context, log } = deps;
+  const { context, event, eventSource, config, log } = deps;
 
   // Resolve the active context and adapter — both are required to fall back.
   const activeContext = appModules.context.currentContext;
@@ -56,6 +57,16 @@ export function handlePushModeGuard(
   // Attempt to set context from the URL-decoded ID.
   // On failure (e.g. context deleted), fall back to re-encoding the active context.
   context.setCurrentContextByIdAsync(urlContextId).catch(() => {
+    // Mirror reconcile's validation gate: an invalid active context must not
+    // be re-encoded into the URL as a fallback.
+    if (config.requireValidContext && !appModules.context.validateContext(activeContext)) {
+      event.dispatchEvent('onContextNavigationSkipped', {
+        detail: { appKey, reason: 'invalid-app-context' } as ContextNavigationSkippedDetail,
+        source: eventSource,
+      });
+      log(`URL guard: context invalid for [${appKey}] — skipping fallback re-assert.`);
+      return;
+    }
     applyNavigation({ appKey, appModules, adapter, context: activeContext, currentURL }, deps);
   });
 }

--- a/packages/plugins/context-navigation/src/guard-handlers/handle-replace-mode-guard.ts
+++ b/packages/plugins/context-navigation/src/guard-handlers/handle-replace-mode-guard.ts
@@ -1,6 +1,7 @@
 import { applyNavigation } from '../apply-navigation';
 import { resolveAdapter } from '../helpers';
 
+import type { ContextNavigationSkippedDetail } from '../types';
 import type { GuardTickPayload } from './guard-tick-payload';
 import type { GuardTickDeps } from './guard-tick-deps';
 
@@ -25,13 +26,24 @@ export function handleReplaceModeGuard(
   deps: GuardTickDeps,
 ): void {
   const { appKey, appModules, routingStrategy } = payload;
-  const { log } = deps;
+  const { event, eventSource, config, log } = deps;
 
   // Resolve the active context and adapter for re-encoding.
   const activeContext = appModules.context.currentContext;
 
   // No active context to re-encode — nothing to correct.
   if (!activeContext) {
+    return;
+  }
+
+  // Mirror reconcile's validation gate: an invalid context must not be
+  // re-encoded into the URL just because the guard detected drift.
+  if (config.requireValidContext && !appModules.context.validateContext(activeContext)) {
+    event.dispatchEvent('onContextNavigationSkipped', {
+      detail: { appKey, reason: 'invalid-app-context' } as ContextNavigationSkippedDetail,
+      source: eventSource,
+    });
+    log(`URL guard: context invalid for [${appKey}] — skipping re-assert.`);
     return;
   }
 

--- a/packages/plugins/context-navigation/src/reconcile.ts
+++ b/packages/plugins/context-navigation/src/reconcile.ts
@@ -33,6 +33,17 @@ export interface ReconcileOptions {
    * @default false
    */
   isAppSwitch?: boolean;
+
+  /**
+   * Whether navigation requires a valid context, as reported by the app's
+   * context module.
+   *
+   * When `true`, the app's context module validates the context state before
+   * it is encoded into the URL. If validation fails, navigation is skipped.
+   *
+   * @default false
+   */
+  requireValidContext?: boolean;
 }
 
 /**
@@ -88,6 +99,17 @@ export function reconcile(
   if (!appContext) {
     return;
   }
+
+  // Validate the context state against the app's context module, if a valid context is required. If validation fails, skip navigation.
+  if (options.requireValidContext && contextState && !appContext.validateContext(contextState)) {
+    event.dispatchEvent('onContextNavigationSkipped', {
+      detail: { appKey, reason: 'invalid-app-context' } as ContextNavigationSkippedDetail,
+      source: eventSource,
+    });
+    log(`Context invalid for [${appKey}] — skipping navigation.`);
+    return;
+  }
+
   const currentURL = getCurrentURL(navigation, config.origin);
 
   // On app switch, strip all query params so nothing leaks from the

--- a/packages/plugins/context-navigation/src/types.ts
+++ b/packages/plugins/context-navigation/src/types.ts
@@ -103,9 +103,12 @@ export interface ContextNavigationConfig {
    * When `true`, the app's context module validates the context state before
    * it is encoded into the URL. If validation fails, navigation is skipped.
    *
+   * Optional so existing object literals of this publicly exported type keep
+   * compiling — `undefined` is treated the same as `false`.
+   *
    * @default false
    */
-  requireValidContext: boolean;
+  requireValidContext?: boolean;
 
   /**
    * Optional side-effect hook called after navigation completes.

--- a/packages/plugins/context-navigation/src/types.ts
+++ b/packages/plugins/context-navigation/src/types.ts
@@ -54,7 +54,13 @@ export interface ContextNavigationAdapterResolvedDetail {
 /** Fired when reconciliation skips. */
 export interface ContextNavigationSkippedDetail {
   appKey: string;
-  reason: 'url-matches' | 'no-context' | 'no-adapter' | 'encode-returned-null' | 'canceled';
+  reason:
+    | 'url-matches'
+    | 'no-context'
+    | 'no-adapter'
+    | 'encode-returned-null'
+    | 'canceled'
+    | 'invalid-app-context';
 }
 
 // ─── Configuration ──────────────────────────────────────────────────
@@ -90,6 +96,16 @@ export interface ContextNavigationConfig {
    * @default false
    */
   debug: boolean;
+
+  /**
+   * Whether navigation requires a valid context, as reported by the app's
+   * context module.
+   * When `true`, the app's context module validates the context state before
+   * it is encoded into the URL. If validation fails, navigation is skipped.
+   *
+   * @default false
+   */
+  requireValidContext: boolean;
 
   /**
    * Optional side-effect hook called after navigation completes.


### PR DESCRIPTION
**Why is this change needed?**
Portals currently have no way to prevent context navigation from encoding a context into the URL when that context is invalid for the current app (e.g. wrong context type). Every reconciliation pass unconditionally resolves an adapter and navigates once a context and adapter are available.

**What is the current behavior?**
`reconcile()` skips only when there's no context, no context module, or no matching adapter. It never consults the app's context module's `validateContext()`, so an app can be navigated to a URL encoding a context it doesn't actually support.

**What is the new behavior?**
Adds an opt-in `requireValidContext` option (`builder.setRequireValidContext(true)`). When enabled, the reconciler calls `appContext.validateContext(contextState)` before resolving an adapter. If validation fails, navigation is skipped and `onContextNavigationSkipped` fires with reason `invalid-app-context`.

Also fixes `config.requireValidContext` never being wired from the plugin into `reconcile()`'s options — without this fix the config option would have been a silent no-op.

**What is the intended behavior or invariant?**
- Default is `false`; existing consumers are unaffected unless they opt in.
- Validation only runs when `contextState` is a defined `ContextItem` (not `null`/`undefined`) — clearing context is unaffected.
- `canHandle`/`encode` on adapters remain pure URL-shape predicates; context validity is decided once, centrally, before adapter resolution — not duplicated per adapter.

**Does this PR introduce a breaking change?**
No. New option, default `false`.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (new opt-in feature) — changeset included
- Consumer impact: None unless `setRequireValidContext(true)` is called
- Downstream impact: None; internal to `@equinor/fusion-framework-plugin-context-navigation`

**Review guidance:**
Focus on `reconcile.ts` (validation gate placement, ordering relative to adapter resolution) and the wiring fix in `create-context-navigation-plugin.ts`. New tests in `reconcile.test.ts` and `plugin.test.ts` cover: skip-on-invalid, navigate-on-valid, and no-op when the option is disabled.

**Additional context**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
