### PR TITLE
fix(plugin-context-navigation): preserve sub-route on context change

### DIFF
--- a/.changeset/plugin-context-navigation_preserve-sub-route-on-context-change.md
+++ b/.changeset/plugin-context-navigation_preserve-sub-route-on-context-change.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-plugin-context-navigation": patch
+---
+
+Fix the path adapter to preserve the app's sub-route when the context changes, instead of always resetting to the app root. The sub-route is still dropped when context is cleared entirely, since there's no valid context to resolve it against.
+
+Fixes: https://github.com/equinor/fusion/issues/904

--- a/packages/plugins/context-navigation/src/__tests__/create-path-adapter.test.ts
+++ b/packages/plugins/context-navigation/src/__tests__/create-path-adapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPathAdapter } from '../adapters/create-path-adapter';
+
+const CONTEXT_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('createPathAdapter', () => {
+  const adapter = createPathAdapter();
+
+  it('drops the context segment and sub-route when context becomes null', () => {
+    const currentURL = new URL(`/apps/my-app/${CONTEXT_ID}/settings/general`, 'https://example.com');
+    const result = adapter.encode({ context: null, currentURL });
+
+    expect(result?.pathname).toBe('/apps/my-app');
+  });
+
+  it('preserves the sub-route when swapping to a new context', () => {
+    const currentURL = new URL(`/apps/my-app/${CONTEXT_ID}/settings/general`, 'https://example.com');
+    const result = adapter.encode({
+      context: { id: 'new-context-id' } as never,
+      currentURL,
+    });
+
+    expect(result?.pathname).toBe('/apps/my-app/new-context-id/settings/general');
+  });
+
+  it('preserves the full route tail when there was no prior context id to distinguish from a route name', () => {
+    // With no active context, the segment after the app key is a route name
+    // (e.g. "settings"), not a context id — it must be folded into the tail
+    // rather than clobbered by the new context id.
+    const currentURL = new URL('/apps/my-app/settings/general', 'https://example.com');
+    const result = adapter.encode({
+      context: { id: CONTEXT_ID } as never,
+      currentURL,
+    });
+
+    expect(result?.pathname).toBe(`/apps/my-app/${CONTEXT_ID}/settings/general`);
+  });
+});

--- a/packages/plugins/context-navigation/src/__tests__/create-path-adapter.test.ts
+++ b/packages/plugins/context-navigation/src/__tests__/create-path-adapter.test.ts
@@ -8,14 +8,20 @@ describe('createPathAdapter', () => {
   const adapter = createPathAdapter();
 
   it('drops the context segment and sub-route when context becomes null', () => {
-    const currentURL = new URL(`/apps/my-app/${CONTEXT_ID}/settings/general`, 'https://example.com');
+    const currentURL = new URL(
+      `/apps/my-app/${CONTEXT_ID}/settings/general`,
+      'https://example.com',
+    );
     const result = adapter.encode({ context: null, currentURL });
 
     expect(result?.pathname).toBe('/apps/my-app');
   });
 
   it('preserves the sub-route when swapping to a new context', () => {
-    const currentURL = new URL(`/apps/my-app/${CONTEXT_ID}/settings/general`, 'https://example.com');
+    const currentURL = new URL(
+      `/apps/my-app/${CONTEXT_ID}/settings/general`,
+      'https://example.com',
+    );
     const result = adapter.encode({
       context: { id: 'new-context-id' } as never,
       currentURL,

--- a/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
+++ b/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
@@ -5,6 +5,7 @@ import { stripContextQueryParam } from '../utils/url/strip-context-query-param';
 import { parseAppRoute } from '../utils/url/parse-app-route';
 import { UUID_PATTERN } from '../constants';
 import { buildAppRoute } from '../utils/url/build-app-route';
+import { resolveRouteTail } from '../utils/url/resolve-route-tail';
 
 /**
  * Path adapter — encodes context identity as the first path segment after
@@ -82,7 +83,7 @@ export function createPathAdapter(): ContextNavigationAdapter {
       const targetPath =
         context === null
           ? buildAppRoute(match.appKey)
-          : buildAppRoute(match.appKey, context.id, match.rest);
+          : buildAppRoute(match.appKey, context.id, resolveRouteTail(match));
 
       const url = new URL(targetPath, currentURL.origin);
       url.search = currentURL.search;

--- a/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
+++ b/packages/plugins/context-navigation/src/adapters/create-path-adapter.ts
@@ -68,11 +68,11 @@ export function createPathAdapter(): ContextNavigationAdapter {
     /**
      * Encode context into the URL as a path segment.
      *
-     * - **Null context:** removes the context segment to produce a bare app route.
-     * - **Active context:** places/replaces the context id as the segment after the app key.
-     *
-     * Sub-routes after the context segment are intentionally dropped — a context
-     * change resets the app to its root view to avoid landing in an invalid state.
+     * - **Null context:** removes the context segment and drops any sub-route,
+     *   resetting the app to its root view — there's no valid context to resolve
+     *   the sub-route against.
+     * - **Active context:** places/replaces the context id as the segment after
+     *   the app key, preserving the existing sub-route.
      */
     encode({ context, currentURL }: { context: ContextItem | null; currentURL: URL }): URL | null {
       const match = parseAppRoute(currentURL.pathname);
@@ -80,7 +80,9 @@ export function createPathAdapter(): ContextNavigationAdapter {
       if (!match) return null;
 
       const targetPath =
-        context === null ? buildAppRoute(match.appKey) : buildAppRoute(match.appKey, context.id);
+        context === null
+          ? buildAppRoute(match.appKey)
+          : buildAppRoute(match.appKey, context.id, match.rest);
 
       const url = new URL(targetPath, currentURL.origin);
       url.search = currentURL.search;

--- a/packages/plugins/context-navigation/src/utils/url/index.ts
+++ b/packages/plugins/context-navigation/src/utils/url/index.ts
@@ -4,4 +4,5 @@ export { buildAppRoute } from './build-app-route';
 export { CONTEXT_QUERY_PARAM_KEY, UUID_PATTERN } from '../../constants';
 export { stripContextQueryParam } from './strip-context-query-param';
 export { resolveContextIdFromUrl } from './resolve-context-id-from-url';
+export { resolveRouteTail } from './resolve-route-tail';
 export { buildContextUrlForStrategy } from './build-context-url-for-strategy';

--- a/packages/plugins/context-navigation/src/utils/url/resolve-route-tail.ts
+++ b/packages/plugins/context-navigation/src/utils/url/resolve-route-tail.ts
@@ -1,0 +1,22 @@
+import { UUID_PATTERN } from '../../constants';
+import type { AppRouteMatch } from './parse-app-route';
+
+/**
+ * Reconstructs the full sub-route tail from a parsed app route.
+ *
+ * `contextId` is a positional capture, not a verified context — when the URL has
+ * no active context that slot actually holds a route name (e.g. "settings" in
+ * `/apps/app/settings/general`). Folding it back into the tail prevents it from
+ * being silently discarded when a real context id is substituted into that slot.
+ *
+ * @param match - The `contextId`/`rest` segments from `parseAppRoute`.
+ * @returns The full sub-route tail, or `undefined` when there is none.
+ */
+export const resolveRouteTail = (match: Pick<AppRouteMatch, 'contextId' | 'rest'>): string | undefined => {
+  // A UUID in this slot is a real context id — the tail is just whatever follows it
+  if (match.contextId && UUID_PATTERN.test(match.contextId)) {
+    return match.rest;
+  }
+  // Otherwise the slot is a route name, not a context — rejoin it with the rest to keep the full tail
+  return [match.contextId, match.rest].filter(Boolean).join('/') || undefined;
+};

--- a/packages/plugins/context-navigation/src/utils/url/resolve-route-tail.ts
+++ b/packages/plugins/context-navigation/src/utils/url/resolve-route-tail.ts
@@ -12,7 +12,9 @@ import type { AppRouteMatch } from './parse-app-route';
  * @param match - The `contextId`/`rest` segments from `parseAppRoute`.
  * @returns The full sub-route tail, or `undefined` when there is none.
  */
-export const resolveRouteTail = (match: Pick<AppRouteMatch, 'contextId' | 'rest'>): string | undefined => {
+export const resolveRouteTail = (
+  match: Pick<AppRouteMatch, 'contextId' | 'rest'>,
+): string | undefined => {
   // A UUID in this slot is a real context id — the tail is just whatever follows it
   if (match.contextId && UUID_PATTERN.test(match.contextId)) {
     return match.rest;


### PR DESCRIPTION
**Why is this change needed?**
The path adapter's `encode()` always dropped the app's sub-route when re-encoding context into the URL, even on a simple context switch. This forced apps back to their root view any time the active context changed, not just when context was cleared.

**What is the current behavior?**
Any context encode (context set or cleared) rewrites the URL to `/apps/{appKey}/{contextId}` and discards whatever sub-route path followed the context segment.

**What is the new behavior?**
- Context change (non-null): the sub-route is preserved — `/apps/{appKey}/{contextId}/{rest}`.
- Context cleared (null): the sub-route is still dropped — `/apps/{appKey}` — since there's no valid context left to resolve it against.

**What is the intended behavior or invariant?**
Sub-routes are only ever dropped when context becomes `null`. A context id swap must not affect app-level routing state.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: Patch (see changeset)
- Consumer impact: Apps using the default path adapter will no longer be reset to their root view on a context switch; sub-route is preserved.
- Downstream impact: Scoped to `@equinor/fusion-framework-plugin-context-navigation`, no other packages affected.

**Review guidance:**
Focus on `encode()` in `create-path-adapter.ts` — verify the `context === null` branch intentionally omits `match.rest` while the context-change branch still passes it through.

**Related issues**
Fixes: equinor/fusion#904

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable (not applicable)
- [x] Confirm README/docs are updated for user-facing changes (README table already reflects this shape; no change needed)
- [x] Confirm changes to target branch validation
- [x] Confirm adherence to code of conduct
