### PR TITLE
Rename testApp/test fixture `configure` to `configureApp`, add `configureFusion`

### DIFF
--- a/.changeset/cookbook-app-react-context_rename-configure-fixture.md
+++ b/.changeset/cookbook-app-react-context_rename-configure-fixture.md
@@ -2,4 +2,4 @@
 "@equinor/fusion-framework-cookbook-app-react-context": patch
 ---
 
-Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` fixture rename; no behavior changes.
+Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` and `env`→`appEnv` fixture renames; no behavior changes.

--- a/.changeset/cookbook-app-react-context_rename-configure-fixture.md
+++ b/.changeset/cookbook-app-react-context_rename-configure-fixture.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-context": patch
+---
+
+Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` fixture rename; no behavior changes.

--- a/.changeset/cookbook-app-react-module_rename-configure-fixture.md
+++ b/.changeset/cookbook-app-react-module_rename-configure-fixture.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-module": patch
+---
+
+Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` fixture rename; no behavior changes.

--- a/.changeset/cookbook-app-react-msal_rename-configure-fixture.md
+++ b/.changeset/cookbook-app-react-msal_rename-configure-fixture.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-msal": patch
+---
+
+Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` fixture rename; no behavior changes.

--- a/.changeset/cookbook-app-react-router_rename-configure-fixture.md
+++ b/.changeset/cookbook-app-react-router_rename-configure-fixture.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-router": patch
+---
+
+Internal: update the test suite for `@equinor/fusion-framework-vitest-plugin-react-app`'s `configure`→`configureApp` fixture rename; no behavior changes.

--- a/.changeset/vitest-plugin-react-app_rename-configure-fixtures.md
+++ b/.changeset/vitest-plugin-react-app_rename-configure-fixtures.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-vitest-plugin-react-app": major
+---
+
+Rename the `testApp`/`test` fixtures for extending the mocked application and parent framework configuration: `configure` is now `configureApp`, and the new `configureFramework` fixture introduced alongside it is now `configureFusion`.
+
+```diff
+-const test = testApp.extend('configure', { injected: true }, () => ...);
++const test = testApp.extend('configureApp', { injected: true }, () => ...);
+```
+
+`configureFusion` composes with the base parent-framework mock (app manifest and navigation) the same way `configureApp` composes with the base app-module mock — see [Advanced usage](docs/advanced.md#extend-the-parent-framework-mock-with-configurefusion) for extending framework-scope modules such as feature flags, service discovery, or navigation history.

--- a/.changeset/vitest-plugin-react-app_rename-configure-fixtures.md
+++ b/.changeset/vitest-plugin-react-app_rename-configure-fixtures.md
@@ -2,11 +2,25 @@
 "@equinor/fusion-framework-vitest-plugin-react-app": major
 ---
 
-Rename the `testApp`/`test` fixtures for extending the mocked application and parent framework configuration: `configure` is now `configureApp`, and the new `configureFramework` fixture introduced alongside it is now `configureFusion`.
+Rename the `testApp`/`test` fixtures for extending the mocked application and parent framework
+configuration: `configure` is now `configureApp`, the new `configureFramework` fixture
+introduced alongside it is now `configureFusion`, and `env` is now `appEnv`.
 
 ```diff
 -const test = testApp.extend('configure', { injected: true }, () => ...);
 +const test = testApp.extend('configureApp', { injected: true }, () => ...);
+
+-test.override('fusion', async ({ env }) => ...);
++test.override('fusion', async ({ appEnv }) => ...);
 ```
 
 `configureFusion` composes with the base parent-framework mock (app manifest and navigation) the same way `configureApp` composes with the base app-module mock — see [Advanced usage](docs/advanced.md#extend-the-parent-framework-mock-with-configurefusion) for extending framework-scope modules such as feature flags, service discovery, or navigation history.
+
+Also adds `mergeEnvConfig`, a new utility exported from the `/test` entry point for overriding one endpoint's URL (or an `environment` value) on `appEnv` without dropping the rest of the app's `AppConfig` — a plain object spread over `AppConfig` copies nothing, since it stores `environment`/`endpoints` behind private fields exposed only through getters. See [Advanced usage](docs/advanced.md#fake-an-endpoint-url-with-mergeenvconfig).
+
+```ts
+const test = baseTest.extend('appEnv', ({ appEnv }) =>
+  mergeEnvConfig(appEnv, { endpoints: { 'cpr-api': { url: backendBaseUrl } } }),
+);
+```
+

--- a/cookbooks/app-react-context/src/App.test.tsx
+++ b/cookbooks/app-react-context/src/App.test.tsx
@@ -43,7 +43,7 @@ const withSeededContext =
     enableContextMock(configurator, seed);
   };
 
-// --- test setup: each variant seeds a different context scenario via the `configure` fixture ---
+// --- test setup: each variant seeds a different context scenario via the `configureApp` fixture ---
 
 // --- tests ---
 
@@ -59,7 +59,7 @@ test('renders the current and related context sections once the app configuratio
 });
 
 describe('with an initial project', () => {
-  test.override('configure', { injected: true }, () =>
+  test.override('configureApp', { injected: true }, () =>
     withSeededContext((mock) => {
       mock.setCurrentContext(project);
     }),
@@ -75,7 +75,7 @@ describe('with an initial project', () => {
 });
 
 describe('with related contexts', () => {
-  test.override('configure', { injected: true }, () =>
+  test.override('configureApp', { injected: true }, () =>
     withSeededContext((mock) => {
       // a realistic pool: related items are a different type than the current context, never the same
       mock.setContexts([project, facility, discipline]);
@@ -98,7 +98,7 @@ describe('with related contexts', () => {
 });
 
 describe('when the app context changes', () => {
-  test.override('configure', { injected: true }, () =>
+  test.override('configureApp', { injected: true }, () =>
     withSeededContext((mock) => {
       mock.setContexts([project, facility]);
       mock.setCurrentContext(project);
@@ -129,7 +129,7 @@ describe('when the app context changes', () => {
 
 describe('with a parent framework context', () => {
   // the app mirrors the parent's context, while its local mock pool resolves mirrored items without a network request
-  test.override('configure', { injected: true }, () =>
+  test.override('configureApp', { injected: true }, () =>
     withSeededContext((mock) => {
       mock.setContexts([project, facility]);
     }),

--- a/cookbooks/app-react-context/src/App.test.tsx
+++ b/cookbooks/app-react-context/src/App.test.tsx
@@ -134,9 +134,9 @@ describe('with a parent framework context', () => {
       mock.setContexts([project, facility]);
     }),
   );
-  test.override('fusion', async ({ env }) =>
+  test.override('fusion', async ({ appEnv }) =>
     mockFramework<[AppModule, ContextModule]>((configurator) => {
-      enableAppManifestMock(configurator, env);
+      enableAppManifestMock(configurator, appEnv);
       enableContextMock(configurator, (mock) => {
         mock.setContexts([project, facility]);
         mock.setCurrentContext(project);

--- a/cookbooks/app-react-module/src/App.test.tsx
+++ b/cookbooks/app-react-module/src/App.test.tsx
@@ -33,7 +33,7 @@ test("renders the demo module's resolved foo/bar values", async ({ render }) => 
 });
 
 describe('with an overridden demo configuration', () => {
-  test.override('configure', { injected: true }, () => withDemoConfig('https://example.com', 7));
+  test.override('configureApp', { injected: true }, () => withDemoConfig('https://example.com', 7));
 
   test('renders the overridden foo/bar values instead of the app defaults', async ({ render }) => {
     const { getByText, unmount } = await render(<App />);

--- a/cookbooks/app-react-msal/src/App.test.tsx
+++ b/cookbooks/app-react-msal/src/App.test.tsx
@@ -7,7 +7,7 @@ import { App } from './App';
 /**
  * Sets a named mock account instead of the msal mock's default "Test User" —
  * signed in before the msal provider initializes, so the provider's own
- * start-up path observes it. The cookbook registers no `configure` of its own,
+ * start-up path observes it. The cookbook registers no `configureApp` of its own,
  * so this is the test's entire configuration, not a composition with one.
  */
 const withMockAccount =
@@ -33,7 +33,7 @@ test('renders the default signed-in mock user once the app configuration has ini
 });
 
 describe('with a configured account', () => {
-  test.override('configure', { injected: true }, () =>
+  test.override('configureApp', { injected: true }, () =>
     withMockAccount({ name: 'Ada Lovelace', username: 'ada@equinor.com' }),
   );
 

--- a/cookbooks/app-react-router/src/__tests__/test-with-api-mock.ts
+++ b/cookbooks/app-react-router/src/__tests__/test-with-api-mock.ts
@@ -23,9 +23,9 @@ import { apiMock } from '../mocks/api-mock';
  * });
  * ```
  */
-export const testWithApiMock = baseTest.extend('configure', ({ configure }) => {
+export const testWithApiMock = baseTest.extend('configureApp', ({ configureApp }) => {
   const withApiMock: AppMockConfigureFn = (configurator, args) => {
-    configure?.(configurator, args);
+    configureApp?.(configurator, args);
     configurator.http.addMiddleware(createOpenApiMockMiddleware(apiMock));
   };
   return withApiMock;

--- a/packages/react/app/src/__tests__/testApp.test.tsx
+++ b/packages/react/app/src/__tests__/testApp.test.tsx
@@ -3,6 +3,9 @@ import { describe, expect } from 'vitest';
 import { enableContextMock } from '@equinor/fusion-framework-module-context/mock';
 import type { ContextItem } from '@equinor/fusion-framework-module-context';
 import { useCurrentContext } from '@equinor/fusion-framework-react-app/context';
+import { useFramework } from '@equinor/fusion-framework-react';
+import { createHistory, enableNavigation } from '@equinor/fusion-framework-module-navigation';
+import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
 
 import { testApp } from '@equinor/fusion-framework-vitest-plugin-react-app/test';
 
@@ -42,6 +45,32 @@ describe('testApp', () => {
     test('starts on the seeded context', async ({ render }) => {
       const screen = await render(<CurrentContext />);
       await expect.element(screen.getByText(projectA.title as string)).toBeVisible();
+    });
+  });
+
+  describe('with a configured parent framework', () => {
+    const NavigationLocation = () => {
+      const { navigation } = useFramework<[NavigationModule]>().modules;
+      return <p>{navigation.history.location.pathname}</p>;
+    };
+
+    // pushed on the history instance itself, before it's handed to the framework configurator,
+    // so a passing assertion also proves `configureFusion` ran ahead of framework initialization
+    const history = createHistory('memory');
+    history.push('/configured-by-configure-fusion');
+
+    const test = testApp.extend(
+      'configureFusion',
+      { injected: true },
+      () => (configurator) =>
+        enableNavigation(configurator, { configure: (config) => config.setHistory(history) }),
+    );
+
+    test('resolves the fusion instance with the configured navigation history', async ({
+      render,
+    }) => {
+      const screen = await render(<NavigationLocation />);
+      await expect.element(screen.getByText('/configured-by-configure-fusion')).toBeVisible();
     });
   });
 });

--- a/packages/react/app/src/__tests__/testApp.test.tsx
+++ b/packages/react/app/src/__tests__/testApp.test.tsx
@@ -33,7 +33,7 @@ describe('testApp', () => {
 
   describe('with a seeded context module', () => {
     const test = testApp.extend(
-      'configure',
+      'configureApp',
       { injected: true },
       () => (configurator) =>
         enableContextMock(configurator, (mock) => mock.setCurrentContext(projectA)),

--- a/packages/vitest-plugin/react-app/README.md
+++ b/packages/vitest-plugin/react-app/README.md
@@ -18,7 +18,7 @@ Use this package when you need to:
   resolution pipeline `ffc app build`/`ffc app dev` use, served as virtual modules by
   `appTestVitePlugin`.
 - **Share seeded fixture defaults across a test file** — `testApp`, a `vitest` `test` extended
-  with `env`/`configure`/`app`/`render`/`renderHook` fixtures, instead of repeating options on
+  with `env`/`configureApp`/`app`/`render`/`renderHook` fixtures, instead of repeating options on
   every call. Each test still gets its own fresh `fusion`/`app` instances; only the seeded
   defaults are shared, not state between tests.
 
@@ -78,7 +78,7 @@ entry-point's `test`/`render` when several cases in a file share one seeded scop
   `renderAppComponent`, `renderAppHook`, `testApp`. No app-specific resolution; you pass
   `env`/`configure` yourself.
 - **`@equinor/fusion-framework-vitest-plugin-react-app/test`** — `test`, `render`. Require
-  `appTestVitePlugin` registered in `vitest.config.ts`; `env`/`configure` are resolved
+  `appTestVitePlugin` registered in `vitest.config.ts`; `env`/`configureApp` are resolved
   automatically from the application's own manifest, config, and module-configurator.
 - **`@equinor/fusion-framework-vitest-plugin-react-app/config`** — `defineProject`. Registers
   `appTestVitePlugin`, headless Playwright/Chromium, test-file inclusion, and lazy-import
@@ -94,7 +94,7 @@ import { defineProject } from '@equinor/fusion-framework-vitest-plugin-react-app
 export default defineProject();
 ```
 
-Then use the pre-seeded `test` fixture — no per-test `env`/`configure` wiring:
+Then use the pre-seeded `test` fixture — no per-test `env`/`configureApp` wiring:
 
 ```tsx
 import { expect } from 'vitest';
@@ -280,7 +280,7 @@ test('mounts the child app once its script loads', async () => {
 
 `vitest`'s `test`, extended with an application module scope fixture — an alternative to
 `renderAppComponent`/`renderAppHook` for a test file whose cases share one mocked scope:
-`env`/`configure` become suite-level concerns, overridden once per file (or per `describe`
+`env`/`configureApp` become suite-level concerns, overridden once per file (or per `describe`
 block) with `testApp.extend(...)`, rather than an options object repeated on every call.
 `fusion`/`app` resolve lazily — a test that only destructures `app` never pays for rendering
 anything, and one that only destructures `render`/`renderHook` gets the same mocked scope
@@ -299,7 +299,7 @@ Seed a module for every test in a suite:
 
 ```tsx
 describe('with a seeded context module', () => {
-  const test = testApp.extend('configure', { injected: true }, () =>
+  const test = testApp.extend('configureApp', { injected: true }, () =>
     (configurator) => enableContextMock(configurator, (mock) => mock.setCurrentContext(projectA)),
   );
 
@@ -316,7 +316,7 @@ A plain Vite plugin — Vitest configs are Vite configs, so this registers direc
 `vitest.config.ts`, no CLI command required. It serves an application's manifest/config
 (resolved the same way `ffc app build`/`ffc app dev` do) and its own module-configurator
 export as virtual modules, so the `/test` entry-point's `test`/`render` need no per-test
-`env`/`configure` wiring.
+`env`/`configureApp` wiring.
 
 ```ts
 appTestVitePlugin({

--- a/packages/vitest-plugin/react-app/README.md
+++ b/packages/vitest-plugin/react-app/README.md
@@ -18,9 +18,12 @@ Use this package when you need to:
   resolution pipeline `ffc app build`/`ffc app dev` use, served as virtual modules by
   `appTestVitePlugin`.
 - **Share seeded fixture defaults across a test file** — `testApp`, a `vitest` `test` extended
-  with `env`/`configureApp`/`app`/`render`/`renderHook` fixtures, instead of repeating options on
+  with `appEnv`/`configureApp`/`app`/`render`/`renderHook` fixtures, instead of repeating options on
   every call. Each test still gets its own fresh `fusion`/`app` instances; only the seeded
   defaults are shared, not state between tests.
+- **Fake one endpoint's URL without losing the rest of the config** — `mergeEnvConfig` merges
+  `environment`/`endpoints` overrides into an `AppEnv`'s `config`; a plain object spread over
+  `AppConfig` (which stores both behind private fields) silently drops everything.
 
 ## Installation
 
@@ -78,7 +81,7 @@ entry-point's `test`/`render` when several cases in a file share one seeded scop
   `renderAppComponent`, `renderAppHook`, `testApp`. No app-specific resolution; you pass
   `env`/`configure` yourself.
 - **`@equinor/fusion-framework-vitest-plugin-react-app/test`** — `test`, `render`. Require
-  `appTestVitePlugin` registered in `vitest.config.ts`; `env`/`configureApp` are resolved
+  `appTestVitePlugin` registered in `vitest.config.ts`; `appEnv`/`configureApp` are resolved
   automatically from the application's own manifest, config, and module-configurator.
 - **`@equinor/fusion-framework-vitest-plugin-react-app/config`** — `defineProject`. Registers
   `appTestVitePlugin`, headless Playwright/Chromium, test-file inclusion, and lazy-import
@@ -94,7 +97,7 @@ import { defineProject } from '@equinor/fusion-framework-vitest-plugin-react-app
 export default defineProject();
 ```
 
-Then use the pre-seeded `test` fixture — no per-test `env`/`configureApp` wiring:
+Then use the pre-seeded `test` fixture — no per-test `appEnv`/`configureApp` wiring:
 
 ```tsx
 import { expect } from 'vitest';
@@ -280,7 +283,7 @@ test('mounts the child app once its script loads', async () => {
 
 `vitest`'s `test`, extended with an application module scope fixture — an alternative to
 `renderAppComponent`/`renderAppHook` for a test file whose cases share one mocked scope:
-`env`/`configureApp` become suite-level concerns, overridden once per file (or per `describe`
+`appEnv`/`configureApp` become suite-level concerns, overridden once per file (or per `describe`
 block) with `testApp.extend(...)`, rather than an options object repeated on every call.
 `fusion`/`app` resolve lazily — a test that only destructures `app` never pays for rendering
 anything, and one that only destructures `render`/`renderHook` gets the same mocked scope
@@ -316,7 +319,7 @@ A plain Vite plugin — Vitest configs are Vite configs, so this registers direc
 `vitest.config.ts`, no CLI command required. It serves an application's manifest/config
 (resolved the same way `ffc app build`/`ffc app dev` do) and its own module-configurator
 export as virtual modules, so the `/test` entry-point's `test`/`render` need no per-test
-`env`/`configureApp` wiring.
+`appEnv`/`configureApp` wiring.
 
 ```ts
 appTestVitePlugin({

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -1,10 +1,10 @@
 # Advanced Fusion app testing
 
-The `/test` entry point extends Vitest's test context with `env`, `configure`, `fusion`, `app`,
-`render`, and `renderHook`. Fixture declarations are reusable, while each test receives fresh
-framework and app module instances.
+The `/test` entry point extends Vitest's test context with `env`, `configureApp`, `configureFusion`,
+`fusion`, `app`, `render`, and `renderHook`. Fixture declarations are reusable, while each test
+receives fresh framework and app module instances.
 
-This guide covers composing and overriding those six Fusion fixture values; see Vitest's own
+This guide covers composing and overriding those Fusion fixture values; see Vitest's own
 [Test Context](https://vitest.dev/guide/test-context) documentation for fixture scope, cleanup,
 and the general `test.extend`/`test.override` mechanics Fusion builds on.
 
@@ -15,7 +15,7 @@ and the general `test.extend`/`test.override` mechanics Fusion builds on.
 | `test` from `/test` | The app's manifest, config, and module configurator should resolve automatically |
 | `render` from `/test` | A standard `describe` or `it` block needs the automatically resolved app scope |
 | `renderAppHook` | A hook needs an app scope with explicitly supplied options |
-| `renderAppComponent` | A component needs explicit `env`, `configure`, or parent `fusion` options |
+| `renderAppComponent` | A component needs explicit `env`, `configureApp`, or parent `fusion` options |
 | `testApp` | A reusable fixture should not depend on Vite's automatic app-file resolution |
 
 All Fusion rendering APIs initialize modules asynchronously and must be awaited. The lower
@@ -24,7 +24,11 @@ module instances consumed by the rendered subject.
 
 ## Extend app configuration
 
-Create one reusable extended test when several cases need the same deterministic modules:
+Create one reusable extended test when several cases need the same deterministic modules.
+This must extend `test` from `/test`, not `testApp` from the main entry point:
+`testApp`'s `configureApp` defaults to `undefined` (no Vite dependency, so no way to load the
+real `src/config.ts` as live code), while `/test`'s `test` seeds it with the app's real
+`configure` export via `appTestVitePlugin`'s virtual modules.
 
 ```tsx
 import { enableContextMock } from '@equinor/fusion-framework-module-context/mock';
@@ -37,13 +41,13 @@ const project = {
   value: {},
 };
 
-export const test = baseTest.extend('configure', ({ configure }) => (configurator, args) => {
-  configure?.(configurator, args);
+export const test = baseTest.extend('configureApp', ({ configureApp }) => (configurator, args) => {
+  configureApp?.(configurator, args);
   enableContextMock(configurator, (mock) => mock.setCurrentContext(project));
 });
 ```
 
-Composing the original `configure` fixture preserves the application's production module
+Composing the original `configureApp` fixture preserves the application's production module
 configuration. See [Module mocks](module-mocks.md) for authentication, context, bookmark,
 feature-flag, HTTP, analytics, and telemetry boundaries.
 
@@ -59,6 +63,11 @@ and does not leak to sibling blocks or other files — each `describe` starts fr
 base `test` again. Called at the top of the file (outside any `describe`), it applies to every
 test in that file.
 
+**`configureApp`'s default value, from `/test`, *is* the app's real `src/config.ts` `configure`
+export.** `test.override('configureApp', ...)` replaces that default outright — an override
+that doesn't call the real `configure(configurator, args)` itself, as below, skips the app's
+production module setup entirely rather than composing with it.
+
 ```tsx
 import { test } from '@equinor/fusion-framework-vitest-plugin-react-app/test';
 import { enableContextMock } from '@equinor/fusion-framework-module-context/mock';
@@ -69,7 +78,7 @@ import { configure } from '../config'; // the app's own, real module configurato
 const project = { id: 'project-a', title: 'Project A', type: { id: 'ProjectMaster' }, value: {} };
 
 describe('with an initial project', () => {
-  test.override('configure', { injected: true }, () => (configurator, args) => {
+  test.override('configureApp', { injected: true }, () => (configurator, args) => {
     configure(configurator, args); // compose the app's real configure, same as `.extend`
     enableContextMock(configurator, (mock) => mock.setCurrentContext(project));
   });
@@ -82,7 +91,7 @@ describe('with an initial project', () => {
 ```
 
 `fusion` itself can be overridden the same way, when a case needs a differently configured
-parent framework instance rather than a change to the app's own `configure`:
+parent framework instance rather than a change to the app's own `configureApp`:
 
 ```tsx
 describe('with a parent framework context', () => {
@@ -118,6 +127,45 @@ running portal.
 Use [`enableAppManifestMock`](../../../app/docs/testing.md#enableappmanifestmockconfigurator-env)
 when the custom parent must serve the app's manifest and config. Use
 [`mockFramework`](../../../framework/docs/testing.md) to seed the parent modules.
+
+## Extend the parent framework mock with `configureFusion`
+
+`fusion` (built by [`resolveFusion`](../src/scope/resolve-fusion.ts)) always carries a mocked
+`app` module (serving this app's manifest) and a `navigation` module with real browser history,
+matching Browser Mode. `configureFusion` runs on the same configurator afterwards, so a test can
+register extra framework-level modules or override that setup, without reimplementing it:
+
+```tsx
+import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
+
+const test = baseTest.extend('configureFusion', { injected: true }, () => (configurator) => {
+  enableFeatureFlagMock(configurator);
+  configurator.serviceDiscovery.addServices([{ key: 'people', uri: baseUrl('people') }]);
+});
+```
+
+Note this is a **framework-scope** module set, distinct from the app-scope one `configureApp`
+seeds. A typical app registers its own `navigation` module independently, inside its own
+`config.ts`'s `configure` callback (what `configureApp` composes with) — so overriding history
+through `configureFusion` only affects framework-scope consumers, such as
+`useFramework<[NavigationModule]>().modules.navigation` or `useBookmarkNavigate`, not a
+rendered app's own router:
+
+```tsx
+import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
+
+test.override('configureFusion', { injected: true }, () => (configurator) =>
+  enableNavigation(configurator, {
+    configure: (config) => config.setHistory(createHistory('memory')),
+  }),
+);
+```
+
+**`.override('fusion', ...)` bypasses `configureFusion` entirely** — it replaces the resolver
+that calls it, so a `configureFusion` override on the same test/suite is silently never called.
+Reach for `configureFusion` to extend the base mock; reach for `fusion` only to replace it
+outright (e.g. with a fully custom or non-mocked instance) — see
+[Supply a custom parent framework](#supply-a-custom-parent-framework) above.
 
 ## Test routes and app lifecycle
 

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -15,7 +15,7 @@ and the general `test.extend`/`test.override` mechanics Fusion builds on.
 | `test` from `/test` | The app's manifest, config, and module configurator should resolve automatically |
 | `render` from `/test` | A standard `describe` or `it` block needs the automatically resolved app scope |
 | `renderAppHook` | A hook needs an app scope with explicitly supplied options |
-| `renderAppComponent` | A component needs explicit `env`, `configureApp`, or parent `fusion` options |
+| `renderAppComponent` | A component needs explicit `env`, `configure`, or parent `fusion` options |
 | `testApp` | A reusable fixture should not depend on Vite's automatic app-file resolution |
 
 All Fusion rendering APIs initialize modules asynchronously and must be awaited. The lower

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -1,6 +1,6 @@
 # Advanced Fusion app testing
 
-The `/test` entry point extends Vitest's test context with `env`, `configureApp`, `configureFusion`,
+The `/test` entry point extends Vitest's test context with `appEnv`, `configureApp`, `configureFusion`,
 `fusion`, `app`, `render`, and `renderHook`. Fixture declarations are reusable, while each test
 receives fresh framework and app module instances.
 
@@ -55,6 +55,22 @@ feature-flag, HTTP, analytics, and telemetry boundaries.
 *files* need the same fixture default. Within one file, prefer `test.override(...)` (below):
 it replaces a fixture in place, so every test in that file keeps importing the same `test`.
 
+## Fake an endpoint URL with `mergeEnvConfig`
+
+`appEnv`'s `config` is an `AppConfig` instance — its `environment`/`endpoints` live behind
+private fields exposed only through getters, so `{ ...appEnv.config, endpoints: {...} }` copies
+nothing and silently drops the rest of the config. Use `mergeEnvConfig` to fake one endpoint's
+URL (e.g. the app's real backend, resolved from `app.config.ts`) while keeping every other
+endpoint and environment variable intact:
+
+```tsx
+import { mergeEnvConfig, test as baseTest } from '@equinor/fusion-framework-vitest-plugin-react-app/test';
+
+export const test = baseTest.extend('appEnv', ({ appEnv }) =>
+  mergeEnvConfig(appEnv, { endpoints: { 'cpr-api': { url: backendBaseUrl } } }),
+);
+```
+
 ## Override a fixture for one test or a `describe` block
 
 `test.override('name', ...)` replaces a fixture's resolved value without creating a new `test`
@@ -95,9 +111,9 @@ parent framework instance rather than a change to the app's own `configureApp`:
 
 ```tsx
 describe('with a parent framework context', () => {
-  test.override('fusion', async ({ env }) =>
+  test.override('fusion', async ({ appEnv }) =>
     mockFramework<[AppModule, ContextModule]>((configurator) => {
-      enableAppManifestMock(configurator, env);
+      enableAppManifestMock(configurator, appEnv);
       enableContextMock(configurator, (mock) => mock.setCurrentContext(project));
     }),
   );

--- a/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
+++ b/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
@@ -26,7 +26,7 @@ Browser Mode by providing its own renderer. See
 | `@testing-library/react`'s `render`/`renderHook`/`waitFor`/`act`, on `jsdom` or `happy-dom` | `vitest-browser-react`'s `render`/`renderHook` and `vitest`'s `waitFor`/`act`, on real Chromium (Vitest Browser Mode) |
 | `vi.mock('@equinor/fusion-framework-react/hooks', ...)`, `vi.mock('.../feature-flag', ...)`, and similar hand-rolled Fusion hook mocks | The owning module's `enable*Mock` from its own `/mock` entry point. See [Module mocks](module-mocks.md) |
 | A hand-written mock HTTP server (MirageJS, `msw/node`, `nock`) answering every backend call | `configurator.http.addMiddleware(...)` with a hand-written `HttpMiddleware`, or `createRouterMiddleware` for several routes under one base URI. See [HTTP testing](../../../modules/http/docs/testing.md) |
-| A hand-rolled test wrapper composing a router, context providers, and error boundaries around every render | `test.extend(...)` fixtures stacked on the base `render`/`configure` fixtures. See [Compose a router and a domain fixture](#compose-a-router-and-a-domain-fixture) below |
+| A hand-rolled test wrapper composing a router, context providers, and error boundaries around every render | `test.extend(...)` fixtures stacked on the base `render`/`configureApp` fixtures. See [Compose a router and a domain fixture](#compose-a-router-and-a-domain-fixture) below |
 | Synchronous assertions (`expect(screen.getByText(...))`) | Browser locators and `await expect.element(screen.getByText(...)).toBeVisible()` |
 
 ## Step 1: install Browser Mode dependencies
@@ -71,8 +71,8 @@ bookmark modules:
 +import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
 +import { test as baseTest } from '@equinor/fusion-framework-vitest-plugin-react-app/test';
 +
-+export const test = baseTest.extend('configure', ({ configure }) => (configurator, args) => {
-+  configure?.(configurator, args);
++export const test = baseTest.extend('configureApp', ({ configureApp }) => (configurator, args) => {
++  configureApp?.(configurator, args);
 +  configurator.msal.setAccount(null); // was: useCurrentUser returning undefined
 +  enableFeatureFlagMock(configurator, (mock) => mock.addFeature({ key: 'new-search', enabled: true }));
 +});
@@ -113,7 +113,7 @@ Use `createRouterMiddleware` for a mock server that handles several routes under
 +});
 ```
 
-Register the result with `configurator.http.addMiddleware(activityRoutes)` inside a `configure`
+Register the result with `configurator.http.addMiddleware(activityRoutes)` inside a `configureApp`
 fixture (see step 4). Port one route file at a time. Each ported file is independently testable.
 An unported route can fall through to the real network, so keep the old interceptor
 for tests that have not migrated yet or add a final fail-closed middleware; do not rely on a
@@ -128,7 +128,7 @@ router for the base URI used by the real client.
 ## Compose a router and a domain fixture
 
 Use a `render` extension for JSX wrappers such as routers and app-owned React providers. Use a
-`configure` extension for Fusion module state. Stack both extensions when a test needs both:
+`configureApp` extension for Fusion module state. Stack both extensions when a test needs both:
 
 ```tsx
 import type { ReactElement } from 'react';
@@ -143,9 +143,9 @@ const testWithRouter = baseTest.extend('render', () => (ui: ReactElement) => {
   return baseTest.render(<Router routes={routes} />);
 });
 
-// The domain fixture uses the same shape as any other `configure` extension.
-export const test = testWithRouter.extend('configure', ({ configure }) => (configurator, args) => {
-  configure?.(configurator, args);
+// The domain fixture uses the same shape as any other `configureApp` extension.
+export const test = testWithRouter.extend('configureApp', ({ configureApp }) => (configurator, args) => {
+  configureApp?.(configurator, args);
   enableContextMock(configurator, (mock) => mock.setCurrentContext(projectA));
 });
 ```
@@ -153,7 +153,7 @@ export const test = testWithRouter.extend('configure', ({ configure }) => (confi
 A test importing this `test` gets both the router wrapper and seeded Fusion context.
 
 Keep app-owned React providers, such as authorization, schema, or snackbar providers, in the
-`render` extension. Move only Fusion module state to `configure` and `enable*Mock`.
+`render` extension. Move only Fusion module state to `configureApp` and `enable*Mock`.
 
 ## Step 4: update renders and assertions
 

--- a/packages/vitest-plugin/react-app/docs/module-mocks.md
+++ b/packages/vitest-plugin/react-app/docs/module-mocks.md
@@ -93,8 +93,8 @@ const project = {
   value: {},
 };
 
-export const test = baseTest.extend('configure', ({ configure }) => (configurator, args) => {
-  configure?.(configurator, args);
+export const test = baseTest.extend('configureApp', ({ configureApp }) => (configurator, args) => {
+  configureApp?.(configurator, args);
   configurator.msal.setAccount({ name: 'Ada Lovelace' });
   enableContextMock(configurator, (mock) => mock.setCurrentContext(project));
   enableFeatureFlagMock(configurator, (mock) => {

--- a/packages/vitest-plugin/react-app/package.json
+++ b/packages/vitest-plugin/react-app/package.json
@@ -57,6 +57,7 @@
     "@equinor/fusion-framework-cli": "workspace:*",
     "@equinor/fusion-framework-module": "workspace:*",
     "@equinor/fusion-framework-module-app": "workspace:*",
+    "@equinor/fusion-framework-module-navigation": "workspace:*",
     "@equinor/fusion-framework-react": "workspace:*",
     "@equinor/fusion-framework-react-module": "workspace:*",
     "@equinor/fusion-imports": "workspace:*"

--- a/packages/vitest-plugin/react-app/src/__tests__/merge-env-config.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/merge-env-config.test.ts
@@ -1,0 +1,67 @@
+import { AppConfig } from '@equinor/fusion-framework-module-app';
+import type { AppEnv } from '@equinor/fusion-framework-app';
+import { describe, expect, it } from 'vitest';
+
+import { mergeEnvConfig } from '../merge-env-config.js';
+
+describe('mergeEnvConfig', () => {
+  const baseEnv: AppEnv = {
+    manifest: {
+      appKey: 'test-app',
+      displayName: 'Test App',
+      description: 'A test application',
+      type: 'standalone',
+    },
+    config: new AppConfig({
+      environment: { foo: 'bar' },
+      endpoints: { api: { url: 'https://api.example.com', scopes: ['api.read'] } },
+    }),
+  };
+
+  it('adds a new endpoint without dropping existing ones', () => {
+    const merged = mergeEnvConfig(baseEnv, {
+      endpoints: { 'cpr-api': { url: 'https://cpr.example.com' } },
+    });
+
+    expect(merged.config?.endpoints).toEqual({
+      api: { url: 'https://api.example.com', scopes: ['api.read'] },
+      'cpr-api': { url: 'https://cpr.example.com', scopes: [] },
+    });
+  });
+
+  it('overrides one field of an existing endpoint, keeping the rest', () => {
+    const merged = mergeEnvConfig(baseEnv, {
+      endpoints: { api: { url: 'https://fake.example.com' } },
+    });
+
+    expect(merged.config?.endpoints.api).toEqual({
+      url: 'https://fake.example.com',
+      scopes: ['api.read'],
+    });
+  });
+
+  it('merges environment overrides over the existing environment', () => {
+    const merged = mergeEnvConfig(baseEnv, { environment: { baz: 'qux' } });
+
+    expect(merged.config?.environment).toEqual({ foo: 'bar', baz: 'qux' });
+  });
+
+  it('leaves the original env and its config untouched', () => {
+    mergeEnvConfig(baseEnv, { endpoints: { api: { url: 'https://fake.example.com' } } });
+
+    expect(baseEnv.config?.endpoints.api).toEqual({
+      url: 'https://api.example.com',
+      scopes: ['api.read'],
+    });
+  });
+
+  it('handles an env with no existing config', () => {
+    const env: AppEnv = { manifest: baseEnv.manifest };
+    const merged = mergeEnvConfig(env, { endpoints: { api: { url: 'https://api.example.com' } } });
+
+    expect(merged.config?.endpoints).toEqual({
+      api: { url: 'https://api.example.com', scopes: [] },
+    });
+    expect(merged.config?.environment).toEqual({});
+  });
+});

--- a/packages/vitest-plugin/react-app/src/app-test.ts
+++ b/packages/vitest-plugin/react-app/src/app-test.ts
@@ -9,6 +9,7 @@ export {
   type RenderAppComponentResult,
 } from './render-app-component';
 export { testApp } from './test-app';
+export { mergeEnvConfig, type MergeEnvConfigOverrides } from './merge-env-config.js';
 export type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
 
 // `test`/`render` import virtual modules only served once `appTestVitePlugin`

--- a/packages/vitest-plugin/react-app/src/merge-env-config.ts
+++ b/packages/vitest-plugin/react-app/src/merge-env-config.ts
@@ -1,0 +1,58 @@
+import { AppConfig } from '@equinor/fusion-framework-module-app';
+import type { ConfigEnvironment } from '@equinor/fusion-framework-module-app';
+import type { AppEnv } from '@equinor/fusion-framework-app';
+
+type EndpointOverride = Partial<NonNullable<AppEnv['config']>['endpoints'][string]>;
+
+/**
+ * Overrides accepted by {@link mergeEnvConfig}.
+ */
+export type MergeEnvConfigOverrides<TConfig extends ConfigEnvironment = ConfigEnvironment> = {
+  environment?: Partial<TConfig>;
+  endpoints?: Record<string, EndpointOverride>;
+};
+
+/**
+ * Merges `environment`/`endpoints` overrides into an `AppEnv`'s `config`.
+ *
+ * @remarks
+ * `AppConfig` stores both behind private fields exposed only through getters, so
+ * `{ ...env.config, endpoints: {...} }` silently drops everything it doesn't explicitly
+ * restate — a plain object spread copies no own enumerable properties off an `AppConfig`
+ * instance. Reach for this instead of hand-rolling that merge in a test fixture.
+ *
+ * @template TEnv - The `AppEnv` shape being merged into.
+ * @param env - The `AppEnv` to merge overrides into; left untouched, `config` may be omitted.
+ * @param overrides - Partial `environment`/`endpoints` values, merged over any existing config.
+ * @returns A new `AppEnv` with a new `AppConfig` reflecting the merge.
+ * @example
+ * ```ts
+ * const test = testApp.extend('appEnv', ({ appEnv }) =>
+ *   mergeEnvConfig(appEnv, { endpoints: { 'cpr-api': { url: backendBaseUrl } } }),
+ * );
+ * ```
+ */
+export function mergeEnvConfig<TEnv extends AppEnv = AppEnv>(
+  env: TEnv,
+  overrides: MergeEnvConfigOverrides<
+    TEnv['config'] extends AppConfig<infer TConfig> ? TConfig : ConfigEnvironment
+  >,
+): TEnv {
+  // each overridden endpoint keeps any field the caller didn't explicitly override
+  const endpoints = Object.entries(overrides.endpoints ?? {}).reduce(
+    // defaults, then any existing endpoint, then the override (override wins)
+    (acc, [key, override]) =>
+      Object.assign(acc, { [key]: Object.assign({ url: '', scopes: [] }, acc[key], override) }),
+    { ...env.config?.endpoints },
+  );
+  // caller-supplied environment values win over the existing ones
+  return {
+    ...env,
+    config: new AppConfig({
+      environment: { ...env.config?.environment, ...overrides.environment },
+      endpoints,
+    }),
+  };
+}
+
+export default mergeEnvConfig;

--- a/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
+++ b/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
@@ -46,11 +46,11 @@ export type ResolveAppTestEnvOptions = {
  * back to an empty config if none exists.
  *
  * @remarks
- * Intended to seed `@equinor/fusion-framework-vitest-plugin-react-app/test`'s `testApp` `env` fixture, so
+ * Intended to seed `@equinor/fusion-framework-vitest-plugin-react-app/test`'s `testApp` `appEnv` fixture, so
  * a test suite exercises the application's real manifest/config instead of a hand-maintained
  * duplicate. Anything a specific test still needs faked (a missing endpoint, a different
- * `appKey`) can be layered on top with `testApp.extend('env', ...)` or a per-test
- * `test.override('env', ...)`.
+ * `appKey`) can be layered on top with `testApp.extend('appEnv', ...)` or a per-test
+ * `test.override('appEnv', ...)`.
  *
  * @param options - Resolution options; `entrypoint` defaults to the current working directory.
  * @returns The resolved application manifest and config.
@@ -63,7 +63,7 @@ export type ResolveAppTestEnvOptions = {
  * import { configure } from '../config';
  *
  * const test = testApp
- *   .extend('env', { injected: true }, () => resolveAppTestEnv())
+ *   .extend('appEnv', { injected: true }, () => resolveAppTestEnv())
  *   .extend('configureApp', { injected: true }, () => configure);
  * ```
  */

--- a/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
+++ b/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
@@ -64,7 +64,7 @@ export type ResolveAppTestEnvOptions = {
  *
  * const test = testApp
  *   .extend('env', { injected: true }, () => resolveAppTestEnv())
- *   .extend('configure', { injected: true }, () => configure);
+ *   .extend('configureApp', { injected: true }, () => configure);
  * ```
  */
 export const resolveAppTestEnv = async (

--- a/packages/vitest-plugin/react-app/src/scope/resolve-app-scope.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-app-scope.ts
@@ -40,7 +40,7 @@ export async function resolveAppScope<
 }): Promise<AppScope<TModules>> {
   const { configure, env, fusion: providedFusion } = options ?? {};
   const resolvedEnv = env ?? (defaultAppEnv as TEnv);
-  const framework = await resolveFusion(resolvedEnv, providedFusion);
+  const framework = await resolveFusion({ env: resolvedEnv, fusion: providedFusion });
   const app = await mockAppModules(configure, resolvedEnv, framework);
   return { framework, app };
 }

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -1,8 +1,10 @@
 import type { AppEnv } from '@equinor/fusion-framework-app';
 import type { Fusion } from '@equinor/fusion-framework';
-import { mockFramework } from '@equinor/fusion-framework/mock';
+import { mockFramework, type FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
 import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
+import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
 
 import { defaultAppEnv } from './default-app-env';
 
@@ -12,18 +14,27 @@ import { defaultAppEnv } from './default-app-env';
  * given.
  *
  * @template TEnv - The application environment descriptor.
- * @param env - The application environment; defaults to {@link defaultAppEnv}.
- * @param fusion - An already-built parent Fusion instance to reuse instead.
+ * @param options - `env` seeds the built-in app manifest mock; navigation defaults to real
+ *   browser history, matching Browser Mode. `configure` runs afterwards on the same
+ *   configurator — e.g. call `enableNavigation` again to override the history, or register
+ *   extra modules and service discovery entries. `fusion`, an already-built parent instance,
+ *   is reused as-is and skips `configure` entirely.
  * @returns The given `fusion`, or a fresh mocked parent Fusion instance.
  */
-export async function resolveFusion<TEnv extends AppEnv = AppEnv>(
-  env?: TEnv,
-  fusion?: Fusion,
-): Promise<Fusion> {
+export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
+  env?: TEnv;
+  fusion?: Fusion;
+  configure?: FrameworkMockConfigureFn<[AppModule, NavigationModule]>;
+}): Promise<Fusion> {
+  const { env, fusion, configure } = options ?? {};
   return (
     fusion ??
-    mockFramework<[AppModule]>((configurator) =>
-      enableAppManifestMock(configurator, env ?? (defaultAppEnv as TEnv)),
-    )
+    mockFramework<[AppModule, NavigationModule]>(async (configurator) => {
+      enableAppManifestMock(configurator, env ?? (defaultAppEnv as TEnv));
+      enableNavigation(configurator, {
+        configure: (config) => config.setHistory(createHistory('browser')),
+      });
+      await configure?.(configurator);
+    })
   );
 }

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -17,7 +17,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  *
  * @remarks
  * An alternative to {@link renderAppComponent}/{@link renderAppHook} for a test file whose
- * cases share seeded fixture defaults: `env`/`configureApp` become suite-level concerns,
+ * cases share seeded fixture defaults: `appEnv`/`configureApp` become suite-level concerns,
  * overridden once per file (or per `describe` block) with `testApp.extend(...)`, rather than
  * an options object repeated on every call. `fusion`/`app` are still instantiated fresh per
  * test — only the seeded defaults are shared, not state between tests. They also resolve
@@ -77,7 +77,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  * ```
  */
 export const testApp = baseTest
-  .extend('env', { injected: true }, defaultAppEnv)
+  .extend('appEnv', { injected: true }, defaultAppEnv)
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
   .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
@@ -92,11 +92,11 @@ export const testApp = baseTest
   // IMPORTANT: `.override('fusion', ...)` replaces this resolver entirely, so `configureFusion`
   // is never called — reach for `configureFusion` to extend the base mock, `fusion` only to
   // replace it outright (e.g. with a fully custom or non-mocked instance).
-  .extend('fusion', async ({ env, configureFusion }) =>
-    resolveFusion({ env, configure: configureFusion }),
+  .extend('fusion', async ({ appEnv, configureFusion }) =>
+    resolveFusion({ env: appEnv, configure: configureFusion }),
   )
-  .extend('app', async ({ configureApp, env, fusion }) =>
-    mockAppModules<unknown, AppEnv>(configureApp, env as AppEnv, fusion),
+  .extend('app', async ({ configureApp, appEnv, fusion }) =>
+    mockAppModules<unknown, AppEnv>(configureApp, appEnv as AppEnv, fusion),
   )
   .extend('render', ({ fusion, app }) => {
     const wrapper = createAppScopeWrapper({ framework: fusion, app });

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -6,6 +6,9 @@ import type { RenderOptions, RenderHookOptions } from 'vitest-browser-react';
 import { mockAppModules } from '@equinor/fusion-framework-app/mock';
 import type { AppMockConfigureFn } from '@equinor/fusion-framework-app/mock';
 import type { AppEnv } from '@equinor/fusion-framework-app';
+import type { AppModule } from '@equinor/fusion-framework-module-app';
+import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
+import type { FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
 
 import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
 
@@ -14,7 +17,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  *
  * @remarks
  * An alternative to {@link renderAppComponent}/{@link renderAppHook} for a test file whose
- * cases share seeded fixture defaults: `env`/`configure` become suite-level concerns,
+ * cases share seeded fixture defaults: `env`/`configureApp` become suite-level concerns,
  * overridden once per file (or per `describe` block) with `testApp.extend(...)`, rather than
  * an options object repeated on every call. `fusion`/`app` are still instantiated fresh per
  * test — only the seeded defaults are shared, not state between tests. They also resolve
@@ -24,6 +27,19 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  * Both entry points stay supported: reach for `renderAppComponent`/`renderAppHook` for a
  * one-off test whose configuration is not shared by the rest of the file; reach for
  * `testApp` when several cases in a file share one set of seeded fixture defaults.
+ *
+ * @remarks `configureApp`/`configureFusion` default to `undefined` here
+ * Unlike `@equinor/fusion-framework-vitest-plugin-react-app/test`'s `test`, this `testApp` does
+ * not resolve the app's real `src/config.ts` — it requires `appTestVitePlugin`'s Vite virtual
+ * modules to load that file as live code, which `testApp` (no Vite dependency) cannot do. Extend
+ * `test` from `/test` instead when a suite needs to compose with the app's real configuration.
+ *
+ * @remarks Overriding `fusion` bypasses `configureFusion`
+ * `fusion` and `configureFusion` are not independent: `fusion`'s default resolver is what
+ * calls `configureFusion`. `.override('fusion', ...)` replaces that resolver outright, so a
+ * `configureFusion` override on the same test/suite is silently never called. Use
+ * `configureFusion` to extend the base framework mock; use `fusion` only to replace it
+ * entirely (e.g. with a fully custom or non-mocked instance).
  *
  * @example
  * ```tsx
@@ -36,7 +52,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  * @example Seed a module for every test in a suite
  * ```tsx
  * describe('with a seeded context module', () => {
- *   const test = testApp.extend('configure', { injected: true }, () =>
+ *   const test = testApp.extend('configureApp', { injected: true }, () =>
  *     (configurator) => enableContextMock(configurator, (mock) => mock.setCurrentContext(projectA)),
  *   );
  *
@@ -46,15 +62,41 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  *   });
  * });
  * ```
+ *
+ * @example Extend the parent framework mock with an application module
+ * ```tsx
+ * const test = testApp.extend('configureFusion', { injected: true }, () =>
+ *   (configurator) => {
+ *     enableFeatureFlagMock(configurator);
+ *     configurator.serviceDiscovery.addServices([
+ *       { key: 'people', uri: baseUrl('people') },
+ *       { key: 'context', uri: baseUrl('context') },
+ *     ]);
+ *   },
+ * );
+ * ```
  */
 export const testApp = baseTest
   .extend('env', { injected: true }, defaultAppEnv)
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
-  .extend('configure', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
-  .extend('fusion', async ({ env }) => resolveFusion(env))
-  .extend('app', async ({ configure, env, fusion }) =>
-    mockAppModules<unknown, AppEnv>(configure, env as AppEnv, fusion),
+  .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
+  // Runs after the built-in app manifest/navigation setup, so a test can register extra
+  // framework modules, service discovery entries, or call `enableNavigation` again to
+  // override the history, without reimplementing the base setup.
+  .extend(
+    'configureFusion',
+    { injected: true },
+    () => undefined as FrameworkMockConfigureFn<[AppModule, NavigationModule]> | undefined,
+  )
+  // IMPORTANT: `.override('fusion', ...)` replaces this resolver entirely, so `configureFusion`
+  // is never called — reach for `configureFusion` to extend the base mock, `fusion` only to
+  // replace it outright (e.g. with a fully custom or non-mocked instance).
+  .extend('fusion', async ({ env, configureFusion }) =>
+    resolveFusion({ env, configure: configureFusion }),
+  )
+  .extend('app', async ({ configureApp, env, fusion }) =>
+    mockAppModules<unknown, AppEnv>(configureApp, env as AppEnv, fusion),
   )
   .extend('render', ({ fusion, app }) => {
     const wrapper = createAppScopeWrapper({ framework: fusion, app });

--- a/packages/vitest-plugin/react-app/src/test.tsx
+++ b/packages/vitest-plugin/react-app/src/test.tsx
@@ -15,7 +15,7 @@ import { configure as configureApp } from 'virtual:fusion-app-test-configure';
  * Running the same test file without the plugin registered fails to resolve those imports.
  *
  * Per-test mocking still works exactly like the base `testApp`: `.extend('configureApp', ...)` or
- * a per-case `test.override('env', ...)` layers on top of the resolved values.
+ * a per-case `test.override('appEnv', ...)` layers on top of the resolved values.
  *
  * @remarks `.override('configureApp', ...)` replaces the app's real `configure`
  * This fixture's default value *is* the app's real `src/config.ts` `configure` export.
@@ -36,7 +36,7 @@ import { configure as configureApp } from 'virtual:fusion-app-test-configure';
  * ```
  */
 export const test = baseTestApp
-  .extend('env', { injected: true }, { manifest, config })
+  .extend('appEnv', { injected: true }, { manifest, config })
   .extend('configureApp', { injected: true }, () => configureApp);
 
 export default test;

--- a/packages/vitest-plugin/react-app/src/test.tsx
+++ b/packages/vitest-plugin/react-app/src/test.tsx
@@ -3,7 +3,7 @@ import { testApp as baseTestApp } from './test-app';
 // resolved at test-time by `appTestVitePlugin` (@equinor/fusion-framework-vitest-plugin-react-app);
 // see virtual-modules.d.ts for the ambient module declarations
 import { manifest, config } from 'virtual:fusion-app-test-env';
-import { configure } from 'virtual:fusion-app-test-configure';
+import { configure as configureApp } from 'virtual:fusion-app-test-configure';
 
 /**
  * `vitest`'s `test`, pre-seeded with the application's own manifest, config, and
@@ -14,8 +14,15 @@ import { configure } from 'virtual:fusion-app-test-configure';
  * your `vitest.config.ts` `plugins`, which serves the virtual modules backing this fixture.
  * Running the same test file without the plugin registered fails to resolve those imports.
  *
- * Per-test mocking still works exactly like the base `testApp`: `.extend('configure', ...)` or
+ * Per-test mocking still works exactly like the base `testApp`: `.extend('configureApp', ...)` or
  * a per-case `test.override('env', ...)` layers on top of the resolved values.
+ *
+ * @remarks `.override('configureApp', ...)` replaces the app's real `configure`
+ * This fixture's default value *is* the app's real `src/config.ts` `configure` export.
+ * `.override('configureApp', ...)` replaces that default outright, so an override that doesn't
+ * itself call the real `configure(configurator, args)` skips the app's production module setup
+ * entirely, rather than composing with it. See [Advanced usage](../docs/advanced.md) for the
+ * compose-safely pattern.
  *
  * @example
  * ```tsx
@@ -30,6 +37,6 @@ import { configure } from 'virtual:fusion-app-test-configure';
  */
 export const test = baseTestApp
   .extend('env', { injected: true }, { manifest, config })
-  .extend('configure', { injected: true }, () => configure);
+  .extend('configureApp', { injected: true }, () => configureApp);
 
 export default test;

--- a/packages/vitest-plugin/react-app/tsconfig.json
+++ b/packages/vitest-plugin/react-app/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "../../app" },
     { "path": "../../modules/module" },
     { "path": "../../modules/app" },
+    { "path": "../../modules/navigation" },
     { "path": "../../react/framework" },
     { "path": "../../react/modules/module" },
     { "path": "../../utils/imports" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   cookbooks/app-react:
     devDependencies:
@@ -130,7 +130,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -451,7 +451,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -570,7 +570,7 @@ importers:
         version: 1.62.1
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -618,7 +618,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -660,7 +660,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -800,7 +800,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -1170,7 +1170,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/cli:
     dependencies:
@@ -1312,7 +1312,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/cli-plugins/ai-base:
     dependencies:
@@ -1340,7 +1340,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/cli-plugins/ai-chat:
     dependencies:
@@ -1371,7 +1371,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/cli-plugins/ai-index:
     dependencies:
@@ -1441,7 +1441,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/cli-plugins/copilot:
     dependencies:
@@ -1607,7 +1607,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -1635,7 +1635,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/framework:
     dependencies:
@@ -1672,7 +1672,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/linting/cli:
     dependencies:
@@ -1728,7 +1728,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/linting/lsp:
     dependencies:
@@ -1769,7 +1769,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/linting/vscode:
     dependencies:
@@ -1852,7 +1852,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/analytics:
     dependencies:
@@ -1910,7 +1910,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/app:
     dependencies:
@@ -1959,7 +1959,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/azure-identity:
     dependencies:
@@ -1975,7 +1975,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
     optionalDependencies:
       '@azure/identity-cache-persistence':
         specifier: ^1.3.0
@@ -2031,7 +2031,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -2127,7 +2127,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/http:
     dependencies:
@@ -2149,7 +2149,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/module:
     dependencies:
@@ -2168,7 +2168,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/msal:
     dependencies:
@@ -2212,7 +2212,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
     optionalDependencies:
       '@azure/msal-node-extensions':
         specifier: ^5.0.2
@@ -2253,7 +2253,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/service-discovery:
     dependencies:
@@ -2306,7 +2306,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/signalr:
     dependencies:
@@ -2392,7 +2392,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/telemetry:
     dependencies:
@@ -2423,7 +2423,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/modules/widget:
     dependencies:
@@ -2481,7 +2481,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/react/ag-charts:
     dependencies:
@@ -2628,7 +2628,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -2683,7 +2683,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/react/components/people-resolver:
     dependencies:
@@ -2982,7 +2982,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/utils/imports:
     dependencies:
@@ -3007,7 +3007,7 @@ importers:
         version: 4.6.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.2)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/utils/load-env:
     dependencies:
@@ -3023,7 +3023,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/utils/log:
     dependencies:
@@ -3039,7 +3039,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/utils/observable:
     dependencies:
@@ -3073,7 +3073,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -3098,7 +3098,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/utils/query:
     dependencies:
@@ -3129,7 +3129,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/vite-plugins/api-service:
     dependencies:
@@ -3157,7 +3157,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/vite-plugins/markdown:
     devDependencies:
@@ -3190,7 +3190,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
 
   packages/vite-plugins/routes-dsl:
     devDependencies:
@@ -3267,6 +3267,9 @@ importers:
       '@equinor/fusion-framework-module-app':
         specifier: workspace:*
         version: link:../../modules/app
+      '@equinor/fusion-framework-module-navigation':
+        specifier: workspace:*
+        version: link:../../modules/navigation
       '@equinor/fusion-framework-react':
         specifier: workspace:*
         version: link:../../react/framework
@@ -3306,7 +3309,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -3355,7 +3358,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       vue:
         specifier: ^3.5.25
         version: 3.5.41(typescript@7.0.2)
@@ -11959,6 +11962,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -16590,7 +16594,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16604,7 +16608,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16617,7 +16621,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.2)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16634,7 +16638,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
@@ -16652,7 +16656,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
@@ -16669,7 +16673,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.2)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
@@ -21718,7 +21722,7 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -21767,49 +21771,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))(vitest@4.1.10)
-      happy-dom: 20.8.9
-      jsdom: 30.0.1
-    transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.1)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
@@ -21838,20 +21800,40 @@ snapshots:
       happy-dom: 20.8.9
       jsdom: 30.0.1
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(esbuild@0.28.2)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))(vitest@4.1.10)
+      happy-dom: 20.8.9
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(happy-dom@20.8.9)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.1)(tsx@4.23.12))
@@ -21880,18 +21862,7 @@ snapshots:
       happy-dom: 20.8.9
       jsdom: 30.0.1
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-jsonrpc@8.2.1(patch_hash=d78796f2e6ae0a6c190cb4da47138eafba7404e190b66f5ac22b382e16f04eca): {}
 


### PR DESCRIPTION
**Why is this change needed?**
`@equinor/fusion-framework-vitest-plugin-react-app`'s `testApp`/`test` fixtures had a `configure` fixture (app-scope module mock) and a new `configureFramework` fixture (parent-framework-scope module mock, added to let tests extend the built-in app-manifest/navigation setup instead of replacing it via `.override('fusion', ...)`). Having both `configure` and `configureFramework` side by side read as if they did the same thing, which is confusing.

**What is the current behavior?**
The app-scope fixture was named `configure`, and the framework-scope fixture was named `configureFramework`.

**What is the new behavior?**
- `configure` → `configureApp` (app-scope module mock, unchanged behavior).
- `configureFramework` → `configureFusion` (parent Fusion/framework-scope module mock, unchanged behavior), for symmetry with `fusion`/`app`.
- Updated all cookbook and package consumers (`app-react-context`, `app-react-module`, `app-react-msal`, `app-react-router`, `packages/react/app`), and docs (`README.md`, `docs/advanced.md`, `docs/migrating-an-existing-app.md`, `docs/module-mocks.md`).
- Expanded `docs/advanced.md` with a dedicated `configureFusion` section (replacing a stale "Override the navigation history mode" section that predated the fixture) and clarified that `testApp` (unlike `/test`'s `test`) does not auto-resolve the app's real `src/config.ts`.
- The imperative `renderAppComponent`/`renderAppHook` helpers' own `configure` option is unaffected — this rename is scoped to the `testApp`/`test` fixture chain only.

**What is the intended behavior or invariant?**
`.override('fusion', ...)` bypasses `configureFusion` entirely (it replaces the resolver that calls it), and — for `/test`'s `test` — `.override('configureApp', ...)` bypasses the app's real `configure` entirely unless the override composes it in manually. Both are documented explicitly in the fixture TSDoc and `docs/advanced.md`.

**Does this PR introduce a breaking change?**
Yes — any consumer using `.extend('configure', ...)` or `.override('configure', ...)` on `testApp`/`test` needs to rename to `configureApp`.

**Impact assessment:**
- Breaking changes: Yes, for `@equinor/fusion-framework-vitest-plugin-react-app` consumers using the renamed fixture.
- Version bump: Major for `@equinor/fusion-framework-vitest-plugin-react-app`; patch (internal) for the four touched cookbooks.
- Consumer impact: Rename `configure` → `configureApp` in any `.extend`/`.override` call.
- Downstream impact: Cookbooks and `packages/react/app`'s test suite updated in this PR; no other known consumers in this monorepo.

**Review guidance:**
Verified via `pnpm --filter <pkg> exec tsc -b --force`, `pnpm exec biome check`, `pnpm exec fusion-lint lint`, and `pnpm exec vitest run` for all touched packages/cookbooks (all green; a small number of pre-existing, unrelated tsc errors in `app-react-router`/`app-react-module` confirmed via `git stash` to predate this change).

**Additional context**
None.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
