### PR TITLE
ci: add manual workflow to test turbo remote cache on fusion cluster runner

### DIFF
--- a/.github/workflows/test-turbo-cluster.yml
+++ b/.github/workflows/test-turbo-cluster.yml
@@ -1,0 +1,33 @@
+name: Test Turbo on Fusion Cluster
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  turbo-build:
+    name: Turbo build on self-hosted runner
+    runs-on: fusion-gh-runner-fusion-framework
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup node and install deps
+        uses: ./.github/actions/node-setup
+        with:
+          # disabled to isolate remote-cache behavior from the GH Actions .turbo cache
+          turbo-cache: false
+
+      - name: Turbo build
+        run: pnpm build --summarize
+
+      - name: Verify remote cache usage
+        run: |
+          summary=$(find .turbo/runs -name '*.json' -newer turbo.json | head -n1)
+          if [ -z "$summary" ]; then
+            echo "::error::No turbo run summary found"
+            exit 1
+          fi
+          echo "Cache sources found:"
+          jq -r '.tasks[].cache.source' "$summary" | sort | uniq -c


### PR DESCRIPTION
## What
Adds a manually-triggered (`workflow_dispatch`) workflow, `test-turbo-cluster.yml`, that runs `pnpm build` on `runs-on: fusion-gh-runner-fusion-framework` to validate turbo's remote cache against the self-hosted cluster runner.

## Why
Need to confirm `TURBO_API`/`TURBO_TOKEN`/`TURBO_TEAM` (set on the runner) are actually picked up and that build tasks hit the remote cache, not just local disk.

## Notes
- The GH Actions `.turbo` folder cache is disabled here (`turbo-cache: false`) to isolate remote-cache behavior.
- A verification step reads the turbo run summary and prints `cache.source` per task — should show `REMOTE` on a hit.
- Can be dispatched directly against this branch via `gh workflow run test-turbo-cluster.yml --ref test/turbo-cluster-workflow` without merging to main.
