### PR TITLE
ci: run Copilot coding agent on fusion cluster runner

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   copilot-setup-steps:
     name: Prepare Fusion Framework workspace
-    runs-on: ubuntu-latest
+    runs-on: fusion-gh-runner-fusion-framework
     # Copilot supplies its own token for repository access; this job only reads code.
     permissions:
       contents: read


### PR DESCRIPTION
Switches `copilot-setup-steps` in [copilot-setup-steps.yml](.github/workflows/copilot-setup-steps.yml) from `ubuntu-latest` to `fusion-gh-runner-fusion-framework`.

Note: this `runs-on` isn't just for this validation job — GitHub's Copilot coding agent uses the same job definition to provision its actual working environment for assigned issues. After this merges, Copilot sessions in this repo will execute on the self-hosted cluster runner instead of GitHub-hosted infra.