### PR TITLE
fix(vitest-plugin-react-app): memory-history + optional feature-flag mock defaults

### DIFF
--- a/.changeset/cookbook-app-react-router_stop-reading-window-location.md
+++ b/.changeset/cookbook-app-react-router_stop-reading-window-location.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-framework-cookbook-app-react-router": patch
+---
+
+Tests no longer read or seed `window.location`/`window.history`. Now that
+`resolveFusion` defaults navigation to in-memory history, real browser
+location never reflects the app's navigation state — assertions read
+`app.navigation.path.pathname` instead, and link `href` assertions match on
+path rather than full origin.

--- a/.changeset/vitest-plugin-react-app_exclude-dts-warmup.md
+++ b/.changeset/vitest-plugin-react-app_exclude-dts-warmup.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-vitest-plugin-react-app": patch
+---
+
+Exclude `.d.ts` files from the default `server.warmup.clientFiles` and `optimizeDeps.entries`
+globs in `defineProject`. Previously, an app shipping a CJS-style declaration file (for example
+one using `export =`) failed the Vite warmup scan, since it was loaded as ESM.

--- a/.changeset/vitest-plugin-react-app_optional-feature-flag-mock.md
+++ b/.changeset/vitest-plugin-react-app_optional-feature-flag-mock.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-framework-vitest-plugin-react-app": minor
+---
+
+`resolveFusion` (and both the `/test` fixtures and `testApp`) now enable the feature-flag
+mock by default, with no flags enabled, so `useFeature` needs no `localStorage` or URL
+seeding in tests.
+
+`@equinor/fusion-framework-module-feature-flag` is an optional peer dependency: the mock is
+only wired up when the package is actually installed, so apps that don't use feature flags
+aren't forced to add it. Install it to get the default mock; call `enableFeatureFlagMock`
+again inside `configureFusion` to seed specific flags.

--- a/.changeset/vitest-plugin-react-app_revert-memory-history.md
+++ b/.changeset/vitest-plugin-react-app_revert-memory-history.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-framework-vitest-plugin-react-app": patch
+---
+
+Revert the mocked framework's default navigation history from browser history back to in-memory
+history. Browser history leaked URL/history state between tests; `configureFusion`/`enableNavigation`
+can still opt back into browser history for a test that specifically needs it.

--- a/cookbooks/app-react-router/src/__tests__/routing-with-api-mock.test.tsx
+++ b/cookbooks/app-react-router/src/__tests__/routing-with-api-mock.test.tsx
@@ -9,7 +9,6 @@ import App from '../App';
 testWithApiMock(
   'navigates to Products and renders the loaded, seeded catalogue',
   async ({ render }) => {
-    window.history.pushState(null, '', '/');
     const { getByTitle, getByText, unmount } = await render(<App />);
 
     await getByTitle('Products').click();
@@ -23,7 +22,6 @@ testWithApiMock(
 testWithApiMock(
   'navigates to a product detail route and renders the loaded product',
   async ({ render, app }) => {
-    window.history.pushState(null, '', '/');
     const { getByText, unmount } = await render(<App />);
 
     app.navigation.navigate('/products/1');
@@ -37,7 +35,6 @@ testWithApiMock(
 testWithApiMock(
   'navigates to Users and renders the loaded, seeded directory',
   async ({ render }) => {
-    window.history.pushState(null, '', '/');
     const { getByTitle, getByText, unmount } = await render(<App />);
 
     await getByTitle('Users').click();

--- a/cookbooks/app-react-router/src/__tests__/routing.test.tsx
+++ b/cookbooks/app-react-router/src/__tests__/routing.test.tsx
@@ -32,20 +32,16 @@ test('navigates to a route nested under prefix() and renders it', async ({ rende
 });
 
 test('navigation module navigates the app to a new route', async ({ render, app }) => {
-  // the browser page (and its history) is shared across tests in this file, so start from a
-  // known location rather than assuming this is the first test to touch it
-  window.history.pushState(null, '', '/');
-
   const { getByRole, unmount } = await render(<App />);
 
-  expect(window.location.pathname).toBe('/');
+  expect(app.navigation.path.pathname).toBe('/');
 
   app.navigation.navigate('/pages/error-test');
 
   // error-test's loader always throws, so the router's error boundary is what renders here,
   // not the route's default-exported component.
   await expect.element(getByRole('heading', { name: /error encountered/i })).toBeInTheDocument();
-  expect(window.location.pathname).toBe('/pages/error-test');
+  expect(app.navigation.path.pathname).toBe('/pages/error-test');
 
   await unmount();
 });

--- a/cookbooks/app-react-router/src/components/Navigation.test.tsx
+++ b/cookbooks/app-react-router/src/components/Navigation.test.tsx
@@ -4,8 +4,6 @@ import { testWithRouter } from '../__tests__/test-with-router';
 import { Navigation } from './Navigation';
 
 testWithRouter('renders a sidebar link for each top-level page', async ({ render }) => {
-  window.history.pushState(null, '', '/');
-
   const { getByText, unmount } = await render(<Navigation />);
 
   await expect.element(getByText('Home')).toBeInTheDocument();
@@ -16,30 +14,26 @@ testWithRouter('renders a sidebar link for each top-level page', async ({ render
   await unmount();
 });
 
-testWithRouter('navigating to a page updates the URL', async ({ render }) => {
-  window.history.pushState(null, '', '/');
-
+testWithRouter('navigating to a page updates the URL', async ({ render, app }) => {
   const { getByText, unmount } = await render(<Navigation />);
 
   await getByText('Products').click();
 
-  expect(window.location.pathname).toBe('/products');
+  await vi.waitFor(() => expect(app.navigation.path.pathname).toBe('/products'));
 
   await unmount();
 });
 
-testWithRouter('the active link swaps when navigating to a different page', async ({ render }) => {
-  window.history.pushState(null, '', '/');
-
+testWithRouter('the active link swaps when navigating to a different page', async ({ render, app }) => {
   const { getByText, unmount } = await render(<Navigation />);
 
   // active state is only reflected as a styled-components color, not a DOM attribute
   const colorOf = (label: string) => getComputedStyle(getByText(label).element()).color;
 
   // navigate via the router's own click handler first, so its internal location is
-  // guaranteed to be in sync with the URL rather than relying on the initial pushState above
+  // guaranteed to be in sync rather than relying on the initial location above
   await getByText('Home').click();
-  await vi.waitFor(() => expect(window.location.pathname).toBe('/'));
+  await vi.waitFor(() => expect(app.navigation.path.pathname).toBe('/'));
 
   // Users is never navigated to in this test, so its color is a stable "inactive" reference
   const inactiveColor = colorOf('Users');

--- a/cookbooks/app-react-router/src/components/product/ProductCard.test.tsx
+++ b/cookbooks/app-react-router/src/components/product/ProductCard.test.tsx
@@ -19,9 +19,7 @@ testWithRouter(
     await expect.element(getByText(/✓ in stock/i)).toBeInTheDocument();
 
     const link = getByRole('link', { name: /view details/i });
-    await expect
-      .element(link)
-      .toHaveAttribute('href', `${window.location.origin}/products/${baseProduct.id}`);
+    await expect.element(link).toHaveAttribute('href', expect.stringContaining(`/products/${baseProduct.id}`));
 
     await unmount();
   },

--- a/cookbooks/app-react-router/src/routes/layout.test.tsx
+++ b/cookbooks/app-react-router/src/routes/layout.test.tsx
@@ -8,7 +8,6 @@ import Layout from './layout';
 test('renders the header, sidebar navigation, and the matched child route content', async ({
   render,
 }) => {
-  window.history.pushState(null, '', '/');
   const routes: RouteObject[] = [
     {
       path: '/',
@@ -32,7 +31,6 @@ test('renders the loader while a navigation is pending, then the outlet once it 
   render,
   app,
 }) => {
-  window.history.pushState(null, '', '/');
   // held open until the assertion below has observed the loading state
   let resolveLoader = (_value?: unknown) => {};
   const pendingLoad = new Promise((resolve) => {

--- a/cookbooks/app-react-router/src/routes/products/[id]/index.test.tsx
+++ b/cookbooks/app-react-router/src/routes/products/[id]/index.test.tsx
@@ -26,7 +26,7 @@ testWithRouter('renders the loaded product in the details view', async ({ render
   await expect.element(getByText(/✓ in stock/i)).toBeInTheDocument();
 
   const backLink = getByRole('link', { name: /back to products/i });
-  await expect.element(backLink).toHaveAttribute('href', `${window.location.origin}/products`);
+  await expect.element(backLink).toHaveAttribute('href', expect.stringContaining('/products'));
 
   await unmount();
 });

--- a/cookbooks/app-react-router/src/routes/users/[id]/index.test.tsx
+++ b/cookbooks/app-react-router/src/routes/users/[id]/index.test.tsx
@@ -25,7 +25,7 @@ testWithRouter(
     await expect.element(getByText(user.name)).toBeInTheDocument();
 
     const backLink = getByRole('link', { name: /back to users/i });
-    await expect.element(backLink).toHaveAttribute('href', `${window.location.origin}/users`);
+    await expect.element(backLink).toHaveAttribute('href', expect.stringContaining('/users'));
 
     await unmount();
   },

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -147,15 +147,20 @@ when the custom parent must serve the app's manifest and config. Use
 ## Extend the parent framework mock with `configureFusion`
 
 `fusion` (built by [`resolveFusion`](../src/scope/resolve-fusion.ts)) always carries a mocked
-`app` module (serving this app's manifest) and a `navigation` module with real browser history,
-matching Browser Mode. `configureFusion` runs on the same configurator afterwards, so a test can
-register extra framework-level modules or override that setup, without reimplementing it:
+`app` module (serving this app's manifest) and a `navigation` module with in-memory history, so
+tests don't leak URL/history state between runs. It also mocks the `featureFlag` module — with
+no flags enabled, so `useFeature` needs no `localStorage` or URL seeding — but only when
+`@equinor/fusion-framework-module-feature-flag` (an optional peer dependency) is actually
+installed; apps that don't use feature flags aren't forced to add it. `configureFusion` runs on
+the same configurator afterwards, so a test can register extra framework-level modules or
+override that setup, without reimplementing it:
 
 ```tsx
 import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
 
 const test = baseTest.extend('configureFusion', { injected: true }, () => (configurator) => {
-  enableFeatureFlagMock(configurator);
+  // seed a specific flag rather than merely enabling the mock — that's already the default
+  enableFeatureFlagMock(configurator, (mock) => mock.addFeature({ key: 'new-search', enabled: true }));
   configurator.serviceDiscovery.addServices([{ key: 'people', uri: baseUrl('people') }]);
 });
 ```
@@ -172,7 +177,7 @@ import { enableNavigation, createHistory } from '@equinor/fusion-framework-modul
 
 test.override('configureFusion', { injected: true }, () => (configurator) =>
   enableNavigation(configurator, {
-    configure: (config) => config.setHistory(createHistory('memory')),
+    configure: (config) => config.setHistory(createHistory('browser')),
   }),
 );
 ```

--- a/packages/vitest-plugin/react-app/docs/configuration.md
+++ b/packages/vitest-plugin/react-app/docs/configuration.md
@@ -92,7 +92,7 @@ export default defineProject({
       instances: [{ browser: 'chromium' }],
     },
   },
-  server: { warmup: { clientFiles: ['src/**/*.{ts,tsx}'] } },
+  server: { warmup: { clientFiles: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'] } },
 });
 ```
 

--- a/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
+++ b/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
@@ -178,6 +178,11 @@ aren't Fusion-specific.
 Review polyfills and component replacements that may only exist for `jsdom` or `happy-dom`.
 Remove one workaround at a time and run the affected tests against the real component.
 
+A common one: a no-op `window.ResizeObserver` stub carried over from `jsdom`/`happy-dom` setup.
+Real Chromium doesn't need the stub, but leaving it in place silently breaks any component that
+measures itself through `ResizeObserver` before rendering — for example a virtualized popover
+list. Remove the stub rather than porting it.
+
 Do not remove unrelated suppressions automatically. AG Grid license messages, Lit dev-mode
 warnings, network behavior, and app-specific test doubles may still apply in Browser Mode.
 

--- a/packages/vitest-plugin/react-app/docs/troubleshooting.md
+++ b/packages/vitest-plugin/react-app/docs/troubleshooting.md
@@ -18,6 +18,9 @@ resolve the app, or behaves differently in Vitest Browser Mode.
 | The app starts signed in unexpectedly | The MSAL mock defaults to `Test User` | Set `configurator.msal.setAccount(null)` before rendering |
 | State configured in one test is missing in another | Framework and app fixtures are test-scoped | Seed the required state per test or publish reusable fixture declarations with `test.extend` |
 | `vi.spyOn` fails on an imported module in Browser Mode | Native ESM module namespace objects are sealed | Use `vi.mock('./module.js', { spy: true })` as documented by Vitest Browser Mode |
+| A `<Router>` route with a catch-all or parameterized `path` never renders; every query on it times out | The navigation module's current location does not match that path yet | Push the target location through the navigation module (`app.modules.navigation.push(path)`) before rendering, not after |
+| A virtualized list or popover (for example an EDS `Autocomplete` built on `@tanstack/react-virtual`) never renders its rows | `window.ResizeObserver` was stubbed as a no-op in test setup | Remove the stub; real Chromium's `ResizeObserver` is required for virtualized layout to measure correctly |
+| `test.each` runs but a fixture in its per-case callback is `undefined` | `test.each` does not forward `test.extend` fixture context to each case | Use Vitest's `test.for` instead, which does receive fixture context |
 
 ## Verify the project wiring
 

--- a/packages/vitest-plugin/react-app/package.json
+++ b/packages/vitest-plugin/react-app/package.json
@@ -63,6 +63,7 @@
     "@equinor/fusion-imports": "workspace:*"
   },
   "devDependencies": {
+    "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitest/browser-playwright": "^4.1.0",
@@ -76,6 +77,7 @@
     "vitest-browser-react": "^2.2.0"
   },
   "peerDependencies": {
+    "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@vitest/browser-playwright": "^4.0.0",
     "playwright": "^1.0.0",
@@ -85,5 +87,10 @@
     "vite": "^8.0.0",
     "vitest": "^4.0.0",
     "vitest-browser-react": "^2.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@equinor/fusion-framework-module-feature-flag": {
+      "optional": true
+    }
   }
 }

--- a/packages/vitest-plugin/react-app/src/define-project.ts
+++ b/packages/vitest-plugin/react-app/src/define-project.ts
@@ -68,13 +68,15 @@ export const defineProject = (override?: AppTestConfigOverride): UserWorkspaceCo
     // pre-transforms all source up front so deps only reached via lazy/code-split imports
     // (e.g. route components) are discovered before the first test request, not mid-run —
     // the latter forces Vite to reload the page and fails the in-flight test file import
-    server: { warmup: { clientFiles: ['src/**/*.{ts,tsx}'] } },
+    // `.d.ts` files are excluded: a CJS-style declaration file (e.g. one using `export =`)
+    // fails the warmup scan when loaded as ESM
+    server: { warmup: { clientFiles: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'] } },
     // same reasoning as `server.warmup` above, but for the esbuild dep scanner: without this,
     // its default entry detection can miss code-split route files entirely, so a package only
     // ever imported from one of those (e.g. react-router's own deps) is discovered mid-run
     // instead of up front — statically crawling every source file (which esbuild's scanner
     // follows through dynamic imports too) avoids that with no per-package name needed
-    optimizeDeps: { entries: ['src/**/*.{ts,tsx}'] },
+    optimizeDeps: { entries: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'] },
   };
   // a function replaces the config outright; a plain object deep-merges onto it via Vite's own mergeConfig
   const resolved =

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -1,11 +1,14 @@
 import type { AppEnv } from '@equinor/fusion-framework-app';
 import type { Fusion } from '@equinor/fusion-framework';
-import { mockFramework, type FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
+import {
+  mockFramework,
+  type FrameworkMockConfigureFn,
+  type FrameworkMockConfigurator,
+} from '@equinor/fusion-framework/mock';
 import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
 import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
 import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
-import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
 
 import { defaultAppEnv } from './default-app-env';
 
@@ -14,13 +17,24 @@ import { defaultAppEnv } from './default-app-env';
  * optional peer dependency — is actually installed, so apps that don't use feature flags aren't
  * forced to install a module they never reference.
  */
-// biome-ignore lint/suspicious/noExplicitAny: must accept any configurator shape, mirrors enableFeatureFlagMock's own signature
-async function enableFeatureFlagMockIfAvailable(configurator: IModulesConfigurator<any, any>): Promise<void> {
+async function enableFeatureFlagMockIfAvailable(
+  configurator: FrameworkMockConfigurator<[AppModule, NavigationModule]>,
+): Promise<void> {
   try {
-    const { enableFeatureFlagMock } = await import('@equinor/fusion-framework-module-feature-flag/mock');
+    const { enableFeatureFlagMock } = await import(
+      '@equinor/fusion-framework-module-feature-flag/mock'
+    );
     enableFeatureFlagMock(configurator);
-  } catch {
-    // not installed — nothing to mock
+  } catch (error) {
+    // re-throw anything other than the optional peer being missing, so a real
+    // registration failure isn't silently swallowed
+    if (
+      error instanceof Error &&
+      (error.message.includes('Cannot find module') || error.message.includes('MODULE_NOT_FOUND'))
+    ) {
+      return;
+    }
+    throw error;
   }
 }
 

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -5,8 +5,24 @@ import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
 import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
 import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
+import type { IModulesConfigurator } from '@equinor/fusion-framework-module';
 
 import { defaultAppEnv } from './default-app-env';
+
+/**
+ * Enables the feature-flag mock only when `@equinor/fusion-framework-module-feature-flag` — an
+ * optional peer dependency — is actually installed, so apps that don't use feature flags aren't
+ * forced to install a module they never reference.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: must accept any configurator shape, mirrors enableFeatureFlagMock's own signature
+async function enableFeatureFlagMockIfAvailable(configurator: IModulesConfigurator<any, any>): Promise<void> {
+  try {
+    const { enableFeatureFlagMock } = await import('@equinor/fusion-framework-module-feature-flag/mock');
+    enableFeatureFlagMock(configurator);
+  } catch {
+    // not installed — nothing to mock
+  }
+}
 
 /**
  * Resolves the parent Fusion instance backing an application module scope, building a
@@ -14,11 +30,14 @@ import { defaultAppEnv } from './default-app-env';
  * given.
  *
  * @template TEnv - The application environment descriptor.
- * @param options - `env` seeds the built-in app manifest mock; navigation defaults to real
- *   browser history, matching Browser Mode. `configure` runs afterwards on the same
- *   configurator — e.g. call `enableNavigation` again to override the history, or register
- *   extra modules and service discovery entries. `fusion`, an already-built parent instance,
- *   is reused as-is and skips `configure` entirely.
+ * @param options - `env` seeds the built-in app manifest mock; navigation defaults to in-memory
+ *   history, so tests don't leak URL/history state between runs. Feature flags default to the
+ *   in-memory feature-flag mock, with none enabled, when the optional
+ *   `@equinor/fusion-framework-module-feature-flag` peer dependency is installed. `configure`
+ *   runs afterwards on the same configurator — e.g. call `enableNavigation` or
+ *   `enableFeatureFlagMock` again to override either, or register extra modules and service
+ *   discovery entries. `fusion`, an already-built parent instance, is reused as-is and skips
+ *   `configure` entirely.
  * @returns The given `fusion`, or a fresh mocked parent Fusion instance.
  */
 export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
@@ -32,8 +51,9 @@ export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
     mockFramework<[AppModule, NavigationModule]>(async (configurator) => {
       enableAppManifestMock(configurator, env ?? (defaultAppEnv as TEnv));
       enableNavigation(configurator, {
-        configure: (config) => config.setHistory(createHistory('browser')),
+        configure: (config) => config.setHistory(createHistory('memory')),
       });
+      await enableFeatureFlagMockIfAvailable(configurator);
       await configure?.(configurator);
     })
   );

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -99,7 +99,9 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  *   { injected: true },
  *   (): FrameworkMockConfigureFn<[AppModule, NavigationModule]> =>
  *     (configurator) => {
- *       enableFeatureFlagMock(configurator);
+ *       // seed a specific flag rather than merely enabling the mock — that's already the
+ *       // default when the optional feature-flag peer dependency is installed
+ *       enableFeatureFlagMock(configurator, (mock) => mock.addFeature({ key: 'new-search', enabled: true }));
  *       configurator.serviceDiscovery.addServices([
  *         { key: 'people', uri: baseUrl('people') },
  *         { key: 'context', uri: baseUrl('context') },
@@ -113,9 +115,9 @@ export const testApp = baseTest
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
   .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
-  // Runs after the built-in app manifest/navigation setup, so a test can register extra
-  // framework modules, service discovery entries, or call `enableNavigation` again to
-  // override the history, without reimplementing the base setup.
+  // Runs after the built-in app manifest/navigation/feature-flag setup, so a test can register
+  // extra framework modules, service discovery entries, or call `enableNavigation`/
+  // `enableFeatureFlagMock` again to override either, without reimplementing the base setup.
   .extend(
     'configureFusion',
     { injected: true },

--- a/packages/vitest-plugin/react-app/tsconfig.json
+++ b/packages/vitest-plugin/react-app/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../../modules/module" },
     { "path": "../../modules/app" },
     { "path": "../../modules/navigation" },
+    { "path": "../../modules/feature-flag" },
     { "path": "../../react/framework" },
     { "path": "../../react/modules/module" },
     { "path": "../../utils/imports" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3267,9 +3267,6 @@ importers:
       '@equinor/fusion-framework-module-app':
         specifier: workspace:*
         version: link:../../modules/app
-      '@equinor/fusion-framework-module-feature-flag':
-        specifier: workspace:*
-        version: link:../../modules/feature-flag
       '@equinor/fusion-framework-module-navigation':
         specifier: workspace:*
         version: link:../../modules/navigation
@@ -3283,6 +3280,9 @@ importers:
         specifier: workspace:*
         version: link:../../utils/imports
     devDependencies:
+      '@equinor/fusion-framework-module-feature-flag':
+        specifier: workspace:*
+        version: link:../../modules/feature-flag
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3267,6 +3267,9 @@ importers:
       '@equinor/fusion-framework-module-app':
         specifier: workspace:*
         version: link:../../modules/app
+      '@equinor/fusion-framework-module-feature-flag':
+        specifier: workspace:*
+        version: link:../../modules/feature-flag
       '@equinor/fusion-framework-module-navigation':
         specifier: workspace:*
         version: link:../../modules/navigation


### PR DESCRIPTION
**Why is this change needed?**
`vitest-plugin-react-app`'s test defaults carried real-world friction discovered while migrating `fusion-cpr-app` to Vitest Browser Mode: a CJS `.d.ts` warmup crash, tests leaking real browser history/URL state between runs, and every app team hand-writing `enableFeatureFlagMock` boilerplate in their own `configureFusion` fixture.

**What is the current behavior?**
- `server.warmup.clientFiles`/`optimizeDeps.entries` include `.d.ts` files, which can fail to load as ESM for CJS-style (`export =`) type-only packages.
- The mocked parent framework (`resolveFusion`) defaults navigation to real `BrowserHistory`, which reads Vitest Browser Mode's iframe URL rather than the app's own basename, and leaks `window.location`/`window.history` state across tests.
- Feature flags are never mocked by default; every app needs its own `enableFeatureFlagMock(configurator)` call.

**What is the new behavior?**
- `.d.ts` files are excluded from both the warmup and `optimizeDeps` globs.
- `resolveFusion` defaults framework-scope navigation to in-memory history.
- `resolveFusion` also enables the feature-flag mock (no flags enabled) by default, but only when `@equinor/fusion-framework-module-feature-flag` — now an optional peer dependency — is actually installed, via a `try`/`catch`-guarded dynamic `import()`. Apps that don't use feature flags aren't forced to add the dependency.
- `cookbooks/app-react-router`'s test suite no longer reads/seeds `window.location`/`window.history` (which no longer reflects in-memory navigation state); it asserts through `app.navigation.path.pathname` and path-only `href` matches instead.

**What is the intended behavior or invariant?**
- Framework-scope (`resolveFusion`) navigation is memory-history by default; an app's own `src/config.ts` navigation setup is untouched and still defaults to `BrowserHistory` for production parity.
- The feature-flag mock default must never force a hard dependency on consumers who don't use feature flags — detection is genuinely dynamic (runtime `import()`, not a static type import) so the public `configure`/`configureFusion` generic signatures stay usable without the optional peer installed.
- Tests must never assert against real `window.location`/`window.history` — use the app's own navigation module.

**Does this PR introduce a breaking change?**
No. All changes are either defaults with unaffected behavior for the common case, or purely test-internal fixes. The feature-flag default only activates when the optional peer is present.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (`@equinor/fusion-framework-vitest-plugin-react-app`), Patch (`@equinor/fusion-framework-cookbook-app-react-router`)
- Consumer impact: Apps relying on real `BrowserHistory` behavior in framework-scope tests should override via `configureFusion`; installing `@equinor/fusion-framework-module-feature-flag` now auto-enables its mock.
- Downstream impact: None outside these two packages.

**Review guidance:**
Focus on `resolve-fusion.ts`'s dynamic-import guard (`enableFeatureFlagMockIfAvailable`) and confirm the public generic types (`FrameworkMockConfigureFn<[AppModule, NavigationModule]>`) intentionally exclude `FeatureFlagModule` to avoid breaking type resolution for consumers without the optional peer.

**Additional context**
Full test suites verified: `packages/vitest-plugin/react-app` (18/18) and `cookbooks/app-react-router` (18 files / 39 tests) both pass; `tsc -b --force` clean.

**Related issues**
None

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
- [x] Confirm adherence to code of conduct
