### PR TITLE
ci: revert broken turbo test task

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -125,7 +125,7 @@ jobs:
         run: exit 1
       
       - name: Create Test Report
-        run: pnpm test:affected
+        run: pnpm test run
 
       - name: Create Test Coverage
         id: test-coverage  

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "format": "biome format",
     "format:staged": "biome format --staged",
     "test": "vitest --run",
-    "test:affected": "turbo run test --affected",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "test:build": "docker build -f alpine.Dockerfile -t fusion_framework:test .",

--- a/turbo.json
+++ b/turbo.json
@@ -7,9 +7,6 @@
       "outputs": ["dist/**"],
       "cache": true
     },
-    "test": {
-      "dependsOn": ["^test"]
-    },
     "//#preindex:eds": {
       "inputs": ["eds/Dockerfile", "eds/*.ts"],
       "outputs": ["eds/out/**"],


### PR DESCRIPTION
Follow-up to #5330. The `test` turbo task and `test:affected` script are broken: packages without their own `vitest.config.ts` fall back to the root config's `projects` glob, which resolves relative to cwd, so running them standalone via turbo fails immediately with "No projects were found". Reverting to `pnpm test run` (full Vitest Projects run) for CI until this repo has per-package vitest configs, per Turborepo's own Vitest integration guide guidance that Projects-mode setups need Root Tasks or per-package configs, not naive per-package turbo tasks.