### PR TITLE
fix(cli-plugin-copilot): narrow JsonValue before reading tool-call arg properties

### DIFF
--- a/.changeset/copilot-plugin_narrow-jsonvalue-args.md
+++ b/.changeset/copilot-plugin_narrow-jsonvalue-args.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-cli-plugin-copilot": patch
+---
+
+Fix a build failure caused by `@github/copilot-sdk`'s stricter `JsonValue` typing on tool-call `arguments`. Tool-call detail extraction (`url`/`path`/`load`/`selector`) now narrows the union type before reading properties instead of relying on unchecked optional chaining.

--- a/packages/cli-plugins/copilot/src/commands/app/attach-session-logger.ts
+++ b/packages/cli-plugins/copilot/src/commands/app/attach-session-logger.ts
@@ -1,9 +1,30 @@
 import chalk from 'chalk';
 import ora from 'ora';
 
-import type { CopilotSession } from '@github/copilot-sdk';
+import type { CopilotSession, JsonValue } from '@github/copilot-sdk';
 
 import { tryFormatMessage } from './try-format-message.js';
+
+/**
+ * Extracts the first string-valued property found among `keys` on a tool-call's
+ * JSON arguments, narrowing the untyped `JsonValue` union to its object branch first.
+ * @param value - The tool-call arguments to inspect, as reported by the Copilot SDK
+ * @param keys - Property names to check, in priority order
+ * @returns The first matching string value, or `undefined` if none match
+ */
+function firstStringProp(value: JsonValue | undefined, keys: string[]): string | undefined {
+  // Primitives and arrays have no named properties to read
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  // Return the first key present with a string value, in caller-specified priority order
+  for (const key of keys) {
+    const prop = value[key];
+    // Skip non-string values (numbers, nested objects, etc.) rather than stringifying them
+    if (typeof prop === 'string') return prop;
+  }
+  return undefined;
+}
 
 const TOOL_ICONS: Record<string, string> = {
   browser_screenshot: '📷',
@@ -69,7 +90,7 @@ export function attachSessionLogger(
     switch (event.type) {
       case 'tool.execution_start': {
         const { toolCallId, toolName, arguments: args } = event.data;
-        const detail = args?.url ?? args?.path ?? args?.load ?? args?.selector;
+        const detail = firstStringProp(args, ['url', 'path', 'load', 'selector']);
         const icon = TOOL_ICONS[toolName] ?? '🔧';
         const label =
           typeof detail === 'string' ? `${icon} ${toolName} (${detail})` : `${icon} ${toolName}`;


### PR DESCRIPTION
## Problem

`main`'s "Check Code" CI is currently failing the build step:

```
src/commands/app/attach-session-logger.ts(72,30): error TS2339: Property 'url' does not exist on type 'string | number | boolean | JsonValue[] | { [key: string]: JsonValue; }'.
```

A recent `@github/copilot-sdk` bump (now `1.0.11` installed alongside an older `1.0.9` in the lockfile) tightened the type of `tool.execution_start`'s `arguments` field to `JsonValue` — a union that also includes primitives and arrays. Reading `.url`/`.path`/`.load`/`.selector` directly off that union no longer type-checks.

## Fix

Added a small type guard (`firstStringProp`) that narrows `JsonValue` to its object branch before reading known keys, replacing the unchecked `args?.url ?? args?.path ?? ...` chain in `attach-session-logger.ts`.

## Validation

- `pnpm --filter @equinor/fusion-framework-cli-plugin-copilot build` — passes (previously failed with the TS2339 errors above).
- `pnpm exec biome check packages/cli-plugins/copilot/src/commands/app/attach-session-logger.ts` — clean.
- Added a patch changeset for `@equinor/fusion-framework-cli-plugin-copilot`.
