### PR TITLE
ci: prune pnpm store before caching and purge PR caches on close

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -21,3 +21,11 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    # Cache keys are immutable, so every lockfile change saves a brand-new
+    # store on top of the previous one and old package versions never get
+    # dropped. Pruning here keeps the saved cache scoped to what this
+    # lockfile actually needs instead of growing unbounded.
+    - name: Prune pnpm store
+      shell: bash
+      run: pnpm store prune

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,39 @@
+name: Cleanup PR caches
+
+# Actions cache entries are scoped to the ref that created them and are never
+# deleted automatically when a PR branch goes away, so they keep consuming
+# the repo's 10GB quota until GitHub's LRU eviction forces it out - which
+# stalls the *next* cache save while eviction runs. Purge a PR's caches as
+# soon as it closes so the quota reflects only active branches.
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete caches for closed PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          echo "Fetching caches for $BRANCH"
+          cacheKeys=$(gh cache list --repo "$REPO" --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+
+          if [ -z "$cacheKeys" ]; then
+            echo "No caches found for $BRANCH"
+            exit 0
+          fi
+
+          for id in $cacheKeys; do
+            echo "Deleting cache $id"
+            gh cache delete "$id" --repo "$REPO" || true
+          done


### PR DESCRIPTION
## Problem

The pnpm store cached by `actions/setup-node`'s `cache: 'pnpm'` only ever grows: cache keys are immutable, so every lockfile change saves a brand-new store on top of the previous one, and pnpm never drops old package versions from it on its own. Combined with GitHub never deleting a PR's caches when the PR closes/merges, the repo's 10GB cache quota was being blown regularly (73 entries / 10.72GB found and manually purged as part of this change), causing cache-save steps to stall while GitHub's LRU eviction ran to free up space.

## Fix

- `.github/actions/node-setup/action.yml`: run `pnpm store prune` after install, so each saved cache entry only contains what the current lockfile actually references instead of every version ever fetched.
- `.github/workflows/cleanup-caches.yml`: new workflow, triggered on `pull_request: closed`, that deletes all cache entries scoped to that PR's ref — following [GitHub's documented pattern](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries) for cleaning up caches when a branch goes away.

## One-time cleanup

Manually purged all 73 pre-existing cache entries (10.72GB, already over the 10GB quota) via `gh cache delete` so both fixes start from a clean slate.

## Notes

- Restore-key fallback (PR caches building off the target branch's cache) already worked correctly before this change — `actions/setup-node` restores via a prefix fallback key on a lockfile-hash miss. The actual issue was unbounded growth + no cleanup on PR close, not missing fallback behavior.
- No changeset needed — this only touches repo-internal CI tooling (`.github/**`), not `packages/*` or `cookbooks/*`.
