### PR TITLE
fix: don't fail release jobs when gh CLI is missing on the runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
-      # Convert changeset PR to draft to prevent accidental merging
+      # fusion-gh-runner-fusion-framework's image doesn't ship gh (tracked with
+      # infra). Non-blocking: worst case the changeset PR stays open/ready.
       - name: convert Changeset PR to draft
         if: steps.changesets.outputs.published == 'false' && steps.changesets.outputs['pr-number']
+        continue-on-error: true
         run: gh pr ready ${{ steps.changesets.outputs['pr-number'] }} --undo
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -77,8 +77,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
+      # fusion-gh-runner-fusion-framework's image doesn't ship gh (tracked with
+      # infra). Non-blocking: worst case the changeset PR stays open/ready.
       - name: convert Changeset PR to draft
         if: steps.changesets.outputs.published == 'false' && steps.changesets.outputs['pr-number']
+        continue-on-error: true
         run: gh pr ready ${{ steps.changesets.outputs['pr-number'] }} --undo
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**Why is this change needed?**
The `fusion-gh-runner-fusion-framework` self-hosted runner doesn't have the GitHub CLI (`gh`) installed. This broke the "convert Changeset PR to draft" step in `ci.yml`'s `release-pkg` job on the last run (`gh: command not found`, exit 127): https://github.com/equinor/fusion-framework/actions/runs/32279766760/job/96155504260. The same step exists in `next.yml`'s `release-pkg` job on the same runner label.

**What is the current behavior?**
Both steps hard-fail the whole job when a changeset PR needs converting to draft, blocking the release/pre-release workflow entirely.

**What is the new behavior?**
Both steps are now `continue-on-error: true`. Worst case, the changeset PR just stays open/ready instead of being converted to draft — non-blocking.

**What is the intended behavior or invariant?**
This is a stopgap. Infra has been notified separately to install `gh` on the `fusion-gh-runner-fusion-framework` runner image; once that's done, these steps will succeed again as before and `continue-on-error` becomes a no-op safety net rather than the primary fix.

**Does this PR introduce a breaking change?**
No.

**Impact assessment:**
- Breaking changes: No
- Version bump: N/A (workflow-only change, no changeset needed)
- Consumer impact: None
- Downstream impact: None

**Review guidance:**
Confirmed via job log that `gh` is genuinely absent on this runner (not a transient issue), and that these are the only two `gh`-CLI-consuming steps running on `fusion-gh-runner-fusion-framework` in the whole workflow set (other jobs on that runner don't call `gh`; other workflows that do call `gh` run on `ubuntu-latest`, which ships it).

**Additional context**
None.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct
