### PR TITLE
feat(observable): export enableMapSet

### DIFF
--- a/.changeset/fusion-observable_export-enable-map-set.md
+++ b/.changeset/fusion-observable_export-enable-map-set.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-observable": minor
+---
+
+Expose Immer's `enableMapSet` from `@equinor/fusion-observable` so consumers can enable Map and Set support without importing from `immer` directly.

--- a/packages/utils/observable/README.md
+++ b/packages/utils/observable/README.md
@@ -140,6 +140,7 @@ action$.pipe(switchMapAction('search', (a) => fetchResults(a.payload))).subscrib
 | `actionMapper(actions, subject)` | Binds action creators to a subject as dispatch functions |
 | `ActionError` | Error class linking an action to a causal error |
 | `ActionReducerMapBuilder` | Builder interface for defining case reducers |
+| `enableMapSet()` | Enables Immer support for drafting `Map` and `Set` values |
 | `isObservableInput(input)` | Type guard for RxJS `ObservableInput` values |
 | `toObservable(input, ...args)` | Converts values/functions/promises to `Observable` |
 

--- a/packages/utils/observable/src/index.ts
+++ b/packages/utils/observable/src/index.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-export { castDraft } from 'immer';
+export { castDraft, enableMapSet } from 'immer';
 
 export * from './FlowSubject';
 export * from './actions/ActionError';


### PR DESCRIPTION
**Why is this change needed?**

Consumers of `@equinor/fusion-observable` may need Immer Map and Set support when using observable state helpers. Exposing `enableMapSet` from the package keeps that setup available through the package API instead of requiring a direct `immer` import.

**What is the current behavior?**

`@equinor/fusion-observable` re-exports `castDraft` from Immer, but consumers cannot import `enableMapSet` from the package entry point.

**What is the new behavior?**

`@equinor/fusion-observable` now re-exports `enableMapSet` from Immer. The package README documents the export in the core API reference, and a minor changeset is included for the new public API surface.

**What is the intended behavior or invariant?**

The observable package should continue to provide its supported Immer interoperability exports from its public entry point, while preserving existing exports unchanged.

**Does this PR introduce a breaking change?**

No. This is an additive export.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor
- Consumer impact: Consumers can import `enableMapSet` from `@equinor/fusion-observable`.
- Downstream impact: No expected downstream breakage; this only adds a public export.

**Review guidance:**

Verify that the new export is available from the package entry point, that the README documents it in the core API reference, and that the changeset bump matches the additive API change.

**Additional context**

Validation performed:

- `pnpm --filter @equinor/fusion-observable build` passed
- `pnpm --filter @equinor/fusion-observable test -- --run` passed
- `git --no-pager diff --check -- packages/utils/observable/README.md` passed
- `pnpm --filter @equinor/fusion-observable lint` could not run because `eslint` was not resolvable in this workspace

**Related issues**

None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
