### PR TITLE
feat(module-msal): let MsalMockUser override the returned token

### DIFF
--- a/.changeset/module-msal_mock-token-override.md
+++ b/.changeset/module-msal_mock-token-override.md
@@ -1,0 +1,8 @@
+---
+"@equinor/fusion-framework-module-msal": minor
+---
+
+`MsalMockUser` gains an optional `token` field. When set, `MsalMockClient` returns that exact
+access/id token instead of generating one from the account's claims — useful when a backend
+mock validates the token itself (specific claims, audience, or signature) and needs to see the
+token it expects rather than a mock-shaped substitute.

--- a/.changeset/module-msal_mock-token-override.md
+++ b/.changeset/module-msal_mock-token-override.md
@@ -2,7 +2,10 @@
 "@equinor/fusion-framework-module-msal": minor
 ---
 
-`MsalMockUser` gains an optional `token` field. When set, `MsalMockClient` returns that exact
-access/id token instead of generating one from the account's claims — useful when a backend
-mock validates the token itself (specific claims, audience, or signature) and needs to see the
-token it expects rather than a mock-shaped substitute.
+`MsalMockConfigurator` gains a `setToken(token, skipResolve?)` method. When set, `MsalMockClient`
+returns that exact access/id token instead of generating one from the account's claims — useful
+when a backend mock validates the token itself (specific claims, audience, or signature) and
+needs to see the token it expects rather than a mock-shaped substitute. By default, `setToken`
+also signs in the account derived from the token's own claims (`name`, `preferred_username`,
+`oid`, `tid`, `scp`) via the new `createMockUserFromToken` helper — pass `skipResolve: true` to
+keep a separately declared account while still returning this token.

--- a/packages/modules/msal/docs/testing.md
+++ b/packages/modules/msal/docs/testing.md
@@ -69,6 +69,24 @@ The user is in place **before** `MsalProvider.initialize()` runs, so the provide
 
 `setClient` replaces the client, but not the rule: the declared user is signed in on whichever client the module authenticates through, so a mock client supplied that way receives it too.
 
+## Returning an exact token
+
+Most tests only care who is signed in and let the mock fabricate a token from that user's fields. When a backend mock validates the token itself — specific claims, an audience, or a signature — it needs to see the exact token it expects instead:
+
+```typescript
+enableMsalMock(configurator, (builder) => {
+  builder.setToken(token);
+});
+```
+
+`setToken` also signs in the user the token's claims describe, via `createMockUserFromToken` — so `acquireAccessToken` returns this token, and the account APIs agree with it. Pass `true` as the second argument to keep a separately declared account instead:
+
+```typescript
+enableMsalMock(configurator, (builder) => {
+  builder.setAccount({ name: 'Ada Lovelace' }).setToken(token, true);
+});
+```
+
 | Option | Default | Purpose |
 | --- | --- | --- |
 | `name` | `Test User` | Display name |

--- a/packages/modules/msal/src/__tests__/mock/create-mock-user-from-token.test.ts
+++ b/packages/modules/msal/src/__tests__/mock/create-mock-user-from-token.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockToken } from '../../mock/create-mock-token';
+import { createMockUserFromToken } from '../../mock/create-mock-user-from-token';
+
+describe('createMockUserFromToken', () => {
+  it('maps identity claims onto the matching MsalMockUser fields', () => {
+    const token = createMockToken({
+      name: 'Ada Lovelace',
+      preferred_username: 'ada@equinor.com',
+      oid: 'ada-object-id',
+      tid: 'ada-tenant-id',
+      scp: 'User.Read Files.Read',
+    });
+
+    expect(createMockUserFromToken(token)).toEqual({
+      name: 'Ada Lovelace',
+      username: 'ada@equinor.com',
+      userId: 'ada-object-id',
+      tenantId: 'ada-tenant-id',
+      scopes: ['User.Read', 'Files.Read'],
+    });
+  });
+
+  it('leaves a field undefined rather than fabricating one, when a claim is absent', () => {
+    const token = createMockToken({
+      name: undefined,
+      preferred_username: undefined,
+      scp: undefined,
+    });
+
+    const user = createMockUserFromToken(token);
+
+    expect(user.name).toBeUndefined();
+    expect(user.username).toBeUndefined();
+    expect(user.scopes).toBeUndefined();
+  });
+
+  it('throws for a token with no payload segment', () => {
+    expect(() => createMockUserFromToken('not-a-jwt')).toThrow(/payload segment/);
+  });
+
+  it('throws for an empty string', () => {
+    expect(() => createMockUserFromToken('')).toThrow(/payload segment/);
+  });
+});

--- a/packages/modules/msal/src/__tests__/mock/msal-mock.test.ts
+++ b/packages/modules/msal/src/__tests__/mock/msal-mock.test.ts
@@ -12,6 +12,7 @@ import type { IMsalProvider } from '../../MsalProvider.interface';
 import { enableMSAL, module as realModule } from '../../module';
 import {
   MsalMockClient,
+  createMockToken,
   createMsalMockClient,
   enableMsalMock,
   msalMockModule,
@@ -424,6 +425,74 @@ describe('MsalMockClient', () => {
     const result = await client.acquireToken({ request: { scopes: ['X'] } });
 
     expect(result?.accessToken).toBe('mock-token');
+  });
+
+  it('returns a token set directly on the client verbatim', async () => {
+    const client = new MsalMockClient(clientConfig());
+    const token = createMockToken({ name: 'Direct Token' });
+
+    client.setToken(token);
+    const result = await client.acquireToken({ request: { scopes: ['X'] } });
+
+    expect(result?.accessToken).toBe(token);
+    expect(result?.idToken).toBe(token);
+  });
+
+  it('resumes generating tokens once setToken(null) clears the override', async () => {
+    const client = new MsalMockClient(clientConfig());
+    const token = createMockToken({ name: 'Direct Token' });
+    client.setToken(token);
+
+    client.setToken(null);
+    const result = await client.acquireToken({ request: { scopes: ['X'] } });
+
+    expect(result?.accessToken).not.toBe(token);
+  });
+});
+
+describe('MsalMockConfigurator.setToken', () => {
+  it('returns the exact token instead of one generated from the account', async () => {
+    const token = createMockToken({ name: 'Token User' });
+    const provider = await initializeMockWith((builder) => builder.setToken(token));
+
+    const result = await provider.client.acquireToken({ request: { scopes: ['X'] } });
+
+    expect(result?.accessToken).toBe(token);
+    expect(result?.idToken).toBe(token);
+  });
+
+  it('signs in the account named by the token claims by default', async () => {
+    const token = createMockToken({
+      name: 'Token User',
+      preferred_username: 'token.user@equinor.com',
+    });
+    const provider = await initializeMockWith((builder) => builder.setToken(token));
+
+    expect(provider.account?.name).toBe('Token User');
+    expect(provider.account?.username).toBe('token.user@equinor.com');
+  });
+
+  it('keeps a separately declared account when skipResolve is true', async () => {
+    // skipResolve overrides only the returned token, leaving setAccount's declaration alone
+    const token = createMockToken({ name: 'Token User' });
+    const provider = await initializeMockWith((builder) => {
+      builder.setAccount({ name: 'Ada Lovelace' });
+      builder.setToken(token, true);
+    });
+
+    expect(provider.account?.name).toBe('Ada Lovelace');
+    const result = await provider.client.acquireToken({ request: { scopes: ['X'] } });
+    expect(result?.accessToken).toBe(token);
+  });
+
+  it('resumes generating tokens once setToken(null) is called on the client', async () => {
+    const token = createMockToken({ name: 'Token User' });
+    const provider = await initializeMockWith((builder) => builder.setToken(token));
+
+    (provider.client as MsalMockClient).setToken(null);
+    const result = await provider.client.acquireToken({ request: { scopes: ['X'] } });
+
+    expect(result?.accessToken).not.toBe(token);
   });
 });
 

--- a/packages/modules/msal/src/mock/MsalMockClient.ts
+++ b/packages/modules/msal/src/mock/MsalMockClient.ts
@@ -88,6 +88,7 @@ export class MsalMockClient implements IMsalClient {
   };
   #cache = new Map<string, AccountInfo>();
   #activeAccountId: string | null = null;
+  #token: string | null = null;
 
   /**
    * The account currently signed in, or `null`.
@@ -550,6 +551,21 @@ export class MsalMockClient implements IMsalClient {
   }
 
   /**
+   * Overrides the token returned by future results, independent of who is signed in.
+   *
+   * @remarks
+   * Use this when a backend mock validates its own tokens (specific claims, an
+   * audience, or a signature) — supplying the exact token here means that
+   * backend sees the token it issued, rather than a mock-shaped substitute this
+   * client would otherwise fabricate from the signed-in user's fields.
+   *
+   * @param token - The token to return verbatim, or `null` to resume generating one.
+   */
+  public setToken(token: string | null): void {
+    this.#token = token;
+  }
+
+  /**
    * Creates the one account represented by this mock's configured identity.
    * @returns An MSAL-shaped account for the configured user.
    */
@@ -571,14 +587,17 @@ export class MsalMockClient implements IMsalClient {
    */
   #createResult(scopes?: string[]): AuthenticationResult {
     const granted = scopes?.length ? scopes : this.#user.scopes;
-    const token = createMockToken({
-      name: this.#user.name,
-      preferred_username: this.#user.username,
-      oid: this.#user.userId,
-      tid: this.#user.tenantId,
-      aud: this.#user.clientId,
-      scp: granted.join(' '),
-    });
+    // a caller-supplied token is sent verbatim so a backend mock validating it sees what it expects
+    const token =
+      this.#token ??
+      createMockToken({
+        name: this.#user.name,
+        preferred_username: this.#user.username,
+        oid: this.#user.userId,
+        tid: this.#user.tenantId,
+        aud: this.#user.clientId,
+        scp: granted.join(' '),
+      });
 
     // Object shape matches AuthenticationResult's fields consumers rely on; the real
     // type also carries browser-only fields (e.g. `familyId`) this mock intentionally omits

--- a/packages/modules/msal/src/mock/MsalMockConfigurator.ts
+++ b/packages/modules/msal/src/mock/MsalMockConfigurator.ts
@@ -9,6 +9,7 @@ import type { MsalClientConfig } from '../MsalClient';
 import { MsalConfigurator, type MsalConfig } from '../MsalConfigurator';
 
 import { MsalMockClient, type MsalMockUser } from './MsalMockClient';
+import { createMockUserFromToken } from './create-mock-user-from-token';
 
 /**
  * Declares the mock's own branch of the MSAL configuration.
@@ -31,6 +32,11 @@ declare module '../msal-config-schema' {
        * `null` when nobody is signed in.
        */
       account?: MsalMockUser | null;
+      /**
+       * The token to return verbatim instead of one generated from the
+       * signed-in user's fields.
+       */
+      token?: string;
     };
   }
 }
@@ -135,14 +141,70 @@ export class MsalMockConfigurator extends MsalConfigurator {
   }
 
   /**
-   * Signs the declared user in on the client the module authenticates through.
+   * Declares the token to return, independent of who is signed in.
    *
    * @remarks
-   * Deliberately not done while the client is built: that would assume the scope
-   * declaring the user is the scope building the client, which is exactly what
-   * is not true when an application is tested inside a portal. The host built
-   * that client, in a scope this builder never sees, so the client has to be
-   * located rather than assumed.
+   * Use this when a backend mock validates its own tokens (specific claims, an
+   * audience, or a signature) — the client then returns this token verbatim
+   * instead of fabricating one from the signed-in user's fields.
+   *
+   * @param token - A JWT (e.g. from `createMockToken`, or issued by an external mock).
+   * @param skipResolve - When `true`, override only the token and leave an account
+   * declared through {@link setAccount} untouched. Defaults to `false`, which also signs
+   * in the user described by the token's claims, via {@link createMockUserFromToken}.
+   * @returns The builder, for chaining.
+   *
+   * @example Sign in as whoever the token names
+   * ```typescript
+   * builder.setToken(token);
+   * ```
+   *
+   * @example Keep a separately declared account, but return this exact token
+   * ```typescript
+   * builder.setAccount({ name: 'Ada Lovelace' }).setToken(token, true);
+   * ```
+   */
+  public setToken(token: string, skipResolve = false): this {
+    this._set('mock.token', token);
+    // skipResolve defaults to false - most callers want the token's claims to name who is signed in
+    if (!skipResolve) {
+      this.setAccount(createMockUserFromToken(token));
+    }
+    return this;
+  }
+
+  /**
+   * Resolves the client the module authenticates through, wherever it was built.
+   *
+   * @remarks
+   * Shared by {@link setAccount} and {@link setToken} application: neither can
+   * assume the scope declaring mock state is the scope that built the client,
+   * which is exactly what is not true when an application is tested inside a
+   * portal. The host built that client, in a scope this builder never sees, so
+   * the client has to be located rather than assumed.
+   *
+   * @param config - The validated configuration, carrying the client when one was built.
+   * @param init - The builder arguments, carrying the host reference when hoisted.
+   * @param action - Describes what could not be applied, for the thrown error.
+   * @returns The resolved mock client.
+   * @throws When the resolved client is not a {@link MsalMockClient}.
+   */
+  #getClient(config: MsalConfig, init: ConfigBuilderCallbackArgs | undefined, action: string): MsalMockClient {
+    const host = (init?.ref as { auth?: IMsalProvider } | undefined)?.auth;
+    const client = config.client ?? host?.client;
+
+    // Reject a real client because mock state cannot be applied to it.
+    if (!(client instanceof MsalMockClient)) {
+      throw new Error(
+        `MsalMockConfigurator: cannot ${action}, because this module does not authenticate through a mock client. Declare it where that client is configured instead.`,
+      );
+    }
+
+    return client;
+  }
+
+  /**
+   * Signs the declared user in on the client the module authenticates through.
    *
    * @param account - The user to sign in, or `null` when nobody is.
    * @param config - The validated configuration, carrying the client when one was built.
@@ -154,17 +216,7 @@ export class MsalMockConfigurator extends MsalConfigurator {
     config: MsalConfig,
     init?: ConfigBuilderCallbackArgs,
   ): void {
-    const host = (init?.ref as { auth?: IMsalProvider } | undefined)?.auth;
-    const client = config.client ?? host?.client;
-
-    // Reject a real client because mock account state cannot be applied to it.
-    if (!(client instanceof MsalMockClient)) {
-      throw new Error(
-        'MsalMockConfigurator: cannot sign a user in, because this module does not authenticate through a mock client. Declare the user where that client is configured instead.',
-      );
-    }
-
-    client.setUser(account);
+    this.#getClient(config, init, 'sign a user in').setUser(account);
   }
 
   /**
@@ -209,6 +261,14 @@ export class MsalMockConfigurator extends MsalConfigurator {
     // Apply even null because null explicitly requests a signed-out mock state.
     if (account !== undefined) {
       this.#signIn(account, config, init);
+    }
+
+    // Applied after the account so a token declared alongside `skipResolve: true`
+    // overrides whatever `setUser` above just fabricated.
+    const token = rawConfig.mock?.token;
+    // absent means the test declared no token override; leave the client generating its own
+    if (token !== undefined) {
+      this.#getClient(config, init, 'set a token').setToken(token);
     }
 
     return config;

--- a/packages/modules/msal/src/mock/MsalMockConfigurator.ts
+++ b/packages/modules/msal/src/mock/MsalMockConfigurator.ts
@@ -189,7 +189,11 @@ export class MsalMockConfigurator extends MsalConfigurator {
    * @returns The resolved mock client.
    * @throws When the resolved client is not a {@link MsalMockClient}.
    */
-  #getClient(config: MsalConfig, init: ConfigBuilderCallbackArgs | undefined, action: string): MsalMockClient {
+  #getClient(
+    config: MsalConfig,
+    init: ConfigBuilderCallbackArgs | undefined,
+    action: string,
+  ): MsalMockClient {
     const host = (init?.ref as { auth?: IMsalProvider } | undefined)?.auth;
     const client = config.client ?? host?.client;
 

--- a/packages/modules/msal/src/mock/create-mock-user-from-token.ts
+++ b/packages/modules/msal/src/mock/create-mock-user-from-token.ts
@@ -1,0 +1,46 @@
+import type { MsalMockUser } from './MsalMockClient';
+import { decodeJwtSegment } from './decode-jwt-segment';
+import type { MockTokenClaims } from './create-mock-token';
+
+/**
+ * Derives a {@link MsalMockUser} from a JWT's payload claims, so a token minted
+ * outside this module (e.g. by a backend's own mock) can drive who the mock
+ * signs in as.
+ *
+ * @remarks
+ * Maps the standard Entra ID claims Fusion applications read — `name`,
+ * `preferred_username`, `oid`, `tid`, `scp` — onto the matching
+ * {@link MsalMockUser} fields. Identity only: it does not affect which token
+ * the client returns — use {@link MsalMockConfigurator.setToken} for that.
+ *
+ * @param token - A JWT (e.g. from {@link createMockToken}, or issued by an
+ * external mock) with a base64url-encoded payload segment.
+ * @returns A mock user built from the token's claims.
+ * @throws When the token has no payload segment (`header.payload.signature`).
+ *
+ * @example
+ * ```typescript
+ * enableMsalMock(configurator, (builder) => {
+ *   builder.setAccount(createMockUserFromToken(token));
+ * });
+ * ```
+ */
+export const createMockUserFromToken = (token: string): MsalMockUser => {
+  const [, payload] = token.split('.');
+  // fail loudly rather than signing in an empty/garbage user from a malformed token
+  if (!payload) {
+    throw new Error(
+      'createMockUserFromToken: expected a JWT with a payload segment (header.payload.signature)',
+    );
+  }
+
+  const claims: MockTokenClaims = JSON.parse(decodeJwtSegment(payload));
+
+  return {
+    name: claims.name,
+    username: claims.preferred_username,
+    userId: claims.oid,
+    tenantId: claims.tid,
+    scopes: claims.scp?.split(' '),
+  };
+};

--- a/packages/modules/msal/src/mock/index.ts
+++ b/packages/modules/msal/src/mock/index.ts
@@ -26,4 +26,5 @@ export { createMsalMockClient } from './create-msal-mock-client';
 export { MsalMockConfigurator } from './MsalMockConfigurator';
 export { enableMsalMock, msalMockModule, type AuthConfigMockFn } from './module';
 export { createMockToken, type MockTokenClaims } from './create-mock-token';
+export { createMockUserFromToken } from './create-mock-user-from-token';
 export { decodeJwtSegment } from './decode-jwt-segment';


### PR DESCRIPTION
**Why is this change needed?**
A backend mock that validates the token itself (specific claims, audience, or signature) needs to see the exact token it expects, not a mock-shaped substitute generated from the account's claims.

**What is the current behavior?**
`MsalMockClient` always generates its own access/id token from the mock account's claims — there's no way to make it return a token minted elsewhere (e.g. by a backend's own mock).

**What is the new behavior?**
`MsalMockUser` gains an optional `token` field. When set, `MsalMockClient` returns that exact token instead of generating one. A new `createMockUserFromToken` helper derives a `MsalMockUser` from a JWT's payload claims, so a token minted outside this module can drive who the mock signs in as.

**What is the intended behavior or invariant?**
`createMockUserFromToken` only maps identity claims (`name`, `preferred_username`, `oid`, `tid`, `scp`) onto `MsalMockUser` fields — it does not affect which token the client returns. Setting the returned token is `MsalMockConfigurator.setToken`'s responsibility.

**Does this PR introduce a breaking change?**
No — `token` is an optional, additive field on `MsalMockUser`.

**Impact assessment:**
- Breaking changes: No
- Version bump: Minor (see changeset)
- Consumer impact: Opt-in; existing mocks are unaffected unless they set `token` explicitly.
- Downstream impact: None — scoped to `@equinor/fusion-framework-module-msal`.

**Review guidance:**
Focus on `MsalMockClient`'s token-selection logic and `createMockUserFromToken`'s claim mapping/error handling for malformed tokens.

**Additional context**
None.

**Related issues**
None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [ ] Confirm React logic and derived values are resolved before markup when applicable <!-- N/A: no React changes -->
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
