### PR TITLE
fix(vitest-plugin-react-app): install framework dependencies

### DIFF
--- a/.changeset/fusion-framework-vitest-plugin-react-app_install-framework-modules.md
+++ b/.changeset/fusion-framework-vitest-plugin-react-app_install-framework-modules.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-vitest-plugin-react-app": patch
+---
+
+Install the feature-flag and telemetry framework modules with the React app Vitest plugin so applications do not need to declare them separately to run tests. Feature flags remain app-scoped and are enabled automatically only when the application's own configuration registers them.

--- a/.changeset/fusion-framework-vitest-plugin-react-app_install-framework-modules.md
+++ b/.changeset/fusion-framework-vitest-plugin-react-app_install-framework-modules.md
@@ -2,4 +2,4 @@
 "@equinor/fusion-framework-vitest-plugin-react-app": patch
 ---
 
-Install the feature-flag and telemetry framework modules with the React app Vitest plugin so applications do not need to declare them separately to run tests. Feature flags remain app-scoped and are enabled automatically only when the application's own configuration registers them.
+Install the feature-flag and telemetry framework modules with the React app Vitest plugin so applications do not need to declare them separately to run tests. The plugin automatically enables the parent feature-flag mock only when the application declares the feature-flag module as a runtime dependency.

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -148,26 +148,22 @@ when the custom parent must serve the app's manifest and config. Use
 
 `fusion` (built by [`resolveFusion`](../src/scope/resolve-fusion.ts)) always carries a mocked
 `app` module (serving this app's manifest) and a `navigation` module with in-memory history, so
-tests don't leak URL/history state between runs. It also mocks the `featureFlag` module — with
-no flags enabled, so `useFeature` needs no `localStorage` or URL seeding — but only when
-`@equinor/fusion-framework-module-feature-flag` (an optional peer dependency) is actually
-installed; apps that don't use feature flags aren't forced to add it. `configureFusion` runs on
-the same configurator afterwards, so a test can register extra framework-level modules or
-override that setup, without reimplementing it:
+tests don't leak URL/history state between runs. The plugin installs the feature-flag and
+telemetry framework modules needed by app test bundles, so applications do not need to declare
+them separately. The application's real `configure` callback still controls whether feature
+flags are enabled in the app scope; app teams do not register feature flags in the parent Fusion
+scope for tests. `configureFusion` runs on the parent configurator afterwards, so a test can
+register framework-level services or override navigation without reimplementing the base setup:
 
 ```tsx
-import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
-
 const test = baseTest.extend('configureFusion', { injected: true }, () => (configurator) => {
-  // seed a specific flag rather than merely enabling the mock — that's already the default
-  enableFeatureFlagMock(configurator, (mock) => mock.addFeature({ key: 'new-search', enabled: true }));
   configurator.serviceDiscovery.addServices([{ key: 'people', uri: baseUrl('people') }]);
 });
 ```
 
 Note this is a **framework-scope** module set, distinct from the app-scope one `configureApp`
-seeds. A typical app registers its own `navigation` module independently, inside its own
-`config.ts`'s `configure` callback (what `configureApp` composes with) — so overriding history
+seeds. A typical app registers its own feature-flag and navigation modules independently, inside
+its own `config.ts`'s `configure` callback (what `configureApp` composes with) — so overriding history
 through `configureFusion` only affects framework-scope consumers, such as
 `useFramework<[NavigationModule]>().modules.navigation` or `useBookmarkNavigate`, not a
 rendered app's own router:

--- a/packages/vitest-plugin/react-app/docs/advanced.md
+++ b/packages/vitest-plugin/react-app/docs/advanced.md
@@ -150,10 +150,12 @@ when the custom parent must serve the app's manifest and config. Use
 `app` module (serving this app's manifest) and a `navigation` module with in-memory history, so
 tests don't leak URL/history state between runs. The plugin installs the feature-flag and
 telemetry framework modules needed by app test bundles, so applications do not need to declare
-them separately. The application's real `configure` callback still controls whether feature
-flags are enabled in the app scope; app teams do not register feature flags in the parent Fusion
-scope for tests. `configureFusion` runs on the parent configurator afterwards, so a test can
-register framework-level services or override navigation without reimplementing the base setup:
+them separately for tests. When the application's `package.json` declares
+`@equinor/fusion-framework-module-feature-flag`, the plugin automatically enables the in-memory
+feature-flag mock in the parent Fusion scope; app teams do not add it through `configureFusion`.
+The application's real `configure` callback still controls the app-scope feature flags.
+`configureFusion` runs on the parent configurator afterwards, so a test can register
+framework-level services or override navigation without reimplementing the base setup:
 
 ```tsx
 const test = baseTest.extend('configureFusion', { injected: true }, () => (configurator) => {

--- a/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
+++ b/packages/vitest-plugin/react-app/docs/migrating-an-existing-app.md
@@ -57,8 +57,8 @@ the browser mid-test. See [Configuration](configuration.md) for overriding any o
 
 The `/test` entry point initializes the real module pipeline. This removes most `vi.mock`
 implementations for hooks such as `useCurrentUser`, `useFeature`, and `useHttpClient`. The
-default setup includes a signed-in `Test User` and initialized feature-flag, context, and
-bookmark modules:
+default setup includes a signed-in `Test User`; enable feature-flag, context, and bookmark mocks
+explicitly when the test needs them:
 
 ```diff
 -vi.mock('@equinor/fusion-framework-react/hooks', async (importOriginal) => ({

--- a/packages/vitest-plugin/react-app/package.json
+++ b/packages/vitest-plugin/react-app/package.json
@@ -57,13 +57,14 @@
     "@equinor/fusion-framework-cli": "workspace:*",
     "@equinor/fusion-framework-module": "workspace:*",
     "@equinor/fusion-framework-module-app": "workspace:*",
+    "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@equinor/fusion-framework-module-navigation": "workspace:*",
+    "@equinor/fusion-framework-module-telemetry": "workspace:*",
     "@equinor/fusion-framework-react": "workspace:*",
     "@equinor/fusion-framework-react-module": "workspace:*",
     "@equinor/fusion-imports": "workspace:*"
   },
   "devDependencies": {
-    "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitest/browser-playwright": "^4.1.0",
@@ -77,7 +78,6 @@
     "vitest-browser-react": "^2.2.0"
   },
   "peerDependencies": {
-    "@equinor/fusion-framework-module-feature-flag": "workspace:*",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@vitest/browser-playwright": "^4.0.0",
     "playwright": "^1.0.0",
@@ -87,10 +87,5 @@
     "vite": "^8.0.0",
     "vitest": "^4.0.0",
     "vitest-browser-react": "^2.2.0"
-  },
-  "peerDependenciesMeta": {
-    "@equinor/fusion-framework-module-feature-flag": {
-      "optional": true
-    }
   }
 }

--- a/packages/vitest-plugin/react-app/src/__tests__/app-test-vite-plugin.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/app-test-vite-plugin.test.ts
@@ -44,6 +44,24 @@ describe('appTestVitePlugin', () => {
 
     expect(source).toContain('"appKey":"my-app"');
     expect(source).toContain('export const config = {"environment":{}};');
+    expect(source).toContain('export const usesFeatureFlag = false;');
+  });
+
+  it('exposes whether the application declares feature flags', async () => {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: '@equinor/my-app',
+        version: '1.2.3',
+        dependencies: { '@equinor/fusion-framework-module-feature-flag': '2.1.0' },
+      }),
+    );
+    const plugin = appTestVitePlugin({ entrypoint: dir });
+    const load = plugin.load as LoadHook;
+
+    const source = await load('\0virtual:fusion-app-test-env');
+
+    expect(source).toContain('export const usesFeatureFlag = true;');
   });
 
   it('serves an undefined configure export when no config file exists', async () => {

--- a/packages/vitest-plugin/react-app/src/__tests__/app-test-vite-plugin.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/app-test-vite-plugin.test.ts
@@ -44,7 +44,7 @@ describe('appTestVitePlugin', () => {
 
     expect(source).toContain('"appKey":"my-app"');
     expect(source).toContain('export const config = {"environment":{}};');
-    expect(source).toContain('export const usesFeatureFlag = false;');
+    expect(source).toContain('export const runtimeDependencies = [];');
   });
 
   it('exposes whether the application declares feature flags', async () => {
@@ -61,7 +61,9 @@ describe('appTestVitePlugin', () => {
 
     const source = await load('\0virtual:fusion-app-test-env');
 
-    expect(source).toContain('export const usesFeatureFlag = true;');
+    expect(source).toContain(
+      'export const runtimeDependencies = ["@equinor/fusion-framework-module-feature-flag"];',
+    );
   });
 
   it('serves an undefined configure export when no config file exists', async () => {

--- a/packages/vitest-plugin/react-app/src/__tests__/resolve-app-test-env.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/resolve-app-test-env.test.ts
@@ -22,7 +22,7 @@ describe('resolveAppTestEnv', () => {
   });
 
   it('falls back to a package-derived manifest and an empty config with no local files', async () => {
-    const { manifest, config } = await resolveAppTestEnv({ entrypoint: dir });
+    const { manifest, config, usesFeatureFlag } = await resolveAppTestEnv({ entrypoint: dir });
 
     expect(manifest).toMatchObject({
       appKey: 'my-app',
@@ -31,6 +31,22 @@ describe('resolveAppTestEnv', () => {
       type: 'standalone',
     });
     expect(config).toEqual({ environment: {} });
+    expect(usesFeatureFlag).toBe(false);
+  });
+
+  it('detects feature flags from the application runtime dependencies', async () => {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: '@equinor/my-app',
+        version: '1.2.3',
+        dependencies: { '@equinor/fusion-framework-module-feature-flag': '2.1.0' },
+      }),
+    );
+
+    const { usesFeatureFlag } = await resolveAppTestEnv({ entrypoint: dir });
+
+    expect(usesFeatureFlag).toBe(true);
   });
 
   it('merges a local app.manifest.ts and app.config.ts, same as ffc app build', async () => {

--- a/packages/vitest-plugin/react-app/src/__tests__/resolve-app-test-env.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/resolve-app-test-env.test.ts
@@ -22,7 +22,7 @@ describe('resolveAppTestEnv', () => {
   });
 
   it('falls back to a package-derived manifest and an empty config with no local files', async () => {
-    const { manifest, config, usesFeatureFlag } = await resolveAppTestEnv({ entrypoint: dir });
+    const { manifest, config, runtimeDependencies } = await resolveAppTestEnv({ entrypoint: dir });
 
     expect(manifest).toMatchObject({
       appKey: 'my-app',
@@ -31,7 +31,7 @@ describe('resolveAppTestEnv', () => {
       type: 'standalone',
     });
     expect(config).toEqual({ environment: {} });
-    expect(usesFeatureFlag).toBe(false);
+    expect(runtimeDependencies).toEqual([]);
   });
 
   it('detects feature flags from the application runtime dependencies', async () => {
@@ -44,9 +44,9 @@ describe('resolveAppTestEnv', () => {
       }),
     );
 
-    const { usesFeatureFlag } = await resolveAppTestEnv({ entrypoint: dir });
+    const { runtimeDependencies } = await resolveAppTestEnv({ entrypoint: dir });
 
-    expect(usesFeatureFlag).toBe(true);
+    expect(runtimeDependencies).toContain('@equinor/fusion-framework-module-feature-flag');
   });
 
   it('merges a local app.manifest.ts and app.config.ts, same as ffc app build', async () => {

--- a/packages/vitest-plugin/react-app/src/__tests__/resolve-fusion.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/resolve-fusion.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveFusion } from '../scope/resolve-fusion.js';
+
+describe('resolveFusion', () => {
+  it('does not enable the parent feature-flag mock by default', async () => {
+    const fusion = await resolveFusion();
+
+    expect('featureFlag' in fusion.modules).toBe(false);
+  });
+
+  it('enables the parent feature-flag mock for an app that declares feature flags', async () => {
+    const fusion = await resolveFusion({ mockFeatureFlag: true });
+
+    expect('featureFlag' in fusion.modules).toBe(true);
+  });
+});

--- a/packages/vitest-plugin/react-app/src/__tests__/resolve-fusion.test.ts
+++ b/packages/vitest-plugin/react-app/src/__tests__/resolve-fusion.test.ts
@@ -10,7 +10,9 @@ describe('resolveFusion', () => {
   });
 
   it('enables the parent feature-flag mock for an app that declares feature flags', async () => {
-    const fusion = await resolveFusion({ mockFeatureFlag: true });
+    const fusion = await resolveFusion({
+      runtimeDependencies: ['@equinor/fusion-framework-module-feature-flag'],
+    });
 
     expect('featureFlag' in fusion.modules).toBe(true);
   });

--- a/packages/vitest-plugin/react-app/src/index.ts
+++ b/packages/vitest-plugin/react-app/src/index.ts
@@ -48,9 +48,10 @@ export type AppTestVitePluginOptions = ResolveAppTestEnvOptions & {
  *   // ...your own browser-mode config
  * });
  * ```
- * Exposes two virtual modules: `virtual:fusion-app-test-env` (`manifest`/`config`, as JSON) and
- * `virtual:fusion-app-test-configure` (a re-export of the resolved `configure` module, or
- * `undefined` if none exists). Not intended to be imported directly by application code.
+ * Exposes two virtual modules: `virtual:fusion-app-test-env`
+ * (`manifest`/`config`/`runtimeDependencies`, as JSON) and `virtual:fusion-app-test-configure`
+ * (a re-export of the resolved `configure` module, or `undefined` if none exists). Not intended
+ * to be imported directly by application code.
  *
  * @param options - Resolution options; `entrypoint` defaults to the current working directory.
  * @returns A Vite plugin instance.

--- a/packages/vitest-plugin/react-app/src/index.ts
+++ b/packages/vitest-plugin/react-app/src/index.ts
@@ -79,14 +79,14 @@ export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin =>
     async load(id) {
       // serves manifest/config resolved lazily here, not at plugin-creation time, so options.entrypoint changes between test runs are respected
       if (id === RESOLVED_ENV_MODULE_ID) {
-        const { manifest, config, usesFeatureFlag } = await resolveAppTestEnv({
+        const { manifest, config, runtimeDependencies } = await resolveAppTestEnv({
           ...options,
           entrypoint,
         });
         return [
           `export const manifest = ${JSON.stringify(manifest)};`,
           `export const config = ${JSON.stringify(config)};`,
-          `export const usesFeatureFlag = ${JSON.stringify(usesFeatureFlag)};`,
+          `export const runtimeDependencies = ${JSON.stringify(runtimeDependencies)};`,
         ].join('\n');
       }
       // no conventional module means the app registers no extra modules, same as omitting `configure` from `makeComponent`

--- a/packages/vitest-plugin/react-app/src/index.ts
+++ b/packages/vitest-plugin/react-app/src/index.ts
@@ -79,10 +79,14 @@ export const appTestVitePlugin = (options?: AppTestVitePluginOptions): Plugin =>
     async load(id) {
       // serves manifest/config resolved lazily here, not at plugin-creation time, so options.entrypoint changes between test runs are respected
       if (id === RESOLVED_ENV_MODULE_ID) {
-        const { manifest, config } = await resolveAppTestEnv({ ...options, entrypoint });
+        const { manifest, config, usesFeatureFlag } = await resolveAppTestEnv({
+          ...options,
+          entrypoint,
+        });
         return [
           `export const manifest = ${JSON.stringify(manifest)};`,
           `export const config = ${JSON.stringify(config)};`,
+          `export const usesFeatureFlag = ${JSON.stringify(usesFeatureFlag)};`,
         ].join('\n');
       }
       // no conventional module means the app registers no extra modules, same as omitting `configure` from `makeComponent`

--- a/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
+++ b/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
@@ -13,12 +13,16 @@ import {
 } from '@equinor/fusion-framework-cli/app';
 import { resolvePackage } from '@equinor/fusion-framework-cli/utils';
 
+const FEATURE_FLAG_PACKAGE = '@equinor/fusion-framework-module-feature-flag';
+
 /**
  * The application manifest and config resolved for a test run.
  */
 export type AppTestEnv = {
   manifest: AppManifest;
   config: ApiAppConfig;
+  /** Whether the application declares the feature-flag module as a runtime dependency. */
+  usesFeatureFlag: boolean;
 };
 
 /**
@@ -53,7 +57,7 @@ export type ResolveAppTestEnvOptions = {
  * `test.override('appEnv', ...)`.
  *
  * @param options - Resolution options; `entrypoint` defaults to the current working directory.
- * @returns The resolved application manifest and config.
+ * @returns The resolved application manifest, config, and module capabilities.
  * @throws If no `package.json` can be found from `entrypoint` upward, or an explicitly requested
  * `manifest`/`config` file does not exist.
  * @example
@@ -79,7 +83,14 @@ export const resolveAppTestEnv = async (
     resolveConfig(env, options?.config),
   ]);
 
-  return { manifest, config };
+  const { dependencies, optionalDependencies, peerDependencies } = pkg.packageJson;
+  const usesFeatureFlag = Boolean(
+    dependencies?.[FEATURE_FLAG_PACKAGE] ??
+      optionalDependencies?.[FEATURE_FLAG_PACKAGE] ??
+      peerDependencies?.[FEATURE_FLAG_PACKAGE],
+  );
+
+  return { manifest, config, usesFeatureFlag };
 };
 
 /**

--- a/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
+++ b/packages/vitest-plugin/react-app/src/resolve-app-test-env.ts
@@ -13,16 +13,14 @@ import {
 } from '@equinor/fusion-framework-cli/app';
 import { resolvePackage } from '@equinor/fusion-framework-cli/utils';
 
-const FEATURE_FLAG_PACKAGE = '@equinor/fusion-framework-module-feature-flag';
-
 /**
  * The application manifest and config resolved for a test run.
  */
 export type AppTestEnv = {
   manifest: AppManifest;
   config: ApiAppConfig;
-  /** Whether the application declares the feature-flag module as a runtime dependency. */
-  usesFeatureFlag: boolean;
+  /** Package names declared by the application as runtime dependencies. */
+  runtimeDependencies: Array<string>;
 };
 
 /**
@@ -83,14 +81,14 @@ export const resolveAppTestEnv = async (
     resolveConfig(env, options?.config),
   ]);
 
-  const { dependencies, optionalDependencies, peerDependencies } = pkg.packageJson;
-  const usesFeatureFlag = Boolean(
-    dependencies?.[FEATURE_FLAG_PACKAGE] ??
-      optionalDependencies?.[FEATURE_FLAG_PACKAGE] ??
-      peerDependencies?.[FEATURE_FLAG_PACKAGE],
-  );
+  // Merge every runtime dependency category so module mock selection follows package ownership.
+  const runtimeDependencies = Object.keys({
+    ...pkg.packageJson.peerDependencies,
+    ...pkg.packageJson.optionalDependencies,
+    ...pkg.packageJson.dependencies,
+  });
 
-  return { manifest, config, usesFeatureFlag };
+  return { manifest, config, runtimeDependencies };
 };
 
 /**

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -1,10 +1,6 @@
 import type { AppEnv } from '@equinor/fusion-framework-app';
 import type { Fusion } from '@equinor/fusion-framework';
-import {
-  mockFramework,
-  type FrameworkMockConfigureFn,
-  type FrameworkMockConfigurator,
-} from '@equinor/fusion-framework/mock';
+import { mockFramework, type FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
 import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
 import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
@@ -13,45 +9,16 @@ import type { NavigationModule } from '@equinor/fusion-framework-module-navigati
 import { defaultAppEnv } from './default-app-env';
 
 /**
- * Enables the feature-flag mock only when `@equinor/fusion-framework-module-feature-flag` — an
- * optional peer dependency — is actually installed, so apps that don't use feature flags aren't
- * forced to install a module they never reference.
- */
-async function enableFeatureFlagMockIfAvailable(
-  configurator: FrameworkMockConfigurator<[AppModule, NavigationModule]>,
-): Promise<void> {
-  try {
-    const { enableFeatureFlagMock } = await import(
-      '@equinor/fusion-framework-module-feature-flag/mock'
-    );
-    enableFeatureFlagMock(configurator);
-  } catch (error) {
-    // re-throw anything other than the optional peer being missing, so a real
-    // registration failure isn't silently swallowed
-    if (
-      error instanceof Error &&
-      (error.message.includes('Cannot find module') || error.message.includes('MODULE_NOT_FOUND'))
-    ) {
-      return;
-    }
-    throw error;
-  }
-}
-
-/**
  * Resolves the parent Fusion instance backing an application module scope, building a
  * fresh {@link mockFramework} instance with this app's own manifest served when none is
  * given.
  *
  * @template TEnv - The application environment descriptor.
  * @param options - `env` seeds the built-in app manifest mock; navigation defaults to in-memory
- *   history, so tests don't leak URL/history state between runs. Feature flags default to the
- *   in-memory feature-flag mock, with none enabled, when the optional
- *   `@equinor/fusion-framework-module-feature-flag` peer dependency is installed. `configure`
- *   runs afterwards on the same configurator — e.g. call `enableNavigation` or
- *   `enableFeatureFlagMock` again to override either, or register extra modules and service
- *   discovery entries. `fusion`, an already-built parent instance, is reused as-is and skips
- *   `configure` entirely.
+ *   history, so tests don't leak URL/history state between runs. `configure` runs afterwards on
+ *   the same configurator — e.g. call `enableNavigation` to override the history or register
+ *   extra modules and service discovery entries. `fusion`, an already-built parent instance, is
+ *   reused as-is and skips `configure` entirely.
  * @returns The given `fusion`, or a fresh mocked parent Fusion instance.
  */
 export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
@@ -67,7 +34,6 @@ export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
       enableNavigation(configurator, {
         configure: (config) => config.setHistory(createHistory('memory')),
       });
-      await enableFeatureFlagMockIfAvailable(configurator);
       await configure?.(configurator);
     })
   );

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -1,6 +1,10 @@
 import type { AppEnv } from '@equinor/fusion-framework-app';
 import type { Fusion } from '@equinor/fusion-framework';
-import { mockFramework, type FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
+import {
+  mockFramework,
+  type FrameworkMockConfigureFn,
+  type FrameworkMockConfigurator,
+} from '@equinor/fusion-framework/mock';
 import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
 import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
@@ -9,6 +13,34 @@ import type { NavigationModule } from '@equinor/fusion-framework-module-navigati
 
 import { defaultAppEnv } from './default-app-env';
 
+type AppModuleMockInstaller = (
+  configurator: FrameworkMockConfigurator<[AppModule, NavigationModule]>,
+) => void;
+
+const APP_MODULE_MOCKS: ReadonlyMap<string, AppModuleMockInstaller> = new Map([
+  ['@equinor/fusion-framework-module-feature-flag', enableFeatureFlagMock],
+]);
+
+/**
+ * Enables parent framework mocks associated with the application's runtime dependencies.
+ *
+ * @param configurator - Parent framework configurator receiving module mocks.
+ * @param runtimeDependencies - Package names declared by the tested application.
+ */
+function enableAppModuleMocks(
+  configurator: FrameworkMockConfigurator<[AppModule, NavigationModule]>,
+  runtimeDependencies: ReadonlyArray<string>,
+): void {
+  // Resolve each app dependency independently so new module mocks only require a registry entry.
+  for (const dependency of runtimeDependencies) {
+    const installMock = APP_MODULE_MOCKS.get(dependency);
+    // Dependencies without a parent mock require no framework-level setup.
+    if (installMock) {
+      installMock(configurator);
+    }
+  }
+}
+
 /**
  * Resolves the parent Fusion instance backing an application module scope, building a
  * fresh {@link mockFramework} instance with this app's own manifest served when none is
@@ -16,8 +48,8 @@ import { defaultAppEnv } from './default-app-env';
  *
  * @template TEnv - The application environment descriptor.
  * @param options - `env` seeds the built-in app manifest mock; navigation defaults to in-memory
- *   history, so tests don't leak URL/history state between runs. `mockFeatureFlag` enables the
- *   parent feature-flag mock when the tested app declares that module. `configure` runs
+ *   history, so tests don't leak URL/history state between runs. `runtimeDependencies` enables
+ *   parent module mocks associated with packages declared by the tested app. `configure` runs
  *   afterwards on the same configurator — e.g. call `enableNavigation` to override the history
  *   or register extra modules and service discovery entries. `fusion`, an already-built parent
  *   instance, is reused as-is and skips `configure` entirely.
@@ -27,9 +59,9 @@ export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
   env?: TEnv;
   fusion?: Fusion;
   configure?: FrameworkMockConfigureFn<[AppModule, NavigationModule]>;
-  mockFeatureFlag?: boolean;
+  runtimeDependencies?: ReadonlyArray<string>;
 }): Promise<Fusion> {
-  const { env, fusion, configure, mockFeatureFlag } = options ?? {};
+  const { env, fusion, configure, runtimeDependencies = [] } = options ?? {};
   return (
     fusion ??
     mockFramework<[AppModule, NavigationModule]>(async (configurator) => {
@@ -37,10 +69,7 @@ export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
       enableNavigation(configurator, {
         configure: (config) => config.setHistory(createHistory('memory')),
       });
-      // Mirror feature flags into the parent only for apps that declare the module.
-      if (mockFeatureFlag) {
-        enableFeatureFlagMock(configurator);
-      }
+      enableAppModuleMocks(configurator, runtimeDependencies);
       await configure?.(configurator);
     })
   );

--- a/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
+++ b/packages/vitest-plugin/react-app/src/scope/resolve-fusion.ts
@@ -3,6 +3,7 @@ import type { Fusion } from '@equinor/fusion-framework';
 import { mockFramework, type FrameworkMockConfigureFn } from '@equinor/fusion-framework/mock';
 import { enableAppManifestMock } from '@equinor/fusion-framework-app/mock';
 import type { AppModule } from '@equinor/fusion-framework-module-app';
+import { enableFeatureFlagMock } from '@equinor/fusion-framework-module-feature-flag/mock';
 import { enableNavigation, createHistory } from '@equinor/fusion-framework-module-navigation';
 import type { NavigationModule } from '@equinor/fusion-framework-module-navigation';
 
@@ -15,18 +16,20 @@ import { defaultAppEnv } from './default-app-env';
  *
  * @template TEnv - The application environment descriptor.
  * @param options - `env` seeds the built-in app manifest mock; navigation defaults to in-memory
- *   history, so tests don't leak URL/history state between runs. `configure` runs afterwards on
- *   the same configurator — e.g. call `enableNavigation` to override the history or register
- *   extra modules and service discovery entries. `fusion`, an already-built parent instance, is
- *   reused as-is and skips `configure` entirely.
+ *   history, so tests don't leak URL/history state between runs. `mockFeatureFlag` enables the
+ *   parent feature-flag mock when the tested app declares that module. `configure` runs
+ *   afterwards on the same configurator — e.g. call `enableNavigation` to override the history
+ *   or register extra modules and service discovery entries. `fusion`, an already-built parent
+ *   instance, is reused as-is and skips `configure` entirely.
  * @returns The given `fusion`, or a fresh mocked parent Fusion instance.
  */
 export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
   env?: TEnv;
   fusion?: Fusion;
   configure?: FrameworkMockConfigureFn<[AppModule, NavigationModule]>;
+  mockFeatureFlag?: boolean;
 }): Promise<Fusion> {
-  const { env, fusion, configure } = options ?? {};
+  const { env, fusion, configure, mockFeatureFlag } = options ?? {};
   return (
     fusion ??
     mockFramework<[AppModule, NavigationModule]>(async (configurator) => {
@@ -34,6 +37,10 @@ export async function resolveFusion<TEnv extends AppEnv = AppEnv>(options?: {
       enableNavigation(configurator, {
         configure: (config) => config.setHistory(createHistory('memory')),
       });
+      // Mirror feature flags into the parent only for apps that declare the module.
+      if (mockFeatureFlag) {
+        enableFeatureFlagMock(configurator);
+      }
       await configure?.(configurator);
     })
   );

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -109,6 +109,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  */
 export const testApp = baseTest
   .extend('appEnv', { injected: true }, defaultAppEnv)
+  .extend('mockFeatureFlag', { injected: true }, false)
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
   .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
@@ -122,8 +123,8 @@ export const testApp = baseTest
   // IMPORTANT: `.override('fusion', ...)` replaces this resolver entirely, so `configureFusion`
   // is never called — reach for `configureFusion` to extend the base mock, `fusion` only to
   // replace it outright (e.g. with a fully custom or non-mocked instance).
-  .extend('fusion', async ({ appEnv, configureFusion }) =>
-    resolveFusion({ env: appEnv, configure: configureFusion }),
+  .extend('fusion', async ({ appEnv, configureFusion, mockFeatureFlag }) =>
+    resolveFusion({ env: appEnv, configure: configureFusion, mockFeatureFlag }),
   )
   .extend('app', async ({ configureApp, appEnv, fusion }) =>
     mockAppModules<unknown, AppEnv>(configureApp, appEnv as AppEnv, fusion),

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -109,7 +109,7 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  */
 export const testApp = baseTest
   .extend('appEnv', { injected: true }, defaultAppEnv)
-  .extend('mockFeatureFlag', { injected: true }, false)
+  .extend('runtimeDependencies', { injected: true }, [] as Array<string>)
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
   .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
@@ -123,8 +123,8 @@ export const testApp = baseTest
   // IMPORTANT: `.override('fusion', ...)` replaces this resolver entirely, so `configureFusion`
   // is never called — reach for `configureFusion` to extend the base mock, `fusion` only to
   // replace it outright (e.g. with a fully custom or non-mocked instance).
-  .extend('fusion', async ({ appEnv, configureFusion, mockFeatureFlag }) =>
-    resolveFusion({ env: appEnv, configure: configureFusion, mockFeatureFlag }),
+  .extend('fusion', async ({ appEnv, configureFusion, runtimeDependencies }) =>
+    resolveFusion({ env: appEnv, configure: configureFusion, runtimeDependencies }),
   )
   .extend('app', async ({ configureApp, appEnv, fusion }) =>
     mockAppModules<unknown, AppEnv>(configureApp, appEnv as AppEnv, fusion),

--- a/packages/vitest-plugin/react-app/src/test-app.tsx
+++ b/packages/vitest-plugin/react-app/src/test-app.tsx
@@ -92,16 +92,13 @@ import { defaultAppEnv, resolveFusion, createAppScopeWrapper } from './scope';
  * });
  * ```
  *
- * @example Extend the parent framework mock with an application module
+ * @example Extend the parent framework mock with service discovery
  * ```tsx
  * const test = testApp.extend(
  *   'configureFusion',
  *   { injected: true },
  *   (): FrameworkMockConfigureFn<[AppModule, NavigationModule]> =>
  *     (configurator) => {
- *       // seed a specific flag rather than merely enabling the mock — that's already the
- *       // default when the optional feature-flag peer dependency is installed
- *       enableFeatureFlagMock(configurator, (mock) => mock.addFeature({ key: 'new-search', enabled: true }));
  *       configurator.serviceDiscovery.addServices([
  *         { key: 'people', uri: baseUrl('people') },
  *         { key: 'context', uri: baseUrl('context') },
@@ -115,9 +112,8 @@ export const testApp = baseTest
   // `test.extend`'s plain-`value` overload rejects function types (ambiguous with the
   // resolver-`fn` overload), so a function-typed fixture default must go through `fn` instead.
   .extend('configureApp', { injected: true }, () => undefined as AppMockConfigureFn | undefined)
-  // Runs after the built-in app manifest/navigation/feature-flag setup, so a test can register
-  // extra framework modules, service discovery entries, or call `enableNavigation`/
-  // `enableFeatureFlagMock` again to override either, without reimplementing the base setup.
+  // Runs after the built-in app manifest/navigation setup, so a test can register
+  // framework-scoped modules, service discovery entries, or override navigation.
   .extend(
     'configureFusion',
     { injected: true },

--- a/packages/vitest-plugin/react-app/src/test.tsx
+++ b/packages/vitest-plugin/react-app/src/test.tsx
@@ -2,7 +2,7 @@ import { testApp as baseTestApp } from './test-app';
 
 // resolved at test-time by `appTestVitePlugin` (@equinor/fusion-framework-vitest-plugin-react-app);
 // see virtual-modules.d.ts for the ambient module declarations
-import { manifest, config, usesFeatureFlag } from 'virtual:fusion-app-test-env';
+import { manifest, config, runtimeDependencies } from 'virtual:fusion-app-test-env';
 import { configure as configureApp } from 'virtual:fusion-app-test-configure';
 
 /**
@@ -37,7 +37,7 @@ import { configure as configureApp } from 'virtual:fusion-app-test-configure';
  */
 export const test = baseTestApp
   .extend('appEnv', { injected: true }, { manifest, config })
-  .extend('mockFeatureFlag', { injected: true }, usesFeatureFlag)
+  .extend('runtimeDependencies', { injected: true }, runtimeDependencies)
   .extend('configureApp', { injected: true }, () => configureApp);
 
 export default test;

--- a/packages/vitest-plugin/react-app/src/test.tsx
+++ b/packages/vitest-plugin/react-app/src/test.tsx
@@ -2,7 +2,7 @@ import { testApp as baseTestApp } from './test-app';
 
 // resolved at test-time by `appTestVitePlugin` (@equinor/fusion-framework-vitest-plugin-react-app);
 // see virtual-modules.d.ts for the ambient module declarations
-import { manifest, config } from 'virtual:fusion-app-test-env';
+import { manifest, config, usesFeatureFlag } from 'virtual:fusion-app-test-env';
 import { configure as configureApp } from 'virtual:fusion-app-test-configure';
 
 /**
@@ -37,6 +37,7 @@ import { configure as configureApp } from 'virtual:fusion-app-test-configure';
  */
 export const test = baseTestApp
   .extend('appEnv', { injected: true }, { manifest, config })
+  .extend('mockFeatureFlag', { injected: true }, usesFeatureFlag)
   .extend('configureApp', { injected: true }, () => configureApp);
 
 export default test;

--- a/packages/vitest-plugin/react-app/src/virtual-modules.d.ts
+++ b/packages/vitest-plugin/react-app/src/virtual-modules.d.ts
@@ -3,6 +3,7 @@ declare module 'virtual:fusion-app-test-env' {
 
   export const manifest: AppEnv['manifest'];
   export const config: AppEnv['config'];
+  export const usesFeatureFlag: boolean;
 }
 
 declare module 'virtual:fusion-app-test-configure' {

--- a/packages/vitest-plugin/react-app/src/virtual-modules.d.ts
+++ b/packages/vitest-plugin/react-app/src/virtual-modules.d.ts
@@ -3,7 +3,7 @@ declare module 'virtual:fusion-app-test-env' {
 
   export const manifest: AppEnv['manifest'];
   export const config: AppEnv['config'];
-  export const usesFeatureFlag: boolean;
+  export const runtimeDependencies: Array<string>;
 }
 
 declare module 'virtual:fusion-app-test-configure' {

--- a/packages/vitest-plugin/react-app/tsconfig.json
+++ b/packages/vitest-plugin/react-app/tsconfig.json
@@ -17,6 +17,7 @@
     { "path": "../../modules/app" },
     { "path": "../../modules/navigation" },
     { "path": "../../modules/feature-flag" },
+    { "path": "../../modules/telemetry" },
     { "path": "../../react/framework" },
     { "path": "../../react/modules/module" },
     { "path": "../../utils/imports" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3378,9 +3378,15 @@ importers:
       '@equinor/fusion-framework-module-app':
         specifier: workspace:*
         version: link:../../modules/app
+      '@equinor/fusion-framework-module-feature-flag':
+        specifier: workspace:*
+        version: link:../../modules/feature-flag
       '@equinor/fusion-framework-module-navigation':
         specifier: workspace:*
         version: link:../../modules/navigation
+      '@equinor/fusion-framework-module-telemetry':
+        specifier: workspace:*
+        version: link:../../modules/telemetry
       '@equinor/fusion-framework-react':
         specifier: workspace:*
         version: link:../../react/framework
@@ -3391,9 +3397,6 @@ importers:
         specifier: workspace:*
         version: link:../../utils/imports
     devDependencies:
-      '@equinor/fusion-framework-module-feature-flag':
-        specifier: workspace:*
-        version: link:../../modules/feature-flag
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.18


### PR DESCRIPTION
**Why is this change needed?**

Applications using the React app Vitest plugin currently have to declare `@equinor/fusion-framework-module-feature-flag` and `@equinor/fusion-framework-module-telemetry` themselves before their tests can resolve the full Fusion app test bundle. Installing the test plugin should be sufficient.

**What is the current behavior?**

The feature-flag module is an optional peer dependency and telemetry is not declared directly by the plugin. Parent feature-flag mocking is inferred from whether Node can resolve the optional package, so dependency availability and application behavior are coupled.

**What is the new behavior?**

The plugin installs feature-flag and telemetry as runtime dependencies, so apps no longer list either package solely to run tests. The Vite plugin exposes the tested application's generic runtime dependency list, and `resolveFusion` applies parent mocks through a dependency-to-mock registry. The current registry automatically enables the in-memory parent feature-flag mock when the app declares `@equinor/fusion-framework-module-feature-flag`. Apps without feature flags do not receive the mock, and app teams do not configure feature flags through `configureFusion`.

**What is the intended behavior or invariant?**

Installing `@equinor/fusion-framework-vitest-plugin-react-app` provides the modules required to resolve app test bundles. Parent test mocks follow the application's runtime dependencies. Supporting another app module requires a registry entry rather than another module-specific fixture or `resolveFusion` option.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: App test projects can remove test-only declarations of feature-flag and telemetry. Feature-flag apps require no `configureFusion` setup.
- Downstream impact: Limited to consumers of the React app Vitest plugin.

**Review guidance:**

Verify three paths: the packed plugin owns both dependencies; an app declaring feature flags receives `fusion.modules.featureFlag`; and an app without that declaration does not. Review `APP_MODULE_MOCKS` as the single extension point for future dependency-driven parent mocks.

**Additional context**

Validation:
- `pnpm --filter @equinor/fusion-framework-vitest-plugin-react-app test` — 22/22 tests passed
- `pnpm --filter @equinor/fusion-framework-vitest-plugin-react-app build` — passed
- `pnpm --filter @equinor/fusion-framework-cookbook-app-react-feature-flag test` — 2/2 tests passed
- `pnpm --filter @equinor/fusion-framework-cookbook-app-react-router test` — 39/39 tests passed (non-feature app control)
- `pnpm exec fusion-lint lint packages/vitest-plugin/react-app` — passed
- Targeted Biome checks and `git diff --check` — passed
- `pnpm build` — passed
- `pnpm lint` — passed with one pre-existing Biome schema-version info message
- `pnpm test` — emitted passing results through the final test file but did not exit or print the aggregate summary; the non-exiting runner was stopped after approximately ten minutes

**Related issues**

None.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [ ] Confirm changes to target branch validation
  - _Included files validated_
  - _No new linting warnings_
  - _Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)