### PR TITLE
feat(lint-config): add graduated lint presets

### DIFF
--- a/.changeset/fusion-framework-lint-config_add-presets.md
+++ b/.changeset/fusion-framework-lint-config_add-presets.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-lint-config": minor
+---
+
+Add `default`, `balanced`, and `strict` Fusion lint presets. The implicit default is intentionally loose for application code but still warns when exported functions, hooks, or components lack TSDoc and when TODOs lack issue references, while reusable public code can select `balanced` and critical framework code can select `strict`.

--- a/fusion-lint.config.json
+++ b/fusion-lint.config.json
@@ -1,4 +1,5 @@
 {
+  "preset": "strict",
   "rules": {
     "single-export-per-file": {
       "excludePattern": [

--- a/packages/linting/config/README.md
+++ b/packages/linting/config/README.md
@@ -1,10 +1,10 @@
 # @equinor/fusion-framework-lint-config
 
-Recommended Fusion lint configuration — a curated set of rules, default severities, a config-file loader, and a fluent `ConfigBuilder` API for extending the linter with custom rules.
+Fusion lint configuration provides loose, balanced, and strict severity presets, a config-file loader, and a fluent `ConfigBuilder` API for extending the linter with custom rules.
 
 ## When to use this package
 
-- You want the recommended rule preset with the engine in `@equinor/fusion-framework-lint-core`.
+- You want a preset matched to application, reusable component, or critical framework code.
 - You want to load and resolve a project-level config file (`fusion-lint.config.ts`, `.fusion-lintrc.json`, etc.).
 - You want a `defineConfig` helper for type-safe config files.
 - You want to register custom rules or adjust built-in severities programmatically.
@@ -17,6 +17,42 @@ import { recommendedRules, recommendedConfig } from '@equinor/fusion-framework-l
 
 const engine = new LintEngine(recommendedRules, recommendedConfig);
 const diagnostics = engine.lint(source, filePath);
+```
+
+`recommendedConfig` is a backwards-compatible alias for `defaultConfig`.
+
+## Choose a preset
+
+| Preset | Intended use | Behavior |
+|---|---|---|
+| `default` | Application code | Loose by design. Enforces correctness rules such as `no-empty-catch`; warns when exported functions, hooks, or components lack TSDoc or a TODO lacks an issue reference; and leaves intent and file-structure rules off. |
+| `balanced` | Reusable components and public APIs | Keeps correctness rules strict and reports public API documentation and structural conventions as warnings. |
+| `strict` | Fusion Framework and other critical libraries | Enforces intent comments, TSDoc, and maintainability conventions as errors. |
+
+Select a preset in a rich JSON, YAML, JavaScript, or TypeScript config:
+
+```json
+{
+  "preset": "balanced",
+  "rules": {
+    "require-tsdoc": "error"
+  }
+}
+```
+
+The `rules` map is applied after the preset, so projects can tune individual rules. With no
+project config, Fusion lint uses the loose `default` preset.
+
+For direct engine construction, import the corresponding severity map:
+
+```typescript
+import {
+  balancedConfig,
+  recommendedRules,
+} from '@equinor/fusion-framework-lint-config';
+import { LintEngine } from '@equinor/fusion-framework-lint-core';
+
+const engine = new LintEngine(recommendedRules, balancedConfig);
 ```
 
 ## Config files
@@ -142,7 +178,11 @@ const engine = new LintEngine(recommendedRules, {
 | Export | Description |
 |---|---|
 | `recommendedRules` | Array of built-in `Rule` objects |
-| `recommendedConfig` | Default severity map for all built-in rules |
+| `defaultConfig` | Loose severity map used by default for application code |
+| `balancedConfig` | Medium-strictness severity map for reusable public code |
+| `strictConfig` | Strict severity map for critical framework code |
+| `recommendedConfig` | Backwards-compatible alias for `defaultConfig` |
+| `LintPreset` | Built-in preset name: `default`, `balanced`, or `strict` |
 | `defineConfig(config)` | Type helper — object form |
 | `defineConfig(factory)` | Type helper — builder form |
 | `loadLintConfig(options?)` | Finds and resolves the nearest config file |

--- a/packages/linting/config/src/__tests__/fixtures/json-invalid-preset/fusion-lint.config.json
+++ b/packages/linting/config/src/__tests__/fixtures/json-invalid-preset/fusion-lint.config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "maximum"
+}

--- a/packages/linting/config/src/__tests__/fixtures/json-preset/fusion-lint.config.json
+++ b/packages/linting/config/src/__tests__/fixtures/json-preset/fusion-lint.config.json
@@ -1,0 +1,6 @@
+{
+  "preset": "balanced",
+  "rules": {
+    "require-tsdoc": "error"
+  }
+}

--- a/packages/linting/config/src/__tests__/load-config.test.ts
+++ b/packages/linting/config/src/__tests__/load-config.test.ts
@@ -4,6 +4,7 @@ import { join, dirname } from 'node:path';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { loadLintConfig } from '../load-lint-config.js';
+import { balancedConfig } from '../balanced-config.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -51,6 +52,7 @@ describe('loadLintConfig', () => {
         'require-tsdoc': 'error',
         'single-export-per-file': 'warn',
       });
+
       expect(Object.keys(result?.ruleMatchers ?? {})).toEqual([
         'single-export-per-file',
         'no-class-components',
@@ -64,6 +66,31 @@ describe('loadLintConfig', () => {
       const noClassComponentsMatcher = result?.ruleMatchers['no-class-components'];
       expect(noClassComponentsMatcher?.('/src/Component.tsx')).toBe(true);
       expect(noClassComponentsMatcher?.('/src/util.ts')).toBe(false);
+    });
+
+    it('loads a preset before applying per-rule overrides', async () => {
+      const result = await loadLintConfig({ cwd: fixture('json-preset') });
+
+      expect(result?.config).toEqual({
+        ...balancedConfig,
+        'require-tsdoc': 'error',
+      });
+    });
+
+    it('rejects an unknown preset', async () => {
+      await expect(loadLintConfig({ cwd: fixture('json-invalid-preset') })).rejects.toThrow(
+        'Unknown Fusion lint preset: maximum',
+      );
+    });
+
+    it('layers a rich config over the provided default base', async () => {
+      const base = { 'require-tsdoc': 'off', 'no-empty-catch': 'error' } as const;
+      const result = await loadLintConfig({ cwd: fixture('json-rich-matchers'), base });
+
+      expect(result?.config).toMatchObject({
+        'require-tsdoc': 'error',
+        'no-empty-catch': 'error',
+      });
     });
   });
 

--- a/packages/linting/config/src/__tests__/preset-configs.test.ts
+++ b/packages/linting/config/src/__tests__/preset-configs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { balancedConfig } from '../balanced-config.js';
+import { defaultConfig } from '../default-config.js';
+import { recommendedConfig } from '../recommended-config.js';
+import { strictConfig } from '../strict-config.js';
+
+describe('lint presets', () => {
+  it('uses the loose default as the backwards-compatible recommended config', () => {
+    expect(recommendedConfig).toBe(defaultConfig);
+    expect(defaultConfig['require-intent-comment/flow']).toBe('off');
+    expect(defaultConfig['require-tsdoc']).toBe('warn');
+    expect(defaultConfig['require-component-tsdoc']).toBe('warn');
+    expect(defaultConfig['require-hook-tsdoc']).toBe('warn');
+    expect(defaultConfig['require-property-tsdoc']).toBe('off');
+    expect(defaultConfig['no-todo-without-issue']).toBe('warn');
+    expect(defaultConfig['no-empty-catch']).toBe('error');
+  });
+
+  it('adds public API guidance in the balanced preset', () => {
+    expect(balancedConfig['require-tsdoc']).toBe('warn');
+    expect(balancedConfig['require-component-tsdoc']).toBe('warn');
+    expect(balancedConfig['single-export-per-file']).toBe('warn');
+    expect(balancedConfig['require-intent-comment/flow']).toBe('off');
+  });
+
+  it('enforces intent and maintainability in the strict preset', () => {
+    expect(Object.values(strictConfig)).not.toContain('off');
+    expect(Object.values(strictConfig)).not.toContain('warn');
+    expect(strictConfig['require-intent-comment/flow']).toBe('error');
+    expect(strictConfig['require-tsdoc']).toBe('error');
+  });
+});

--- a/packages/linting/config/src/balanced-config.ts
+++ b/packages/linting/config/src/balanced-config.ts
@@ -1,0 +1,24 @@
+import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+
+/**
+ * Balanced preset for reusable components and non-critical public APIs.
+ */
+export const balancedConfig: LintConfig = {
+  'require-intent-comment/flow': 'off',
+  'require-intent-comment/iterators': 'off',
+  'require-intent-comment/rxjs': 'off',
+  'require-intent-comment/break-continue': 'off',
+  'require-intent-comment/type-assertion': 'warn',
+  'require-intent-comment/object-merge': 'off',
+  'require-tsdoc': 'warn',
+  'require-component-tsdoc': 'warn',
+  'require-hook-tsdoc': 'warn',
+  'require-property-tsdoc': 'warn',
+  'require-node-protocol': 'error',
+  'no-class-components': 'error',
+  'no-todo-without-issue': 'warn',
+  'no-empty-catch': 'error',
+  'no-separate-export': 'warn',
+  'single-export-per-file': 'warn',
+  'filename-convention': 'warn',
+};

--- a/packages/linting/config/src/default-config.ts
+++ b/packages/linting/config/src/default-config.ts
@@ -1,0 +1,24 @@
+import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+
+/**
+ * Loose preset for application code where teams opt into additional quality rules.
+ */
+export const defaultConfig: LintConfig = {
+  'require-intent-comment/flow': 'off',
+  'require-intent-comment/iterators': 'off',
+  'require-intent-comment/rxjs': 'off',
+  'require-intent-comment/break-continue': 'off',
+  'require-intent-comment/type-assertion': 'off',
+  'require-intent-comment/object-merge': 'off',
+  'require-tsdoc': 'warn',
+  'require-component-tsdoc': 'warn',
+  'require-hook-tsdoc': 'warn',
+  'require-property-tsdoc': 'off',
+  'require-node-protocol': 'error',
+  'no-class-components': 'off',
+  'no-todo-without-issue': 'warn',
+  'no-empty-catch': 'error',
+  'no-separate-export': 'off',
+  'single-export-per-file': 'off',
+  'filename-convention': 'off',
+};

--- a/packages/linting/config/src/define-config.ts
+++ b/packages/linting/config/src/define-config.ts
@@ -1,5 +1,6 @@
 import type { Rule, LintConfig, SeverityConfig } from '@equinor/fusion-framework-lint-core';
 import type { ConfigBuilder } from './ConfigBuilder.js';
+import type { LintPreset } from './lint-preset.js';
 
 /**
  * Per-rule configuration entry accepted in the `rules` map of a
@@ -47,6 +48,8 @@ export type RuleConfigEntry =
 export type FusionLintFileConfig =
   | LintConfig
   | {
+      /** Built-in severity preset used before applying `rules` overrides. */
+      preset?: LintPreset;
       /** Severity and/or file-scoping overrides, keyed by rule ID. */
       rules?: Record<string, RuleConfigEntry>;
       /** Custom rule implementations to register alongside built-in rules. */

--- a/packages/linting/config/src/index.ts
+++ b/packages/linting/config/src/index.ts
@@ -1,4 +1,11 @@
-export { recommendedRules, recommendedConfig } from './recommended-rules.js';
+export {
+  recommendedRules,
+  recommendedConfig,
+  defaultConfig,
+  balancedConfig,
+  strictConfig,
+} from './recommended-rules.js';
+export type { LintPreset } from './lint-preset.js';
 export {
   ConfigBuilder,
   type LoadedLintConfig,

--- a/packages/linting/config/src/lint-preset.ts
+++ b/packages/linting/config/src/lint-preset.ts
@@ -1,0 +1,8 @@
+/**
+ * Built-in Fusion lint preset names.
+ *
+ * - `default` is intentionally loose for application code.
+ * - `balanced` adds guidance for reusable and publicly consumed code.
+ * - `strict` preserves intent and maintainability in critical framework code.
+ */
+export type LintPreset = 'default' | 'balanced' | 'strict';

--- a/packages/linting/config/src/load-lint-config.ts
+++ b/packages/linting/config/src/load-lint-config.ts
@@ -11,6 +11,8 @@ import type {
   FusionLintConfigFactory,
   RuleConfigEntry,
 } from './define-config.js';
+import { resolvePresetConfig } from './resolve-preset-config.js';
+import type { LintPreset } from './lint-preset.js';
 
 /** Config file basenames searched in order. */
 const CONFIG_BASENAMES = ['fusion-lint.config', '.fusion-lintrc'] as const;
@@ -94,12 +96,15 @@ async function resolveConfigFileUpwards(startDir: string, findUp: boolean): Prom
  * format rather than a flat `LintConfig` map.
  */
 function isRichConfig(value: FusionLintFileConfig): value is {
+  preset?: LintPreset;
   rules?: Record<string, RuleConfigEntry>;
   customRules?: Rule[];
   ignorePatterns?: string[];
 } {
   // Guard: flat configs have only string values; rich configs have object/array sub-keys
-  return 'rules' in value || 'customRules' in value || 'ignorePatterns' in value;
+  return (
+    'preset' in value || 'rules' in value || 'customRules' in value || 'ignorePatterns' in value
+  );
 }
 
 /**
@@ -138,19 +143,28 @@ function splitRuleEntries(rules: Record<string, RuleConfigEntry>): {
 /**
  * Normalises any supported file format to a {@link LoadedLintConfig}.
  */
-function normalise(raw: FusionLintFileConfig): LoadedLintConfig {
+function normalise(raw: FusionLintFileConfig, base: LintConfig): LoadedLintConfig {
   // Rich format: extract rules, customRules, and ignorePatterns separately
   if (isRichConfig(raw)) {
     const { config, ruleMatchers } = splitRuleEntries(raw.rules ?? {});
+    // The selected preset or caller base establishes defaults before project overrides.
     return {
-      config,
+      config: {
+        ...(raw.preset ? resolvePresetConfig(raw.preset) : base),
+        ...config,
+      },
       customRules: raw.customRules ?? [],
       ignorePatterns: raw.ignorePatterns ?? [],
       ruleMatchers,
     };
   }
   // Flat format: the entire object is the severity map
-  return { config: raw as LintConfig, customRules: [], ignorePatterns: [], ruleMatchers: {} };
+  return {
+    config: { ...base, ...(raw as LintConfig) },
+    customRules: [],
+    ignorePatterns: [],
+    ruleMatchers: {},
+  };
 }
 
 /**
@@ -195,7 +209,7 @@ export async function loadLintConfig(
     const raw = await readFile(filePath, 'utf-8');
     // Guard: empty or comment-only YAML files parse to null — treat as empty config
     const parsed = (parseYaml(raw) ?? {}) as FusionLintFileConfig;
-    return normalise(parsed);
+    return normalise(parsed, options.base ?? {});
   }
 
   // Delegate TS / JS / JSON loading to fusion-imports (esbuild-backed)
@@ -208,5 +222,5 @@ export async function loadLintConfig(
     await rawExport(builder);
     return builder.resolve(options.base ?? {});
   }
-  return normalise(rawExport);
+  return normalise(rawExport, options.base ?? {});
 }

--- a/packages/linting/config/src/load-lint-config.ts
+++ b/packages/linting/config/src/load-lint-config.ts
@@ -101,7 +101,7 @@ function isRichConfig(value: FusionLintFileConfig): value is {
   customRules?: Rule[];
   ignorePatterns?: string[];
 } {
-  // Guard: flat configs have only string values; rich configs have object/array sub-keys
+  // Guard: rich configs are identified by reserved top-level keys (preset/rules/customRules/ignorePatterns); flat configs are plain severity maps
   return (
     'preset' in value || 'rules' in value || 'customRules' in value || 'ignorePatterns' in value
   );

--- a/packages/linting/config/src/recommended-config.ts
+++ b/packages/linting/config/src/recommended-config.ts
@@ -1,21 +1,6 @@
-import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+import { defaultConfig } from './default-config.js';
 
 /**
- * Severity overrides for the `recommended` preset.
+ * Backwards-compatible alias for the loose {@link defaultConfig} preset.
  */
-export const recommendedConfig: LintConfig = {
-  'require-intent-comment/flow': 'warn',
-  'require-intent-comment/iterators': 'warn',
-  'require-intent-comment/rxjs': 'warn',
-  'require-intent-comment/break-continue': 'warn',
-  'require-intent-comment/type-assertion': 'error',
-  'require-intent-comment/object-merge': 'warn',
-  'require-tsdoc': 'warn',
-  'require-node-protocol': 'error',
-  'no-class-components': 'error',
-  'no-todo-without-issue': 'warn',
-  'no-empty-catch': 'error',
-  'no-separate-export': 'error',
-  'single-export-per-file': 'warn',
-  'filename-convention': 'warn',
-};
+export const recommendedConfig = defaultConfig;

--- a/packages/linting/config/src/recommended-rules.ts
+++ b/packages/linting/config/src/recommended-rules.ts
@@ -20,6 +20,9 @@ import {
 } from '@equinor/fusion-framework-lint-rules';
 
 export { recommendedConfig } from './recommended-config.js';
+export { defaultConfig } from './default-config.js';
+export { balancedConfig } from './balanced-config.js';
+export { strictConfig } from './strict-config.js';
 
 /**
  * Ordered list of rules included in the `recommended` preset.

--- a/packages/linting/config/src/resolve-preset-config.ts
+++ b/packages/linting/config/src/resolve-preset-config.ts
@@ -1,0 +1,26 @@
+import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+import { balancedConfig } from './balanced-config.js';
+import { defaultConfig } from './default-config.js';
+import { strictConfig } from './strict-config.js';
+import type { LintPreset } from './lint-preset.js';
+
+/**
+ * Resolves a built-in preset name to its severity configuration.
+ *
+ * @param preset - Built-in preset selected by a project config.
+ * @returns The severity configuration for the selected preset.
+ * @throws {Error} When a dynamically loaded config contains an unknown preset name.
+ */
+export function resolvePresetConfig(preset: LintPreset): LintConfig {
+  // Keep runtime-loaded JSON and YAML configs aligned with the compile-time preset union.
+  switch (preset) {
+    case 'default':
+      return defaultConfig;
+    case 'balanced':
+      return balancedConfig;
+    case 'strict':
+      return strictConfig;
+    default:
+      throw new Error(`Unknown Fusion lint preset: ${String(preset)}`);
+  }
+}

--- a/packages/linting/config/src/strict-config.ts
+++ b/packages/linting/config/src/strict-config.ts
@@ -1,0 +1,24 @@
+import type { LintConfig } from '@equinor/fusion-framework-lint-core';
+
+/**
+ * Strict preset for critical framework code whose intent must remain maintainable.
+ */
+export const strictConfig: LintConfig = {
+  'require-intent-comment/flow': 'error',
+  'require-intent-comment/iterators': 'error',
+  'require-intent-comment/rxjs': 'error',
+  'require-intent-comment/break-continue': 'error',
+  'require-intent-comment/type-assertion': 'error',
+  'require-intent-comment/object-merge': 'error',
+  'require-tsdoc': 'error',
+  'require-component-tsdoc': 'error',
+  'require-hook-tsdoc': 'error',
+  'require-property-tsdoc': 'error',
+  'require-node-protocol': 'error',
+  'no-class-components': 'error',
+  'no-todo-without-issue': 'error',
+  'no-empty-catch': 'error',
+  'no-separate-export': 'error',
+  'single-export-per-file': 'error',
+  'filename-convention': 'error',
+};


### PR DESCRIPTION
**Why is this change needed?**

The implicit Fusion lint preset is appropriate for framework code but too eager for application projects. Consumers need clear strictness tiers so apps can start loose while reusable and critical code can opt into stronger maintainability checks.

**What is the current behavior?**

Fusion lint exposes one recommended severity map. It warns broadly about intent comments, TSDoc, TODOs, and file structure regardless of whether the target is application code or critical framework code.

**What is the new behavior?**

Fusion lint provides `default`, `balanced`, and `strict` presets. `default` keeps correctness errors and non-blocking warnings for public function, hook, and component TSDoc plus TODO issue references; `balanced` adds public API and structural guidance; `strict` enforces intent and maintainability rules as errors. Rich configs can select a preset and then override individual rules, while `recommendedConfig` remains an alias for the loose default. This repository explicitly selects `strict`.

**What is the intended behavior or invariant?**

Preset severity increases monotonically with code criticality. Explicit project rule overrides always win over the selected preset, invalid runtime preset names fail clearly, and existing consumers of `recommendedConfig` continue to compile.

**Does this PR introduce a breaking change?**

No API symbols are removed. The implicit `recommendedConfig` behavior becomes intentionally less strict and is documented in the minor changeset.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor
- Consumer impact: Application projects receive fewer default diagnostics and can select `balanced` or `strict` when appropriate.
- Downstream impact: The CLI and LSP continue using `recommendedConfig`; the framework repository opts into `strict` explicitly.

**Review guidance:**

Focus on the severity boundaries in the three preset maps, preset-versus-rule override precedence, and backwards compatibility of `recommendedConfig`.

**Additional context**

Validation completed:
- 20 lint-config tests
- `@equinor/fusion-framework-lint-config` TypeScript build
- Fusion lint on changed TypeScript files
- Biome checks
- `git diff --check`

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)