### PR TITLE
fix(ci): prepare runner and Playwright prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # pnpm's standalone binary requires libatomic, which is not included in
+      # the self-hosted runner image.
+      - name: Setup fusion runner
+        uses: ./.github/actions/setup-fusion-runner
+
       - name: Setup node and install deps
         uses: ./.github/actions/node-setup
 
@@ -185,5 +190,4 @@ jobs:
     with:
       environment: docs
     secrets: inherit
-
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,15 @@ jobs:
         if: steps.build.outcome == 'failure'
         run: exit 1
 
+      # These tests run for every PR, so their workspace dependencies must exist
+      # even when the affected build legitimately skips both cookbooks.
+      - name: Build CLI and cookbook Playwright prerequisites
+        run: |
+          pnpm build:cli
+          pnpm turbo build \
+            --filter @equinor/fusion-framework-cookbook-app-react-context... \
+            --filter @equinor/fusion-framework-cookbook-app-react-mock-playwright...
+
       - name: Install Playwright browsers
         # `playwright` isn't a root dependency, so `pnpm exec` needs a --filter into a package that
         # has it; the installed browser cache is shared across packages.


### PR DESCRIPTION
**Why is this change needed?**

Two CI jobs assume build/runtime prerequisites that are absent on clean self-hosted runners:

- The VS Code Marketplace publish job fails during pnpm setup because the runner image does not include libatomic.so.1.
- Cookbook Playwright tests run for every PR, but an affected-only build can skip the CLI and cookbook dependency graphs for workflow-only changes.

**What is the current behavior?**

Extension release runs call the shared Node setup action directly, causing the standalone pnpm binary to exit with code 127. Workflow-only pull requests can then start cookbook Playwright tests without packages/cli/bin/build/cli.mjs.

**What is the new behavior?**

- The Marketplace publish job runs the existing Fusion runner setup action before Node and pnpm setup.
- The PR job explicitly calls pnpm build:cli and builds both Playwright cookbook dependency graphs before starting their web servers.

**What is the intended behavior or invariant?**

Every job using pnpm on the Fusion self-hosted runner must prepare its runner prerequisites. Tests that run unconditionally must also build their required workspace artifacts independently of affected-package detection.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: None; these are internal CI-only changes
- Consumer impact: None
- Downstream impact: VS Code extension releases can publish, and workflow-only PRs can run cookbook Playwright tests from a clean checkout

**Review guidance:**

Verify that Setup fusion runner precedes Node/pnpm setup in the Marketplace job, and that the PR job explicitly invokes pnpm build:cli before the cookbook Playwright suites.

**Additional context**

- Marketplace failure: https://github.com/equinor/fusion-framework/actions/runs/33382277876/job/99460522211
- Playwright prerequisite failure: https://github.com/equinor/fusion-framework/actions/runs/33429496936/job/99611125764

Validation:

- Both workflow files parse as YAML and their relevant step ordering was asserted.
- git diff --check passes.
- The exact prerequisite build block completes successfully from a missing CLI-artifact state.
- The app-react-context Playwright suite passes after building its dependency graph.
- The mock Playwright suite starts successfully instead of failing on the missing CLI artifact; later browser assertions still fail locally for a separate runtime condition outside this PR's linked failure.

A changeset is not required for internal CI-only changes.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions (not applicable)
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist (not applicable)
- [x] Confirm React logic and derived values are resolved before markup when applicable (not applicable)
- [x] Confirm README/docs are updated for user-facing changes (not applicable)
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR ([check existing](https://github.com/equinor/fusion-framework/pulls))
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
