### PR TITLE
feat(openapi-mock-server): add patch and options routes

### DIFF
--- a/.changeset/fusion-framework-docs_document-router-methods.md
+++ b/.changeset/fusion-framework-docs_document-router-methods.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-docs": patch
+---
+
+Document the supported middleware router request methods, including the new `patch` and `options` shorthands.

--- a/.changeset/fusion-openapi-mock-server_add-router-methods.md
+++ b/.changeset/fusion-openapi-mock-server_add-router-methods.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-openapi-mock-server": minor
+---
+
+Add `patch` and `options` middleware router shorthands for mocking PATCH and OPTIONS requests.

--- a/packages/utils/openapi-mock-server/docs/getting-started.md
+++ b/packages/utils/openapi-mock-server/docs/getting-started.md
@@ -139,6 +139,9 @@ const people = createService('people', peopleDocument).middleware((router) => {
 const server = createMockServer({ seed: 42 }).use([people]);
 ```
 
+The middleware router supports `get`, `post`, `put`, `patch`, `delete`, and `options` request
+methods with exact service-relative path matching.
+
 ## Point your app at it
 
 For a Fusion app running through `@equinor/fusion-framework-cli`, use `ffc app dev --mock`:

--- a/packages/utils/openapi-mock-server/src/__tests__/create-mock-server.test.ts
+++ b/packages/utils/openapi-mock-server/src/__tests__/create-mock-server.test.ts
@@ -138,6 +138,41 @@ describe('createMockServer', () => {
     expect(response.status).toBe(200);
   });
 
+  it('supports PATCH and OPTIONS middleware route shorthands', async () => {
+    const document = {
+      openapi: '3.0.0',
+      info: { title: 'Middleware methods', version: '1' },
+      paths: {},
+    };
+    const service = createService('middleware-methods', document).middleware((router) => {
+      router.patch('/resource', (_req, res, { body }) => {
+        res.json({ method: 'PATCH', body });
+      });
+      router.options('/resource', (_req, res) => {
+        res.statusCode = 204;
+        res.end();
+      });
+    });
+    server = createMockServer().use([service]);
+    const { url } = await server.start();
+
+    const patchResponse = await fetch(`${url}/middleware-methods/resource`, {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled: true }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const optionsResponse = await fetch(`${url}/middleware-methods/resource`, {
+      method: 'OPTIONS',
+    });
+
+    expect(patchResponse.status).toBe(200);
+    await expect(patchResponse.json()).resolves.toEqual({
+      method: 'PATCH',
+      body: { enabled: true },
+    });
+    expect(optionsResponse.status).toBe(204);
+  });
+
   it('lets a later use() layer override an earlier one by service key', async () => {
     const overridesDir = fileURLToPath(new URL('./fixtures/overrides', import.meta.url));
     server = createMockServer().use(fixturesDir).use(overridesDir);

--- a/packages/utils/openapi-mock-server/src/discovery/create-router.ts
+++ b/packages/utils/openapi-mock-server/src/discovery/create-router.ts
@@ -33,7 +33,9 @@ export interface Router {
   get(path: string, handler: RouteHandler): void;
   post(path: string, handler: RouteHandler): void;
   put(path: string, handler: RouteHandler): void;
+  patch(path: string, handler: RouteHandler): void;
   delete(path: string, handler: RouteHandler): void;
+  options(path: string, handler: RouteHandler): void;
   /**
    * Attempts to handle `req`; returns `true` if a registered route matched (and `res` was
    * written to).
@@ -72,7 +74,9 @@ export function createRouter(): Router {
     get: (path, handler) => register('GET', path, handler),
     post: (path, handler) => register('POST', path, handler),
     put: (path, handler) => register('PUT', path, handler),
+    patch: (path, handler) => register('PATCH', path, handler),
     delete: (path, handler) => register('DELETE', path, handler),
+    options: (path, handler) => register('OPTIONS', path, handler),
     async handle(req, res, seed) {
       const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
       const handler = routes.get(`${req.method} ${pathname}`);


### PR DESCRIPTION
**Why is this change needed?**

Mock-service middleware cannot currently register handlers for PATCH or OPTIONS requests through the typed router API, even though the server can receive both methods.

**What is the current behavior?**

The middleware router exposes only `get`, `post`, `put`, and `delete` request-method shorthands. Consumers must avoid middleware for PATCH and OPTIONS routes.

**What is the new behavior?**

The router exposes `patch(path, handler)` and `options(path, handler)`. Both use the existing exact method-and-service-relative-path matching behavior, including JSON request-body parsing for PATCH handlers.

**What is the intended behavior or invariant?**

Every router shorthand registers the uppercase HTTP method through the same internal route registry. Middleware continues to take precedence over generated OpenAPI responses, while CORS preflight requests remain handled by the existing preflight behavior.

**Does this PR introduce a breaking change?**

No. The router interface is extended with backward-compatible methods.

**Impact assessment:**

- Breaking changes: No
- Version bump: Minor for `@equinor/fusion-openapi-mock-server`; patch for consumer documentation
- Consumer impact: Consumers can mock PATCH and ordinary OPTIONS requests with the same middleware API used for existing methods.
- Downstream impact: Existing consumers require no changes.

**Review guidance:**

Verify that `Router.patch` and `Router.options` map to the correct uppercase methods and that the HTTP-level test covers request-body parsing and ordinary OPTIONS routing.

**Additional context**

Validation completed with `pnpm test`, `pnpm build`, and `pnpm lint`. The first test invocation ran concurrently with the initial workspace build and could not load unbuilt cookbook test-config dependencies; the serial post-build run passed.

### Checklist

- [x] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
