### PR TITLE
fix(react-router): support Windows Vite module IDs

### DIFF
--- a/.changeset/fusion-framework-react-router_windows-vite-ids.md
+++ b/.changeset/fusion-framework-react-router_windows-vite-ids.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-framework-react-router": patch
+---
+
+Fix DSL route transformation on Windows when Vite module IDs and the configured project root use different path separators.

--- a/.github/instructions/code-generation.instructions.md
+++ b/.github/instructions/code-generation.instructions.md
@@ -15,6 +15,7 @@ The global non-negotiables (no `any`, explicit return types, scoped imports, `pn
 - **Errors**: Throw clear, contextual error messages; never silently swallow failures.
 - **Comments**: Add inline intent comments for iterator blocks, decision gates, RxJS operator chains, assumptions, and workarounds. Explain why the block exists, not what the syntax does.
 - **Node built-ins**: Always use the `node:` protocol (`node:fs`, `node:path`).
+- **Cross-platform paths**: Normalize paths at filesystem/tooling boundaries, emit module specifiers with `/`, and test path logic with Windows-shaped input.
 - **Filenames**: One value export per file, named to match. See below.
 
 ## Core Principles
@@ -90,6 +91,17 @@ if (!existsSync(filePath)) {
 }
 ```
 
+#### Cross-Platform Path Handling
+- Use `node:path` for filesystem resolution, but do not emit `path.join()` results as import
+  specifiers. JavaScript and TypeScript module specifiers must use `/` separators.
+- Normalize filesystem paths and tool-provided module IDs to the same separator form before
+  comparing them. Vite and similar tools can provide `/`-separated IDs on Windows while
+  `process.cwd()` and configured roots still contain `\`.
+- Check directory containment at path-segment boundaries; a bare `startsWith(root)` also matches
+  sibling paths such as `/workspace/app-copy`.
+- When code resolves, compares, transforms, or generates paths, add regression coverage for both
+  POSIX and Windows-shaped inputs even if CI runs on only one operating system.
+
 ### Inline Comments
 Add intent comments for:
 - Iterator blocks such as `for`, `forEach`, `map`, `filter`, and `reduce`
@@ -132,4 +144,3 @@ Bare `// TODO - ...` comments are flagged by `no-todo-without-issue`. Every TODO
 - **Everything else** (plain functions, consts, enums): filename must be the kebab-case form of the export name, e.g. `capitalizeRequestMethod` → `capitalize-request-method.ts`. A trailing dotted category suffix is allowed, e.g. `sse.operator.ts`, `my-foo.schema.ts` — only the segment before the first dot needs to match.
 - Barrels (`index.ts`) are exempt and may have multiple exports.
 - If a file needs a second export (e.g. an `Error` subclass alongside the function that throws it), extract it into its own file rather than suppressing the rule.
-

--- a/packages/react/router/src/__tests__/vite-plugin.test.ts
+++ b/packages/react/router/src/__tests__/vite-plugin.test.ts
@@ -176,4 +176,17 @@ describe('reactRouterPlugin', () => {
     expect(transformResult).toContain('default as MocksFsRoutesUsers,');
     expect(transformResult).toContain('default as MocksFsRoutesUsersId,');
   });
+
+  it('should transform Vite module IDs when the Windows project root uses backslashes', () => {
+    plugin.config({ root: String.raw`C:\workspace\app` });
+    const inputCode = [
+      `import { route } from '@equinor/fusion-framework-react-router/routes';`,
+      `export const routes = route('home', './pages/HomePage.tsx');`,
+    ].join('\n');
+
+    const transformResult = plugin.transform(inputCode, 'C:/workspace/app/src/routes.ts');
+
+    expect(transformResult).not.toBeNull();
+    expect(transformResult).toContain(`path: 'home'`);
+  });
 });

--- a/packages/react/router/src/vite-plugin/react-router-plugin.ts
+++ b/packages/react/router/src/vite-plugin/react-router-plugin.ts
@@ -86,6 +86,16 @@ function isRelativePath(filePath: string): boolean {
 }
 
 /**
+ * Normalizes filesystem separators for comparison with Vite module IDs.
+ *
+ * @param filePath - A filesystem path or Vite module ID.
+ * @returns The path with POSIX separators.
+ */
+function normalizePathSeparators(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+/**
  * Extracts all file paths from DSL route calls in the code
  */
 function extractFilePaths(code: string): Set<string> {
@@ -650,7 +660,7 @@ export const reactRouterPlugin = (options: ReactRouterPluginOptions = {}): Plugi
   return {
     name: 'fusion:react-router',
     config(config: UserConfig) {
-      projectRoot = config.root ?? process.cwd();
+      projectRoot = normalizePathSeparators(config.root ?? process.cwd());
 
       // Debug logging is opt-in to avoid noisy build output by default
       if (debug) {
@@ -659,8 +669,18 @@ export const reactRouterPlugin = (options: ReactRouterPluginOptions = {}): Plugi
     },
     transform(code, id) {
       try {
-        // Skip files outside the project root or in node_modules
-        if (!projectRoot || !id.startsWith(projectRoot) || id.includes('node_modules')) {
+        // Vite initializes the project root through the config hook before transforming modules.
+        if (!projectRoot) {
+          return null;
+        }
+
+        const normalizedId = normalizePathSeparators(id);
+        const projectRootPrefix = projectRoot.endsWith('/') ? projectRoot : `${projectRoot}/`;
+        const isWithinProject =
+          normalizedId === projectRoot || normalizedId.startsWith(projectRootPrefix);
+
+        // Vite module IDs use POSIX separators even when the configured root uses Windows separators.
+        if (!isWithinProject || normalizedId.includes('/node_modules/')) {
           return null;
         }
 
@@ -682,7 +702,10 @@ export const reactRouterPlugin = (options: ReactRouterPluginOptions = {}): Plugi
 
         // Debug logging is opt-in to avoid noisy build output by default
         if (debug) {
-          console.log('[fusion:react-router] Transforming file:', id.replace(projectRoot, ''));
+          console.log(
+            '[fusion:react-router] Transforming file:',
+            normalizedId.replace(projectRoot, ''),
+          );
         }
 
         // Extract all file paths from DSL route calls


### PR DESCRIPTION
**Why is this change needed?**

The React Router DSL Vite plugin compares its configured project root with Vite module IDs before transforming route definitions. On Windows those values can use different path separators, causing valid route modules to be skipped.

**What is the current behavior?**

A Windows project root such as `C:\workspace\app` does not prefix-match Vite's normalized module ID `C:/workspace/app/src/routes.ts`, so the DSL transform returns without generating route imports.

**What is the new behavior?**

The plugin normalizes project roots and module IDs to POSIX separators before comparison, while preserving path-segment boundaries and excluding `node_modules`. A Windows-shaped regression test covers the behavior, and the TypeScript agent instructions now document cross-platform path requirements.

**What is the intended behavior or invariant?**

Filesystem and tool-provided paths must be normalized to a common representation before comparison. Generated module specifiers use forward slashes, and project containment checks must not match sibling directories that merely share a string prefix.

**Does this PR introduce a breaking change?**

No.

**Impact assessment:**

- Breaking changes: No
- Version bump: Patch
- Consumer impact: DSL route transformation now works when Windows roots and Vite IDs use different separators.
- Downstream impact: Limited to `@equinor/fusion-framework-react-router` consumers using the Vite DSL plugin.

**Review guidance:**

Focus on the project-root containment check and the Windows-shaped regression test. Verify that POSIX behavior and the `node_modules` exclusion remain unchanged.

**Additional context**

Validation:
- `pnpm build`: passed
- `pnpm lint`: passed (existing Biome schema-version informational message only)
- `pnpm test`: 1,807/1,808 passed; one unrelated CLI test timed out during the full parallel suite and passed immediately in isolation (4/4)
- React router package tests: 20/20 passed
- `pnpm verify:agent-context`: passed

**Related issues**

None.

### Checklist

- [x] Confirm completion of the self-review checklist
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist
- [x] Confirm React logic and derived values are resolved before markup when applicable
- [x] Confirm README/docs are updated for user-facing changes
- [x] Confirm changes to target branch validation
  - Included files validated
  - No new linting warnings
  - Not a duplicate PR
- [x] Confirm adherence to code of conduct