### PR TITLE
chore(codespaces): prune installed dependencies from prebuilds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
       "version": "1.0.80"
     }
   },
-  "updateContentCommand": "pnpm install --frozen-lockfile --prefer-offline && pnpm build:packages",
-  "waitFor": "updateContentCommand"
+  "updateContentCommand": "pnpm install --frozen-lockfile --prefer-offline && pnpm build:packages && pnpm clean:npm",
+  "postCreateCommand": "pnpm install --frozen-lockfile --prefer-offline",
+  "waitFor": "postCreateCommand"
 }


### PR DESCRIPTION
**Why is this change needed?**

Reduce the installed dependency tree captured in human Codespaces prebuilds. The first successful prebuild took 22m51s, including 8m16s of upload. Local installed dependencies measured 2.0 GB; actual snapshot savings remain to be measured.

**What is the current behavior?**

Prebuild setup installs locked dependencies and builds packages, leaving every workspace's installed dependencies in the snapshot. Automated Codespaces issue execution has already been removed from main and is not part of this PR.

**What is the new behavior?**

After successful installation and package builds, run the existing `pnpm clean:npm` script to remove workspace `node_modules` directories. On Codespace creation, reinstall with `pnpm install --frozen-lockfile --prefer-offline`. Wait for that post-create step before considering setup ready.

**What is the intended behavior or invariant?**

Preserve the pnpm content store, package build outputs and Turbo cache. Never run `pnpm store prune` or the broader build-cleaning command. Cleanup runs only after successful builds. Dependency restoration is required before developers start work, with network fallback for missing cached packages. No authentication is added to prebuild setup.

**Does this PR introduce a breaking change?**

No published API change. The developer lifecycle intentionally moves dependency restoration to post-create; a failed restoration blocks readiness.

**Impact assessment:**

- No changeset/version bump: development-environment configuration only.
- No published package or consumer changes.
- Trade snapshot size/file processing against per-Codespace reinstall time. No claim yet that managed prebuild duration or download time improves.

**Review guidance:**

Verify cleanup is limited to installed dependencies and that `waitFor` includes restoration.

Validation:
- Isolated local checkout with 93 workspace projects: actual `pnpm clean:npm` removed all `node_modules` directories while retaining the pnpm store, copied package outputs and a Turbo cache directory.
- Subsequent frozen `--prefer-offline` installation succeeded in 16.74 seconds; TypeScript and workspace CLI executable links were restored.
- Earlier benchmark: zero package downloads, 1,688 packages installed, lifecycle scripts enabled; already-installed baseline was 0.29 seconds.
- Targeted Biome and `git diff --check` passed.
- Temporary checkouts removed; working dependencies untouched.

Full monorepo tests/build/lint were not rerun for this lifecycle-only change. These timings are macOS measurements, not Linux Codespaces measurements. A managed prebuild followed by fresh Codespace creation remains the end-to-end validation.

**Additional context**

GitHub runs `updateContentCommand` during prebuild creation but defers `postCreateCommand` until Codespace creation. No managed prebuild schedule or region setting is changed here.

**Related issues**

None.

### Checklist

- [ ] Confirm completion of the [self-review checklist](https://github.com/equinor/fusion-framework/blob/main/contributing/self-review.md) (live lifecycle validation pending)
- [x] Confirm TSDoc captures intent for functions, hooks, components, classes, and named arrow functions (no new symbols)
- [x] Confirm iterator blocks, decision gates, RxJS chains, and complex decisions explain why they exist (not applicable)
- [x] Confirm React logic and derived values are resolved before markup when applicable (not applicable)
- [x] Confirm README/docs are updated for user-facing changes (no consumer API changes)
- [ ] Confirm changes to target branch validation (targeted checks passed; live prebuild/startup pending)
  - _Included configuration validated_
  - _No new linting warnings_
  - _No existing PR for this branch_
- [x] Confirm adherence to [code of conduct](https://github.com/equinor/fusion-framework/blob/main/CODE_OF_CONDUCT.md)
